### PR TITLE
Fix user edit button visibility

### DIFF
--- a/src/components/features/User/UserDetail/index.stories.tsx
+++ b/src/components/features/User/UserDetail/index.stories.tsx
@@ -64,6 +64,7 @@ const meta = {
     ],
     currentShopRole: "owner",
     currentShopId: "shop1" as Id<"shops">,
+    currentUserId: "currentUser1" as Id<"users">,
   },
 } satisfies Meta<typeof UserDetail>;
 

--- a/src/components/features/User/UserDetail/index.tsx
+++ b/src/components/features/User/UserDetail/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { LuCalendar, LuClock, LuPencil, LuStore, LuTrendingUp, LuUser, LuUsers } from "react-icons/lu";
-import type { Doc } from "@/convex/_generated/dataModel";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { Title } from "@/src/components/ui/Title";
 import { convertRole } from "@/src/helpers/domain/convertShopData";
 import { AttendanceTab } from "./TabContents/AttendanceTab";
@@ -32,15 +32,29 @@ type UserDetailProps = {
   shops: ShopWithRole[];
   currentShopRole: string | null;
   currentShopId: string;
+  currentUserId: Id<"users"> | null;
 };
 
 export const UserDetailTabTypes = ["info", "shifts", "attendance"] as const;
 
-export const UserDetail = ({ user, shops, currentShopRole, currentShopId }: UserDetailProps) => {
+export const UserDetail = ({ user, shops, currentShopRole, currentShopId, currentUserId }: UserDetailProps) => {
   const navigate = useNavigate();
   const search = useSearch({ strict: false });
   const currentTab = search.tab || "info";
-  const canEdit = currentShopRole === "owner" || currentShopRole === "manager";
+
+  // 対象ユーザーのこの店舗での役割を取得
+  const targetUserRole = shops.find((shop) => shop._id === currentShopId)?.role ?? null;
+
+  // 編集権限の判定
+  // - オーナー: 全員編集可能
+  // - マネージャー: 全員編集可能、ただしオーナーは編集不可
+  // - 一般ユーザー: 自分のものだけ編集可能
+  const canEdit = (() => {
+    if (currentShopRole === "owner") return true;
+    if (currentShopRole === "manager") return targetUserRole !== "owner";
+    if (currentShopRole === "general") return currentUserId === user._id;
+    return false;
+  })();
 
   const handleTabChange = (value: string) => {
     navigate({

--- a/src/components/pages/Staffs/DetailPage/index.tsx
+++ b/src/components/pages/Staffs/DetailPage/index.tsx
@@ -26,8 +26,16 @@ export const StaffDetailPage = ({ userId, shopId }: Props) => {
     user.authId ? { shopId: shopId as Id<"shops">, authId: user.authId } : "skip",
   );
 
+  // 現在のログインユーザー情報取得（編集権限判定用）
+  const currentUserData = useQuery(api.user.getUserByAuthId, user.authId ? { authId: user.authId } : "skip");
+
   // ローディング
-  if (staffData === undefined || shops === undefined || currentUserRole === undefined) {
+  if (
+    staffData === undefined ||
+    shops === undefined ||
+    currentUserRole === undefined ||
+    currentUserData === undefined
+  ) {
     return (
       <LazyShow>
         <UserDetailLoading />
@@ -41,5 +49,13 @@ export const StaffDetailPage = ({ userId, shopId }: Props) => {
   }
 
   // 通常表示
-  return <UserDetail user={staffData} shops={shops} currentShopRole={currentUserRole} currentShopId={shopId} />;
+  return (
+    <UserDetail
+      user={staffData}
+      shops={shops}
+      currentShopRole={currentUserRole}
+      currentShopId={shopId}
+      currentUserId={currentUserData?._id ?? null}
+    />
+  );
 };


### PR DESCRIPTION
- オーナー: 全員編集可能
- マネージャー: 全員編集可能、ただしオーナーは編集不可
- 一般ユーザー: 自分のものだけ編集可能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ユーザーロール（オーナー、マネージャー、一般ユーザー）に基づいた権限チェックロジックを改善しました。各ロールに応じて、スタッフ情報の編集機能へのアクセスがより厳密に制御されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->