### PR TITLE
Preserve tab state when navigating back

### DIFF
--- a/src/components/features/Shop/Invite/index.tsx
+++ b/src/components/features/Shop/Invite/index.tsx
@@ -19,6 +19,7 @@ export const InviteShopStaff = ({ invitations }: InviteShopStaffProps) => {
   const navigate = useNavigate();
   const search = useSearch({ strict: false });
   const currentTab = search.tab || "send";
+  const fromTab = search.fromTab;
 
   const handleTabChange = (value: string) => {
     navigate({
@@ -33,7 +34,9 @@ export const InviteShopStaff = ({ invitations }: InviteShopStaffProps) => {
     <Animation>
       <Container maxW="6xl">
         {/* ヘッダー */}
-        <Title prev={{ url: `/shops/${shopId}`, label: "店舗詳細に戻る" }}>スタッフ招待</Title>
+        <Title prev={{ url: `/shops/${shopId}${fromTab ? `?tab=${fromTab}` : ""}`, label: "店舗詳細に戻る" }}>
+          スタッフ招待
+        </Title>
 
         {/* タブ */}
         <Tabs.Root value={currentTab} onValueChange={(e) => handleTabChange(e.value)} w="full" variant="enclosed">

--- a/src/components/features/Shop/ShopDetail/TabContents/StaffTab/index.tsx
+++ b/src/components/features/Shop/ShopDetail/TabContents/StaffTab/index.tsx
@@ -146,7 +146,7 @@ export const StaffTab = ({ shop, users, canEdit }: StaffTabProps) => {
 
         {/* スタッフ招待ボタン */}
         {canEdit && (
-          <Link to="/shops/$shopId/invite" params={{ shopId: shop._id }}>
+          <Link to="/shops/$shopId/invite" params={{ shopId: shop._id }} search={{ fromTab: "staff" }}>
             <Button w={{ base: "full", md: "auto" }} colorPalette="teal" gap={2}>
               <Icon as={LuPlus} boxSize={4} />
               スタッフを招待
@@ -163,7 +163,12 @@ export const StaffTab = ({ shop, users, canEdit }: StaffTabProps) => {
           </Text>
           <Box>
             {filteredUsers.map((user) => (
-              <Link key={user._id} to="/shops/$shopId/staffs/$userId" params={{ shopId: shop._id, userId: user._id }}>
+              <Link
+                key={user._id}
+                to="/shops/$shopId/staffs/$userId"
+                params={{ shopId: shop._id, userId: user._id }}
+                search={{ fromTab: "staff" }}
+              >
                 <Card.Root
                   mb={{ base: 2, md: 3 }}
                   borderWidth={0}

--- a/src/components/features/User/UserDetail/index.tsx
+++ b/src/components/features/User/UserDetail/index.tsx
@@ -57,6 +57,7 @@ export const UserDetail = ({ user, shops, currentShopRole, currentShopId, curren
   const navigate = useNavigate();
   const search = useSearch({ strict: false });
   const currentTab = search.tab || "info";
+  const fromTab = search.fromTab;
 
   // 制限ビューかどうかを判定
   const limitedView = isLimitedView(user);
@@ -141,7 +142,7 @@ export const UserDetail = ({ user, shops, currentShopRole, currentShopId, curren
     <Container maxW="6xl">
       {/* ヘッダー */}
       <Title
-        prev={{ url: `/shops/${currentShopId}`, label: "店舗詳細に戻る" }}
+        prev={{ url: `/shops/${currentShopId}${fromTab ? `?tab=${fromTab}` : ""}`, label: "店舗詳細に戻る" }}
         action={
           canEdit ? (
             <Button

--- a/src/routes/_auth/shops/$shopId/invite/index.tsx
+++ b/src/routes/_auth/shops/$shopId/invite/index.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { InviteShopStaffTabTypes } from "@/src/components/features/Shop/Invite";
+import { ShopDetailTabTypes } from "@/src/components/features/Shop/ShopDetail";
 import { InvitePage } from "@/src/components/pages/Shops/InvitePage";
 import { Animation } from "@/src/components/templates/Animation";
 
 const inviteSearchSchema = z.object({
   tab: z.enum(InviteShopStaffTabTypes).optional().catch(InviteShopStaffTabTypes[0]),
+  fromTab: z.enum(ShopDetailTabTypes).optional(),
 });
 
 export const Route = createFileRoute("/_auth/shops/$shopId/invite/")({

--- a/src/routes/_auth/shops/$shopId/staffs/$userId/index.tsx
+++ b/src/routes/_auth/shops/$shopId/staffs/$userId/index.tsx
@@ -1,11 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
+import { ShopDetailTabTypes } from "@/src/components/features/Shop/ShopDetail";
 import { UserDetailTabTypes } from "@/src/components/features/User/UserDetail";
 import { StaffDetailPage } from "@/src/components/pages/Staffs/DetailPage";
 import { Animation } from "@/src/components/templates/Animation";
 
 const userDetailSearchSchema = z.object({
   tab: z.enum(UserDetailTabTypes).optional().catch(UserDetailTabTypes[0]),
+  fromTab: z.enum(ShopDetailTabTypes).optional(),
 });
 
 export const Route = createFileRoute("/_auth/shops/$shopId/staffs/$userId/")({


### PR DESCRIPTION
- 店舗詳細→ユーザー詳細、店舗詳細→招待画面への遷移時にfromTabパラメータを追加
- 戻るリンクにfromTabの値を引き継ぎ、タブ状態を復元

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ショップ詳細ページで選択中のタブ状態を保持するようになりました。スタッフ招待や従業員詳細ページから戻った際に、以前選択していたタブが自動的に復帰します。これにより、ページ遷移後の操作がより効率的になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->