### PR TITLE
feat: シフト管理機能のモック実装

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: create-pr
+description: GitHubにPull Requestを作成するスキル。コミット・プッシュ済みの状態で、現在のブランチの変更内容を分析し、適切なタイトルと説明文でPRを作成する。「PRを作成して」「プルリクエストを作って」「PR作って」などのトリガーで発動。
+---
+
+# PR作成スキル
+
+## 前提条件
+
+- コミット済み
+- プッシュ済み
+- GitHubリポジトリと連携済み
+
+## ワークフロー
+
+### 1. 現在のブランチ情報を取得
+
+```bash
+git branch --show-current
+```
+
+### 2. デフォルトブランチを自動検出
+
+```bash
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+```
+
+### 3. 変更内容を把握
+
+デフォルトブランチとの差分コミットを取得:
+
+```bash
+git log <default-branch>..HEAD --oneline
+```
+
+詳細な変更内容を確認:
+
+```bash
+git diff <default-branch>...HEAD --stat
+```
+
+### 4. PRを作成
+
+```bash
+gh pr create --title "<タイトル>" --body "<本文>"
+```
+
+## PR本文フォーマット（日本語で出力）
+
+```markdown
+## Summary
+<!-- なぜこの変更が必要か（背景・目的）を1-2文で -->
+
+
+## Design
+<!-- 設計の全体像をmermaid図で表現 -->
+
+### コンポーネント構成
+```mermaid
+graph TD
+    A[ParentComponent] --> B[ChildComponent]
+    B --> C[SubComponent]
+```
+
+### データフロー
+```mermaid
+sequenceDiagram
+    User->>Component: アクション
+    Component->>Convex: mutation呼び出し
+    Convex-->>Component: 結果返却
+```
+
+## Changes
+<!-- 主要な変更点を箇条書きで -->
+- **変更1**: 具体的な説明
+- **変更2**: 具体的な説明
+```
+
+## 注意事項
+
+- PRのタイトルと本文は**日本語**で作成すること
+- コミットメッセージを参考にしつつ、読み手にわかりやすい表現にする
+- mermaid図は変更内容に応じて適切なものを選択（不要なら省略可）
+  - コンポーネント構成: 新規コンポーネント追加時
+  - データフロー: API連携やデータの流れが重要な場合
+- 変更が小さい場合はDesignセクションを省略してシンプルに保つ

--- a/doc/plans/2026-01-14_シフト管理機能_実装計画.md
+++ b/doc/plans/2026-01-14_シフト管理機能_実装計画.md
@@ -374,30 +374,64 @@ type RequiredStaffingType = {
 
 ### Step 5: 画面間の連携
 
-- [ ] RecruitmentList から各画面へのリンク追加
-- [ ] ナビゲーションの整合性確認
+#### 5.1 RecruitmentList → RequestStatus リンク追加
+- [ ] 募集カードクリック時に詳細画面へ遷移するよう修正
+- [ ] `handleNotImplemented("募集詳細")` を `navigate()` に置き換え
+- [ ] 遷移先: `/shops/$shopId/shifts/recruitments/$recruitmentId`
 
-**対象ファイル**: `src/components/features/Shift/RecruitmentList/`
+#### 5.2 RequestStatus → ShiftEditor ナビゲーション追加
+- [ ] 「シフト確定へ進む」ボタンのモック処理を実際の遷移に変更
+- [ ] `handleGoToConfirm()` を `navigate()` に置き換え
+- [ ] 遷移先: `/shops/$shopId/shifts/recruitments/$recruitmentId/confirm`
+
+#### 5.3 RecruitmentList → StaffingMatrix リンク追加
+- [ ] 「必要人員設定」ボタンのモック処理を実際の遷移に変更
+- [ ] `handleNotImplemented("必要人員設定")` を `Link` に置き換え
+- [ ] 遷移先: `/shops/$shopId/shifts/settings`
+
+#### 5.4 ナビゲーション整合性確認
+- [ ] 全画面の遷移テスト実施
+- [ ] 戻るボタンの動作確認
+- [ ] URL パラメータの引き継ぎ確認
+
+**対象ファイル**:
+- `src/components/features/Shift/RecruitmentList/index.tsx`（修正）
+- `src/components/features/Shift/RequestStatus/index.tsx`（修正）
 
 ---
 
-## 8. 現在の進捗 🔴
+## 8. 現在の進捗 🟢
 
-**最終更新**: 2026-01-14
-**完了ステップ**: 未着手
-**次にやること**: Step 1 の募集作成画面から開始
+**最終更新**: 2026-01-20
+**完了ステップ**: Step 1, Step 2, Step 3, Step 4, Step 5
+**ステータス**: モック実装完了
 
 ### 完了したタスク
 
-（なし）
+- [x] Step 1: 募集作成画面
+  - `src/routes/_auth/shops/$shopId/shifts/recruitments/new.tsx`
+  - `src/components/pages/Shops/RecruitmentNewPage/index.tsx`
+  - `src/components/features/Shift/RecruitmentForm/` (schema.ts, index.tsx, index.stories.tsx)
+  - `src/components/features/Shift/RecruitmentNew/index.tsx`
+- [x] Step 2: 申請状況確認画面
+  - `src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/index.tsx`
+  - `src/components/pages/Shops/RecruitmentDetailPage/index.tsx`
+  - `src/components/features/Shift/RequestStatus/` (index.tsx, index.stories.tsx)
+- [x] Step 3: シフト確定画面
+  - `src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm.tsx`
+  - `src/components/pages/Shops/ShiftConfirmPage/index.tsx`
+  - `src/components/features/Shift/ShiftEditor/` (index.tsx, index.stories.tsx)
+- [x] Step 4: 必要人員設定画面
+  - `src/routes/_auth/shops/$shopId/shifts/settings.tsx`
+  - `src/components/pages/Shops/StaffingSettingsPage/index.tsx`
+  - `src/components/features/Shift/StaffingMatrix/` (index.tsx, index.stories.tsx)
+- [x] Step 5: 画面間の連携
+  - `src/components/features/Shift/RecruitmentList/index.tsx` - 募集詳細・必要人員設定へのリンク追加
+  - `src/components/features/Shift/RequestStatus/index.tsx` - シフト確定画面への遷移追加
 
 ### 残りのタスク
 
-- [ ] Step 1: 募集作成画面
-- [ ] Step 2: 申請状況確認画面
-- [ ] Step 3: シフト確定画面
-- [ ] Step 4: 必要人員設定画面
-- [ ] Step 5: 画面間の連携
+（モック実装完了。今後のスコープ: DBスキーマ、API実装、スタッフ用画面）
 
 ### ブロッカー・課題（あれば）
 
@@ -452,14 +486,7 @@ type RequiredStaffingType = {
 
 ## 10. 検証方法
 
-### 10.1 開発時の確認
-
-```bash
-pnpm dev          # 開発サーバー起動
-pnpm storybook    # Storybook確認
-```
-
-### 10.2 品質チェック
+### 10.1 品質チェック
 
 ```bash
 pnpm format       # フォーマット
@@ -467,7 +494,7 @@ pnpm lint         # リント
 pnpm type-check   # 型チェック
 ```
 
-### 10.3 画面遷移テスト
+### 10.2 画面遷移テスト
 
 1. `/shops/$shopId/shifts` → 募集一覧表示
 2. 「新規募集作成」→ `/shops/$shopId/shifts/recruitments/new`

--- a/src/components/features/Shift/RecruitmentList/index.tsx
+++ b/src/components/features/Shift/RecruitmentList/index.tsx
@@ -1,5 +1,5 @@
 import { Badge, Box, Button, Card, Container, Flex, Heading, HStack, Icon, Text } from "@chakra-ui/react";
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import dayjs from "dayjs";
 import "dayjs/locale/ja";
 import { useState } from "react";
@@ -9,7 +9,6 @@ import { Empty } from "@/src/components/ui/Empty";
 import { LoadingState } from "@/src/components/ui/LoadingState";
 import { Select } from "@/src/components/ui/Select";
 import { Title } from "@/src/components/ui/Title";
-import { toaster } from "@/src/components/ui/toaster";
 
 dayjs.locale("ja");
 
@@ -50,15 +49,8 @@ const formatDate = (date: string) => {
   return dayjs(date).format("M/D(ddd)");
 };
 
-// モック用: 未実装ページへのナビゲーション
-const handleNotImplemented = (pageName: string) => {
-  toaster.create({
-    description: `${pageName}は未実装です`,
-    type: "info",
-  });
-};
-
 export const RecruitmentList = ({ shop, recruitments }: RecruitmentListProps) => {
+  const navigate = useNavigate();
   const [statusFilter, setStatusFilter] = useState("all");
 
   // ステータスフィルター
@@ -79,10 +71,12 @@ export const RecruitmentList = ({ shop, recruitments }: RecruitmentListProps) =>
         prev={{ url: "/mypage", label: "マイページに戻る" }}
         action={
           <HStack gap={2} display={{ base: "none", md: "flex" }}>
-            <Button variant="outline" colorPalette="gray" gap={2} onClick={() => handleNotImplemented("必要人員設定")}>
-              <Icon as={LuSettings} boxSize={4} />
-              必要人員設定
-            </Button>
+            <Link to="/shops/$shopId/shifts/settings" params={{ shopId: shop._id }}>
+              <Button variant="outline" colorPalette="gray" gap={2}>
+                <Icon as={LuSettings} boxSize={4} />
+                必要人員設定
+              </Button>
+            </Link>
             <Link to="/shops/$shopId/shifts/recruitments/new" params={{ shopId: shop._id }}>
               <Button colorPalette="teal" gap={2}>
                 <Icon as={LuCalendarPlus} boxSize={4} />
@@ -127,16 +121,12 @@ export const RecruitmentList = ({ shop, recruitments }: RecruitmentListProps) =>
 
           {/* モバイル用ボタン */}
           <Flex direction="column" gap={2} display={{ base: "flex", md: "none" }}>
-            <Button
-              w="full"
-              variant="outline"
-              colorPalette="gray"
-              gap={2}
-              onClick={() => handleNotImplemented("必要人員設定")}
-            >
-              <Icon as={LuSettings} boxSize={4} />
-              必要人員設定
-            </Button>
+            <Link to="/shops/$shopId/shifts/settings" params={{ shopId: shop._id }}>
+              <Button w="full" variant="outline" colorPalette="gray" gap={2}>
+                <Icon as={LuSettings} boxSize={4} />
+                必要人員設定
+              </Button>
+            </Link>
             <Link to="/shops/$shopId/shifts/recruitments/new" params={{ shopId: shop._id }}>
               <Button w="full" colorPalette="teal" gap={2}>
                 <Icon as={LuCalendarPlus} boxSize={4} />
@@ -163,7 +153,12 @@ export const RecruitmentList = ({ shop, recruitments }: RecruitmentListProps) =>
                     shadow="sm"
                     _hover={{ shadow: "md", cursor: "pointer" }}
                     transition="all 0.15s"
-                    onClick={() => handleNotImplemented("募集詳細")}
+                    onClick={() =>
+                      navigate({
+                        to: "/shops/$shopId/shifts/recruitments/$recruitmentId",
+                        params: { shopId: shop._id, recruitmentId: recruitment._id },
+                      })
+                    }
                   >
                     <Card.Body p={{ base: 3, md: 4 }}>
                       <Flex align="center" justify="space-between" gap={4}>

--- a/src/components/features/Shift/RequestStatus/index.stories.tsx
+++ b/src/components/features/Shift/RequestStatus/index.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RequestStatus } from ".";
+
+const meta = {
+  title: "features/Shift/RequestStatus",
+  component: RequestStatus,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof RequestStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockRecruitment = {
+  _id: "recruitment_1",
+  startDate: "2025-12-01",
+  endDate: "2025-12-07",
+  deadline: "2025-11-25",
+  status: "open" as const,
+};
+
+const mockStaffsWithRequests = [
+  {
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    status: "applied" as const,
+    requests: [
+      {
+        _id: "req_1",
+        staffId: "staff_1",
+        staffName: "田中太郎",
+        date: "2025-12-01",
+        startTime: "09:00",
+        endTime: "17:00",
+      },
+      {
+        _id: "req_2",
+        staffId: "staff_1",
+        staffName: "田中太郎",
+        date: "2025-12-03",
+        startTime: "10:00",
+        endTime: "18:00",
+      },
+    ],
+    totalDays: 2,
+    totalHours: 16,
+  },
+  {
+    staffId: "staff_2",
+    staffName: "山田花子",
+    status: "applied" as const,
+    requests: [
+      {
+        _id: "req_3",
+        staffId: "staff_2",
+        staffName: "山田花子",
+        date: "2025-12-02",
+        startTime: "11:00",
+        endTime: "19:00",
+      },
+    ],
+    totalDays: 1,
+    totalHours: 8,
+  },
+  {
+    staffId: "staff_3",
+    staffName: "佐藤一郎",
+    status: "not_applied" as const,
+    requests: [],
+    totalDays: 0,
+    totalHours: 0,
+  },
+];
+
+export const Basic: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    staffsWithRequests: mockStaffsWithRequests,
+  },
+};
+
+export const AllApplied: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    staffsWithRequests: mockStaffsWithRequests
+      .filter((s) => s.status === "applied")
+      .map((s) => ({ ...s, status: "applied" as const })),
+  },
+};
+
+export const NoApplications: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    staffsWithRequests: [
+      {
+        staffId: "staff_1",
+        staffName: "田中太郎",
+        status: "not_applied" as const,
+        requests: [],
+        totalDays: 0,
+        totalHours: 0,
+      },
+      {
+        staffId: "staff_2",
+        staffName: "山田花子",
+        status: "not_applied" as const,
+        requests: [],
+        totalDays: 0,
+        totalHours: 0,
+      },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    staffsWithRequests: [],
+  },
+};

--- a/src/components/features/Shift/RequestStatus/index.tsx
+++ b/src/components/features/Shift/RequestStatus/index.tsx
@@ -1,0 +1,209 @@
+import { Badge, Box, Button, Card, Container, Flex, Heading, Icon, Text, VStack } from "@chakra-ui/react";
+import { useNavigate } from "@tanstack/react-router";
+import dayjs from "dayjs";
+import { useState } from "react";
+import { LuCalendarCheck, LuClipboardList, LuUser } from "react-icons/lu";
+import { Empty } from "@/src/components/ui/Empty";
+import { Select } from "@/src/components/ui/Select";
+import { Title } from "@/src/components/ui/Title";
+import { toaster } from "@/src/components/ui/toaster";
+
+type ShiftRequestType = {
+  _id: string;
+  staffId: string;
+  staffName: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  note?: string;
+};
+
+type StaffWithRequestsType = {
+  staffId: string;
+  staffName: string;
+  status: "applied" | "not_applied";
+  requests: ShiftRequestType[];
+  totalDays: number;
+  totalHours: number;
+};
+
+type RecruitmentInfoType = {
+  _id: string;
+  startDate: string;
+  endDate: string;
+  deadline: string;
+  status: "open" | "closed" | "confirmed";
+};
+
+type RequestStatusProps = {
+  shopId: string;
+  recruitmentId: string;
+  recruitment: RecruitmentInfoType;
+  staffsWithRequests: StaffWithRequestsType[];
+};
+
+const STATUS_FILTER_OPTIONS = [
+  { value: "all", label: "全て" },
+  { value: "applied", label: "申請済み" },
+  { value: "not_applied", label: "未申請" },
+];
+
+const STATUS_CONFIG = {
+  applied: { label: "申請済み", colorPalette: "teal" },
+  not_applied: { label: "未申請", colorPalette: "gray" },
+} as const;
+
+export const RequestStatus = ({ shopId, recruitmentId, recruitment, staffsWithRequests }: RequestStatusProps) => {
+  const navigate = useNavigate();
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  const filteredStaffs = staffsWithRequests.filter((staff) => {
+    if (statusFilter === "all") return true;
+    return staff.status === statusFilter;
+  });
+
+  const appliedCount = staffsWithRequests.filter((s) => s.status === "applied").length;
+  const totalCount = staffsWithRequests.length;
+
+  const formatDateRange = (startDate: string, endDate: string) => {
+    const start = dayjs(startDate);
+    const end = dayjs(endDate);
+    return `${start.format("M/D(ddd)")}〜${end.format("M/D(ddd)")}`;
+  };
+
+  const handleCloseRecruitment = () => {
+    // TODO: useMutation呼び出し
+    console.log("募集を締め切る:", recruitmentId);
+    toaster.create({
+      description: "募集を締め切りました",
+      type: "success",
+    });
+  };
+
+  const handleGoToConfirm = () => {
+    navigate({
+      to: "/shops/$shopId/shifts/recruitments/$recruitmentId/confirm",
+      params: { shopId, recruitmentId },
+    });
+  };
+
+  return (
+    <Container maxW="6xl">
+      <Title prev={{ url: `/shops/${shopId}/shifts`, label: "シフト管理に戻る" }}>
+        <Flex align="center" gap={3}>
+          <Flex p={{ base: 2, md: 3 }} bg="teal.50" borderRadius="lg">
+            <Icon as={LuClipboardList} boxSize={6} color="teal.600" />
+          </Flex>
+          <Box>
+            <Heading as="h2" size="xl" color="gray.900">
+              申請状況確認
+            </Heading>
+            <Text color="gray.500" fontSize="sm">
+              {formatDateRange(recruitment.startDate, recruitment.endDate)}
+            </Text>
+          </Box>
+        </Flex>
+      </Title>
+
+      {/* フィルターエリア */}
+      <Flex
+        mb={4}
+        gap={4}
+        direction={{ base: "column", sm: "row" }}
+        justify="space-between"
+        align={{ base: "stretch", sm: "center" }}
+      >
+        <Select
+          items={STATUS_FILTER_OPTIONS}
+          value={statusFilter}
+          onChange={(value) => setStatusFilter(value)}
+          w={{ base: "full", md: "180px" }}
+        />
+        <Text color="gray.600" fontSize="sm" fontWeight="medium">
+          申請済み: {appliedCount}/{totalCount}名
+        </Text>
+      </Flex>
+
+      {/* スタッフ一覧 */}
+      {filteredStaffs.length === 0 ? (
+        <Empty icon={LuUser} title="該当するスタッフがいません" description="フィルター条件を変更してください" />
+      ) : (
+        <VStack gap={3} align="stretch">
+          {filteredStaffs.map((staff) => (
+            <StaffRequestCard key={staff.staffId} staff={staff} />
+          ))}
+        </VStack>
+      )}
+
+      {/* アクションボタン */}
+      <Flex
+        mt={6}
+        gap={3}
+        direction={{ base: "column", sm: "row" }}
+        justify="flex-end"
+        borderTop="1px solid"
+        borderColor="gray.200"
+        pt={6}
+      >
+        {recruitment.status === "open" && (
+          <Button
+            variant="outline"
+            colorPalette="orange"
+            onClick={handleCloseRecruitment}
+            w={{ base: "full", sm: "auto" }}
+          >
+            募集を締め切る
+          </Button>
+        )}
+        <Button colorPalette="teal" onClick={handleGoToConfirm} w={{ base: "full", sm: "auto" }}>
+          シフト確定へ進む
+        </Button>
+      </Flex>
+    </Container>
+  );
+};
+
+// スタッフカードコンポーネント
+const StaffRequestCard = ({ staff }: { staff: StaffWithRequestsType }) => {
+  const statusConfig = STATUS_CONFIG[staff.status];
+
+  return (
+    <Card.Root borderWidth={0} shadow="sm" _hover={{ shadow: "md" }} transition="all 0.15s">
+      <Card.Body p={{ base: 3, md: 4 }}>
+        <Flex justify="space-between" align="flex-start" mb={2}>
+          <Flex align="center" gap={2}>
+            <Icon as={LuUser} color="gray.500" />
+            <Text fontWeight="bold" color="gray.900">
+              {staff.staffName}
+            </Text>
+          </Flex>
+          <Badge colorPalette={statusConfig.colorPalette} size="sm">
+            {statusConfig.label}
+          </Badge>
+        </Flex>
+
+        {staff.status === "applied" && staff.requests.length > 0 ? (
+          <Box>
+            <VStack align="stretch" gap={1} mb={2}>
+              {staff.requests.map((request) => (
+                <Flex key={request._id} align="center" gap={2}>
+                  <Icon as={LuCalendarCheck} color="teal.500" boxSize={4} />
+                  <Text fontSize="sm" color="gray.600">
+                    {dayjs(request.date).format("M/D(ddd)")} {request.startTime}-{request.endTime}
+                  </Text>
+                </Flex>
+              ))}
+            </VStack>
+            <Text fontSize="xs" color="gray.500">
+              計: {staff.totalDays}日 / {staff.totalHours}時間
+            </Text>
+          </Box>
+        ) : (
+          <Text fontSize="sm" color="gray.400">
+            申請なし
+          </Text>
+        )}
+      </Card.Body>
+    </Card.Root>
+  );
+};

--- a/src/components/features/Shift/ShiftEditor/index.stories.tsx
+++ b/src/components/features/Shift/ShiftEditor/index.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ShiftEditor } from ".";
+
+const meta = {
+  title: "features/Shift/ShiftEditor",
+  component: ShiftEditor,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ShiftEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockRecruitment = {
+  _id: "recruitment_1",
+  startDate: "2025-12-01",
+  endDate: "2025-12-07",
+};
+
+const mockShiftRequests = [
+  {
+    _id: "req_1",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    date: "2025-12-01",
+    startTime: "09:00",
+    endTime: "17:00",
+  },
+  {
+    _id: "req_2",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_2",
+    staffName: "山田花子",
+    date: "2025-12-01",
+    startTime: "11:00",
+    endTime: "19:00",
+  },
+  {
+    _id: "req_3",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_3",
+    staffName: "鈴木次郎",
+    date: "2025-12-01",
+    startTime: "10:00",
+    endTime: "18:00",
+  },
+  {
+    _id: "req_4",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    date: "2025-12-02",
+    startTime: "10:00",
+    endTime: "18:00",
+  },
+  {
+    _id: "req_5",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_2",
+    staffName: "山田花子",
+    date: "2025-12-03",
+    startTime: "09:00",
+    endTime: "15:00",
+  },
+];
+
+const mockPositions = [
+  { value: "hall", label: "ホール" },
+  { value: "kitchen", label: "キッチン" },
+  { value: "register", label: "レジ" },
+];
+
+const mockRequiredStaffing = [
+  { _id: "rs_1", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "ホール", requiredCount: 2 },
+  { _id: "rs_2", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "キッチン", requiredCount: 1 },
+  { _id: "rs_3", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "ホール", requiredCount: 2 },
+  { _id: "rs_4", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "キッチン", requiredCount: 1 },
+  { _id: "rs_5", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "ホール", requiredCount: 3 },
+  { _id: "rs_6", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "キッチン", requiredCount: 2 },
+  { _id: "rs_7", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "ホール", requiredCount: 3 },
+  { _id: "rs_8", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "キッチン", requiredCount: 2 },
+];
+
+export const Basic: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    shiftRequests: mockShiftRequests,
+    positions: mockPositions,
+    requiredStaffing: mockRequiredStaffing,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    shiftRequests: [],
+    positions: mockPositions,
+    requiredStaffing: mockRequiredStaffing,
+  },
+};
+
+export const ManyStaffs: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: mockRecruitment,
+    shiftRequests: [
+      ...mockShiftRequests,
+      {
+        _id: "req_6",
+        recruitmentId: "recruitment_1",
+        staffId: "staff_4",
+        staffName: "高橋三郎",
+        date: "2025-12-01",
+        startTime: "08:00",
+        endTime: "16:00",
+      },
+      {
+        _id: "req_7",
+        recruitmentId: "recruitment_1",
+        staffId: "staff_5",
+        staffName: "伊藤四郎",
+        date: "2025-12-01",
+        startTime: "12:00",
+        endTime: "20:00",
+      },
+      {
+        _id: "req_8",
+        recruitmentId: "recruitment_1",
+        staffId: "staff_6",
+        staffName: "渡辺五郎",
+        date: "2025-12-01",
+        startTime: "14:00",
+        endTime: "22:00",
+      },
+    ],
+    positions: mockPositions,
+    requiredStaffing: mockRequiredStaffing,
+  },
+};
+
+export const SingleDay: Story = {
+  args: {
+    shopId: "shop_1",
+    recruitmentId: "recruitment_1",
+    recruitment: {
+      _id: "recruitment_1",
+      startDate: "2025-12-01",
+      endDate: "2025-12-01",
+    },
+    shiftRequests: mockShiftRequests.filter((r) => r.date === "2025-12-01"),
+    positions: mockPositions,
+    requiredStaffing: mockRequiredStaffing,
+  },
+};

--- a/src/components/features/Shift/ShiftEditor/index.tsx
+++ b/src/components/features/Shift/ShiftEditor/index.tsx
@@ -1,0 +1,463 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Container,
+  Flex,
+  Heading,
+  Icon,
+  Table,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import dayjs from "dayjs";
+import { useMemo, useState } from "react";
+import { LuCalendarCheck, LuCheck, LuUsers } from "react-icons/lu";
+import { Dialog, useDialog } from "@/src/components/ui/Dialog";
+import { Empty } from "@/src/components/ui/Empty";
+import { Select } from "@/src/components/ui/Select";
+import { Title } from "@/src/components/ui/Title";
+import { toaster } from "@/src/components/ui/toaster";
+
+// 希望シフトデータ
+type ShiftRequestType = {
+  _id: string;
+  recruitmentId: string;
+  staffId: string;
+  staffName: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  note?: string;
+};
+
+// 確定シフト編集用の状態型
+type ShiftEditStateType = {
+  requestId: string;
+  staffId: string;
+  staffName: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  isConfirmed: boolean;
+  position: string;
+};
+
+// 募集情報（表示用）
+type RecruitmentInfoType = {
+  _id: string;
+  startDate: string;
+  endDate: string;
+};
+
+// ポジション選択肢
+type PositionOptionType = {
+  value: string;
+  label: string;
+};
+
+// 必要人員データ
+type RequiredStaffingType = {
+  _id: string;
+  shopId: string;
+  dayOfWeek: number;
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+// 人員充足状況
+type StaffingStatusType = {
+  hour: number;
+  positionCounts: { [position: string]: { assigned: number; required: number } };
+};
+
+type ShiftEditorProps = {
+  shopId: string;
+  recruitmentId: string;
+  recruitment: RecruitmentInfoType;
+  shiftRequests: ShiftRequestType[];
+  positions: PositionOptionType[];
+  requiredStaffing: RequiredStaffingType[];
+};
+
+export const ShiftEditor = ({
+  shopId,
+  recruitmentId,
+  recruitment,
+  shiftRequests,
+  positions,
+  requiredStaffing,
+}: ShiftEditorProps) => {
+  // 日付選択（募集期間内の日付を生成）
+  const dateOptions = useMemo(() => {
+    const dates: { value: string; label: string }[] = [];
+    let current = dayjs(recruitment.startDate);
+    const end = dayjs(recruitment.endDate);
+    while (!current.isAfter(end)) {
+      dates.push({
+        value: current.format("YYYY-MM-DD"),
+        label: current.format("M/D(ddd)"),
+      });
+      current = current.add(1, "day");
+    }
+    return dates;
+  }, [recruitment.startDate, recruitment.endDate]);
+
+  const [selectedDate, setSelectedDate] = useState(dateOptions[0]?.value ?? "");
+
+  // 確定状態の管理
+  const [editStates, setEditStates] = useState<ShiftEditStateType[]>(() =>
+    shiftRequests.map((req) => ({
+      requestId: req._id,
+      staffId: req.staffId,
+      staffName: req.staffName,
+      date: req.date,
+      startTime: req.startTime,
+      endTime: req.endTime,
+      isConfirmed: false,
+      position: positions[0]?.value ?? "",
+    })),
+  );
+
+  // 選択日のシフト一覧
+  const filteredShifts = editStates.filter((s) => s.date === selectedDate);
+
+  // 確定チェック切り替え
+  const handleToggleConfirm = (requestId: string, checked: boolean) => {
+    setEditStates((prev) => prev.map((s) => (s.requestId === requestId ? { ...s, isConfirmed: checked } : s)));
+  };
+
+  // ポジション変更
+  const handlePositionChange = (requestId: string, position: string) => {
+    setEditStates((prev) => prev.map((s) => (s.requestId === requestId ? { ...s, position } : s)));
+  };
+
+  // 人員充足ダイアログ
+  const staffingDialog = useDialog();
+
+  // 人員充足状況の計算
+  const staffingStatus = useMemo(() => {
+    const confirmed = editStates.filter((s) => s.isConfirmed && s.date === selectedDate);
+    const selectedDayOfWeek = dayjs(selectedDate).day();
+    const relevantStaffing = requiredStaffing.filter((r) => r.dayOfWeek === selectedDayOfWeek);
+
+    // 時間帯ごとの集計
+    const hourlyMap: { [hour: number]: StaffingStatusType } = {};
+
+    // 必要人員を初期化
+    for (const req of relevantStaffing) {
+      if (!hourlyMap[req.hour]) {
+        hourlyMap[req.hour] = { hour: req.hour, positionCounts: {} };
+      }
+      hourlyMap[req.hour].positionCounts[req.position] = {
+        assigned: 0,
+        required: req.requiredCount,
+      };
+    }
+
+    // 確定シフトをカウント
+    for (const shift of confirmed) {
+      const startHour = Number.parseInt(shift.startTime.split(":")[0], 10);
+      const endHour = Number.parseInt(shift.endTime.split(":")[0], 10);
+      for (let h = startHour; h < endHour; h++) {
+        if (hourlyMap[h]?.positionCounts[shift.position]) {
+          hourlyMap[h].positionCounts[shift.position].assigned += 1;
+        }
+      }
+    }
+
+    return Object.values(hourlyMap).sort((a, b) => a.hour - b.hour);
+  }, [editStates, selectedDate, requiredStaffing]);
+
+  // シフト確定処理
+  const handleConfirmShifts = () => {
+    const confirmedShifts = editStates.filter((s) => s.isConfirmed);
+    if (confirmedShifts.length === 0) {
+      toaster.create({
+        description: "確定するシフトを選択してください",
+        type: "warning",
+      });
+      return;
+    }
+    // TODO: useMutation呼び出し
+    console.log("確定シフト:", confirmedShifts);
+    toaster.create({
+      description: `${confirmedShifts.length}件のシフトを確定しました`,
+      type: "success",
+    });
+  };
+
+  const formatDateRange = (startDate: string, endDate: string) => {
+    return `${dayjs(startDate).format("M/D(ddd)")}〜${dayjs(endDate).format("M/D(ddd)")}`;
+  };
+
+  const confirmedCount = editStates.filter((s) => s.isConfirmed).length;
+
+  return (
+    <Container maxW="6xl">
+      {/* ヘッダー */}
+      <Title prev={{ url: `/shops/${shopId}/shifts/recruitments/${recruitmentId}`, label: "申請状況に戻る" }}>
+        <Flex align="center" gap={3}>
+          <Flex p={{ base: 2, md: 3 }} bg="teal.50" borderRadius="lg">
+            <Icon as={LuCalendarCheck} boxSize={6} color="teal.600" />
+          </Flex>
+          <Box>
+            <Heading as="h2" size="xl" color="gray.900">
+              シフト確定
+            </Heading>
+            <Text color="gray.500" fontSize="sm">
+              {formatDateRange(recruitment.startDate, recruitment.endDate)}
+            </Text>
+          </Box>
+        </Flex>
+      </Title>
+
+      {/* 日付選択 & サマリー */}
+      <Flex
+        mb={4}
+        gap={4}
+        direction={{ base: "column", sm: "row" }}
+        justify="space-between"
+        align={{ base: "stretch", sm: "center" }}
+      >
+        <Select items={dateOptions} value={selectedDate} onChange={setSelectedDate} w={{ base: "full", md: "200px" }} />
+        <Text color="gray.600" fontSize="sm" fontWeight="medium">
+          確定済み: {confirmedCount}/{editStates.length}件
+        </Text>
+      </Flex>
+
+      {/* PC表示: Table形式 */}
+      <Box display={{ base: "none", md: "block" }}>
+        <ShiftTable
+          shifts={filteredShifts}
+          positions={positions}
+          onToggleConfirm={handleToggleConfirm}
+          onPositionChange={handlePositionChange}
+        />
+      </Box>
+
+      {/* SP表示: Card形式 */}
+      <Box display={{ base: "block", md: "none" }}>
+        <ShiftCardList
+          shifts={filteredShifts}
+          positions={positions}
+          onToggleConfirm={handleToggleConfirm}
+          onPositionChange={handlePositionChange}
+        />
+      </Box>
+
+      {/* アクションボタン */}
+      <Flex
+        mt={6}
+        gap={3}
+        direction={{ base: "column", sm: "row" }}
+        justify="flex-end"
+        borderTop="1px solid"
+        borderColor="gray.200"
+        pt={6}
+      >
+        <Button variant="outline" onClick={staffingDialog.open} w={{ base: "full", sm: "auto" }}>
+          <Icon as={LuUsers} />
+          人員充足を確認
+        </Button>
+        <Button colorPalette="teal" onClick={handleConfirmShifts} w={{ base: "full", sm: "auto" }}>
+          <Icon as={LuCheck} />
+          シフトを確定する
+        </Button>
+      </Flex>
+
+      {/* 人員充足確認ダイアログ */}
+      <Dialog
+        title="人員充足状況"
+        isOpen={staffingDialog.isOpen}
+        onOpenChange={staffingDialog.onOpenChange}
+        onClose={staffingDialog.close}
+        closeLabel="閉じる"
+      >
+        <StaffingComparisonTable staffingStatus={staffingStatus} selectedDate={selectedDate} positions={positions} />
+      </Dialog>
+    </Container>
+  );
+};
+
+// PC用テーブル
+const ShiftTable = ({
+  shifts,
+  positions,
+  onToggleConfirm,
+  onPositionChange,
+}: {
+  shifts: ShiftEditStateType[];
+  positions: PositionOptionType[];
+  onToggleConfirm: (requestId: string, checked: boolean) => void;
+  onPositionChange: (requestId: string, position: string) => void;
+}) => {
+  if (shifts.length === 0) {
+    return (
+      <Empty icon={LuCalendarCheck} title="この日の希望シフトはありません" description="他の日付を選択してください" />
+    );
+  }
+
+  return (
+    <Table.Root size="sm" variant="line">
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader>スタッフ</Table.ColumnHeader>
+          <Table.ColumnHeader>希望時間</Table.ColumnHeader>
+          <Table.ColumnHeader textAlign="center">確定</Table.ColumnHeader>
+          <Table.ColumnHeader>ポジション</Table.ColumnHeader>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {shifts.map((shift) => (
+          <Table.Row key={shift.requestId}>
+            <Table.Cell fontWeight="medium">{shift.staffName}</Table.Cell>
+            <Table.Cell>
+              {shift.startTime}-{shift.endTime}
+            </Table.Cell>
+            <Table.Cell textAlign="center">
+              <Checkbox.Root
+                checked={shift.isConfirmed}
+                onCheckedChange={(e) => onToggleConfirm(shift.requestId, !!e.checked)}
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+              </Checkbox.Root>
+            </Table.Cell>
+            <Table.Cell>
+              <Select
+                items={positions}
+                value={shift.position}
+                onChange={(value) => onPositionChange(shift.requestId, value)}
+                w="120px"
+                usePortal={false}
+              />
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  );
+};
+
+// SP用カードリスト
+const ShiftCardList = ({
+  shifts,
+  positions,
+  onToggleConfirm,
+  onPositionChange,
+}: {
+  shifts: ShiftEditStateType[];
+  positions: PositionOptionType[];
+  onToggleConfirm: (requestId: string, checked: boolean) => void;
+  onPositionChange: (requestId: string, position: string) => void;
+}) => {
+  if (shifts.length === 0) {
+    return (
+      <Empty icon={LuCalendarCheck} title="この日の希望シフトはありません" description="他の日付を選択してください" />
+    );
+  }
+
+  return (
+    <VStack gap={3} align="stretch">
+      {shifts.map((shift) => (
+        <Card.Root key={shift.requestId} borderWidth={0} shadow="sm">
+          <Card.Body p={3}>
+            <Text fontWeight="bold" mb={2}>
+              {shift.staffName}
+            </Text>
+            <Text fontSize="sm" color="gray.600" mb={3}>
+              希望: {shift.startTime}-{shift.endTime}
+            </Text>
+            <Flex gap={3} align="center">
+              <Checkbox.Root
+                checked={shift.isConfirmed}
+                onCheckedChange={(e) => onToggleConfirm(shift.requestId, !!e.checked)}
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+                <Checkbox.Label>確定</Checkbox.Label>
+              </Checkbox.Root>
+              <Select
+                items={positions}
+                value={shift.position}
+                onChange={(value) => onPositionChange(shift.requestId, value)}
+                w="120px"
+                usePortal={false}
+              />
+            </Flex>
+          </Card.Body>
+        </Card.Root>
+      ))}
+    </VStack>
+  );
+};
+
+// 人員充足比較テーブル
+const StaffingComparisonTable = ({
+  staffingStatus,
+  selectedDate,
+  positions,
+}: {
+  staffingStatus: StaffingStatusType[];
+  selectedDate: string;
+  positions: PositionOptionType[];
+}) => {
+  if (staffingStatus.length === 0) {
+    return (
+      <Text color="gray.500" textAlign="center" py={4}>
+        この日の必要人員設定がありません
+      </Text>
+    );
+  }
+
+  return (
+    <Box>
+      <Text mb={3} fontWeight="medium">
+        {dayjs(selectedDate).format("M/D(ddd)")} の人員状況
+      </Text>
+      <Table.Root size="sm" variant="outline">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>時間帯</Table.ColumnHeader>
+            {positions.map((pos) => (
+              <Table.ColumnHeader key={pos.value} textAlign="center">
+                {pos.label}
+              </Table.ColumnHeader>
+            ))}
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {staffingStatus.map((status) => (
+            <Table.Row key={status.hour}>
+              <Table.Cell>
+                {status.hour}:00-{status.hour + 1}:00
+              </Table.Cell>
+              {positions.map((pos) => {
+                const count = status.positionCounts[pos.label];
+                if (!count) {
+                  return (
+                    <Table.Cell key={pos.value} textAlign="center">
+                      <Text color="gray.400">-</Text>
+                    </Table.Cell>
+                  );
+                }
+                const isSufficient = count.assigned >= count.required;
+                return (
+                  <Table.Cell key={pos.value} textAlign="center">
+                    <Badge colorPalette={isSufficient ? "green" : "orange"}>
+                      {count.assigned}/{count.required}
+                    </Badge>
+                  </Table.Cell>
+                );
+              })}
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/index.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StaffingMatrix } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix",
+  component: StaffingMatrix,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof StaffingMatrix>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    shopId: "shop_1",
+    shop: {
+      _id: "shop_1",
+      shopName: "サンプル店舗",
+      openTime: "09:00",
+      closeTime: "22:00",
+    },
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+      { _id: "pos_3", name: "その他" },
+    ],
+    initialStaffing: [],
+  },
+};
+
+export const WithData: Story = {
+  args: {
+    shopId: "shop_1",
+    shop: {
+      _id: "shop_1",
+      shopName: "サンプル店舗",
+      openTime: "09:00",
+      closeTime: "22:00",
+    },
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+    ],
+    initialStaffing: [
+      { _id: "1", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "ホール", requiredCount: 2 },
+      { _id: "2", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "キッチン", requiredCount: 1 },
+      { _id: "3", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "ホール", requiredCount: 2 },
+      { _id: "4", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "キッチン", requiredCount: 1 },
+      { _id: "5", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "ホール", requiredCount: 3 },
+      { _id: "6", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "キッチン", requiredCount: 2 },
+      { _id: "7", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "ホール", requiredCount: 3 },
+      { _id: "8", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "キッチン", requiredCount: 2 },
+    ],
+  },
+};
+
+export const ShortHours: Story = {
+  args: {
+    shopId: "shop_1",
+    shop: {
+      _id: "shop_1",
+      shopName: "短時間営業店舗",
+      openTime: "11:00",
+      closeTime: "15:00",
+    },
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+    ],
+    initialStaffing: [],
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/index.tsx
@@ -1,0 +1,269 @@
+import { Box, Button, Card, Container, Flex, Heading, Icon, Input, Table, Tabs, Text, VStack } from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+import { LuSave, LuSettings } from "react-icons/lu";
+import { Title } from "@/src/components/ui/Title";
+import { toaster } from "@/src/components/ui/toaster";
+
+// 必要人員データ型
+type RequiredStaffingType = {
+  _id: string;
+  shopId: string;
+  dayOfWeek: number;
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type PositionType = {
+  _id: string;
+  name: string;
+};
+
+type ShopType = {
+  _id: string;
+  shopName: string;
+  openTime: string;
+  closeTime: string;
+};
+
+type StaffingMatrixProps = {
+  shopId: string;
+  shop: ShopType;
+  positions: PositionType[];
+  initialStaffing: RequiredStaffingType[];
+};
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: StaffingMatrixProps) => {
+  // 曜日タブ選択（月曜=1をデフォルト）
+  const [selectedDay, setSelectedDay] = useState("1");
+
+  // 営業時間から時間帯リストを生成
+  const hours = useMemo(() => {
+    const openHour = Number.parseInt(shop.openTime.split(":")[0], 10);
+    const closeHour = Number.parseInt(shop.closeTime.split(":")[0], 10);
+    const result: number[] = [];
+    for (let h = openHour; h < closeHour; h++) {
+      result.push(h);
+    }
+    return result;
+  }, [shop.openTime, shop.closeTime]);
+
+  // 人員数マトリックス: { `${dayOfWeek}-${hour}-${position}`: count }
+  const [staffingMap, setStaffingMap] = useState<Record<string, number>>(() => {
+    const map: Record<string, number> = {};
+    for (const item of initialStaffing) {
+      const key = `${item.dayOfWeek}-${item.hour}-${item.position}`;
+      map[key] = item.requiredCount;
+    }
+    return map;
+  });
+
+  // 変更フラグ
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // 人員数取得
+  const getCount = (dayOfWeek: number, hour: number, position: string) => {
+    const key = `${dayOfWeek}-${hour}-${position}`;
+    return staffingMap[key] ?? 0;
+  };
+
+  // 人員数更新
+  const handleCountChange = (dayOfWeek: number, hour: number, position: string, value: number) => {
+    const key = `${dayOfWeek}-${hour}-${position}`;
+    setStaffingMap((prev) => ({ ...prev, [key]: Math.max(0, Math.min(10, value)) }));
+    setHasChanges(true);
+  };
+
+  // 保存処理
+  const handleSave = () => {
+    // TODO: useMutation呼び出し
+    console.log("保存データ:", staffingMap);
+    toaster.create({
+      description: "必要人員設定を保存しました",
+      type: "success",
+    });
+    setHasChanges(false);
+  };
+
+  const currentDayOfWeek = Number.parseInt(selectedDay, 10);
+
+  return (
+    <Container maxW="6xl">
+      {/* ヘッダー */}
+      <Title prev={{ url: `/shops/${shopId}/shifts`, label: "シフト管理に戻る" }}>
+        <Flex align="center" gap={3}>
+          <Flex p={{ base: 2, md: 3 }} bg="purple.50" borderRadius="lg">
+            <Icon as={LuSettings} boxSize={6} color="purple.600" />
+          </Flex>
+          <Box>
+            <Heading as="h2" size="xl" color="gray.900">
+              必要人員設定
+            </Heading>
+            <Text color="gray.500" fontSize="sm">
+              {shop.shopName}
+            </Text>
+          </Box>
+        </Flex>
+      </Title>
+
+      {/* 曜日タブ */}
+      <Box mb={4}>
+        <Tabs.Root value={selectedDay} onValueChange={(e) => setSelectedDay(e.value)} variant="outline">
+          <Tabs.List>
+            {DAY_LABELS.map((day, idx) => (
+              <Tabs.Trigger key={idx} value={String(idx)} px={{ base: 3, md: 4 }}>
+                {day}
+              </Tabs.Trigger>
+            ))}
+          </Tabs.List>
+        </Tabs.Root>
+      </Box>
+
+      {/* 曜日見出し */}
+      <Text fontWeight="bold" mb={3} color="gray.700">
+        {DAY_LABELS[currentDayOfWeek]}曜日の必要人員
+      </Text>
+
+      {/* PC表示: Table形式 */}
+      <Box display={{ base: "none", md: "block" }}>
+        <StaffingTable
+          hours={hours}
+          positions={positions}
+          dayOfWeek={currentDayOfWeek}
+          getCount={getCount}
+          onCountChange={handleCountChange}
+        />
+      </Box>
+
+      {/* SP表示: Card形式 */}
+      <Box display={{ base: "block", md: "none" }}>
+        <StaffingCardList
+          hours={hours}
+          positions={positions}
+          dayOfWeek={currentDayOfWeek}
+          getCount={getCount}
+          onCountChange={handleCountChange}
+        />
+      </Box>
+
+      {/* アクションボタン */}
+      <Flex
+        mt={6}
+        gap={3}
+        direction={{ base: "column", sm: "row" }}
+        justify="flex-end"
+        borderTop="1px solid"
+        borderColor="gray.200"
+        pt={6}
+      >
+        <Button colorPalette="purple" onClick={handleSave} disabled={!hasChanges} w={{ base: "full", sm: "auto" }}>
+          <Icon as={LuSave} />
+          保存する
+        </Button>
+      </Flex>
+    </Container>
+  );
+};
+
+// PC用テーブル
+const StaffingTable = ({
+  hours,
+  positions,
+  dayOfWeek,
+  getCount,
+  onCountChange,
+}: {
+  hours: number[];
+  positions: PositionType[];
+  dayOfWeek: number;
+  getCount: (dayOfWeek: number, hour: number, position: string) => number;
+  onCountChange: (dayOfWeek: number, hour: number, position: string, value: number) => void;
+}) => {
+  return (
+    <Table.Root size="sm" variant="outline">
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeader>時間帯</Table.ColumnHeader>
+          {positions.map((pos) => (
+            <Table.ColumnHeader key={pos._id} textAlign="center">
+              {pos.name}
+            </Table.ColumnHeader>
+          ))}
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {hours.map((hour) => (
+          <Table.Row key={hour}>
+            <Table.Cell fontWeight="medium">
+              {hour}:00-{hour + 1}:00
+            </Table.Cell>
+            {positions.map((pos) => (
+              <Table.Cell key={pos._id} textAlign="center">
+                <Input
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={getCount(dayOfWeek, hour, pos.name)}
+                  onChange={(e) => onCountChange(dayOfWeek, hour, pos.name, Number.parseInt(e.target.value, 10) || 0)}
+                  w="60px"
+                  textAlign="center"
+                  size="sm"
+                />
+              </Table.Cell>
+            ))}
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  );
+};
+
+// SP用カードリスト
+const StaffingCardList = ({
+  hours,
+  positions,
+  dayOfWeek,
+  getCount,
+  onCountChange,
+}: {
+  hours: number[];
+  positions: PositionType[];
+  dayOfWeek: number;
+  getCount: (dayOfWeek: number, hour: number, position: string) => number;
+  onCountChange: (dayOfWeek: number, hour: number, position: string, value: number) => void;
+}) => {
+  return (
+    <VStack gap={3} align="stretch">
+      {hours.map((hour) => (
+        <Card.Root key={hour} borderWidth={0} shadow="sm">
+          <Card.Body p={3}>
+            <Text fontWeight="bold" mb={3}>
+              {hour}:00-{hour + 1}:00
+            </Text>
+            <Flex gap={3} wrap="wrap">
+              {positions.map((pos) => (
+                <Flex key={pos._id} align="center" gap={2}>
+                  <Text fontSize="sm" color="gray.600" minW="60px">
+                    {pos.name}
+                  </Text>
+                  <Input
+                    type="number"
+                    min={0}
+                    max={10}
+                    value={getCount(dayOfWeek, hour, pos.name)}
+                    onChange={(e) => onCountChange(dayOfWeek, hour, pos.name, Number.parseInt(e.target.value, 10) || 0)}
+                    w="60px"
+                    textAlign="center"
+                    size="sm"
+                  />
+                </Flex>
+              ))}
+            </Flex>
+          </Card.Body>
+        </Card.Root>
+      ))}
+    </VStack>
+  );
+};

--- a/src/components/pages/Shops/RecruitmentDetailPage/index.tsx
+++ b/src/components/pages/Shops/RecruitmentDetailPage/index.tsx
@@ -1,0 +1,91 @@
+import { RequestStatus } from "@/src/components/features/Shift/RequestStatus";
+
+type Props = {
+  shopId: string;
+  recruitmentId: string;
+};
+
+// モックデータ（将来的にはuseQueryで取得）
+const mockRecruitment = {
+  _id: "recruitment_1",
+  startDate: "2025-12-01",
+  endDate: "2025-12-07",
+  deadline: "2025-11-25",
+  status: "open" as const,
+};
+
+const mockStaffsWithRequests = [
+  {
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    status: "applied" as const,
+    requests: [
+      {
+        _id: "req_1",
+        staffId: "staff_1",
+        staffName: "田中太郎",
+        date: "2025-12-01",
+        startTime: "09:00",
+        endTime: "17:00",
+      },
+      {
+        _id: "req_2",
+        staffId: "staff_1",
+        staffName: "田中太郎",
+        date: "2025-12-03",
+        startTime: "10:00",
+        endTime: "18:00",
+      },
+    ],
+    totalDays: 2,
+    totalHours: 16,
+  },
+  {
+    staffId: "staff_2",
+    staffName: "山田花子",
+    status: "applied" as const,
+    requests: [
+      {
+        _id: "req_3",
+        staffId: "staff_2",
+        staffName: "山田花子",
+        date: "2025-12-02",
+        startTime: "11:00",
+        endTime: "19:00",
+      },
+    ],
+    totalDays: 1,
+    totalHours: 8,
+  },
+  {
+    staffId: "staff_3",
+    staffName: "佐藤一郎",
+    status: "not_applied" as const,
+    requests: [],
+    totalDays: 0,
+    totalHours: 0,
+  },
+];
+
+export const RecruitmentDetailPage = ({ shopId, recruitmentId }: Props) => {
+  // 将来的にはuseQueryでデータ取得
+  // const recruitment = useQuery(api.recruitment.queries.getById, { recruitmentId });
+  // const staffsWithRequests = useQuery(api.shiftRequest.queries.listByRecruitment, { recruitmentId });
+
+  // 将来的なローディング・エラー処理
+  // if (recruitment === undefined || staffsWithRequests === undefined) {
+  //   return <LoadingState />;
+  // }
+  // if (recruitment === null) {
+  //   return <NotFoundState />;
+  // }
+
+  return (
+    <RequestStatus
+      shopId={shopId}
+      recruitmentId={recruitmentId}
+      recruitment={mockRecruitment}
+      staffsWithRequests={mockStaffsWithRequests}
+    />
+  );
+};

--- a/src/components/pages/Shops/ShiftConfirmPage/index.tsx
+++ b/src/components/pages/Shops/ShiftConfirmPage/index.tsx
@@ -1,0 +1,108 @@
+import { ShiftEditor } from "@/src/components/features/Shift/ShiftEditor";
+
+type Props = {
+  shopId: string;
+  recruitmentId: string;
+};
+
+// モックデータ（将来的にはuseQueryで取得）
+const mockRecruitment = {
+  _id: "recruitment_1",
+  startDate: "2025-12-01",
+  endDate: "2025-12-07",
+};
+
+// 希望シフトのモックデータ
+const mockShiftRequests = [
+  {
+    _id: "req_1",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    date: "2025-12-01",
+    startTime: "09:00",
+    endTime: "17:00",
+  },
+  {
+    _id: "req_2",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_2",
+    staffName: "山田花子",
+    date: "2025-12-01",
+    startTime: "11:00",
+    endTime: "19:00",
+  },
+  {
+    _id: "req_3",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_3",
+    staffName: "鈴木次郎",
+    date: "2025-12-01",
+    startTime: "10:00",
+    endTime: "18:00",
+  },
+  {
+    _id: "req_4",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_1",
+    staffName: "田中太郎",
+    date: "2025-12-02",
+    startTime: "10:00",
+    endTime: "18:00",
+  },
+  {
+    _id: "req_5",
+    recruitmentId: "recruitment_1",
+    staffId: "staff_2",
+    staffName: "山田花子",
+    date: "2025-12-03",
+    startTime: "09:00",
+    endTime: "15:00",
+  },
+];
+
+// ポジション選択肢のモックデータ
+const mockPositions = [
+  { value: "hall", label: "ホール" },
+  { value: "kitchen", label: "キッチン" },
+  { value: "register", label: "レジ" },
+];
+
+// 必要人員のモックデータ（月曜日 = 1）
+const mockRequiredStaffing = [
+  { _id: "rs_1", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "ホール", requiredCount: 2 },
+  { _id: "rs_2", shopId: "shop_1", dayOfWeek: 1, hour: 9, position: "キッチン", requiredCount: 1 },
+  { _id: "rs_3", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "ホール", requiredCount: 2 },
+  { _id: "rs_4", shopId: "shop_1", dayOfWeek: 1, hour: 10, position: "キッチン", requiredCount: 1 },
+  { _id: "rs_5", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "ホール", requiredCount: 3 },
+  { _id: "rs_6", shopId: "shop_1", dayOfWeek: 1, hour: 11, position: "キッチン", requiredCount: 2 },
+  { _id: "rs_7", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "ホール", requiredCount: 3 },
+  { _id: "rs_8", shopId: "shop_1", dayOfWeek: 1, hour: 12, position: "キッチン", requiredCount: 2 },
+];
+
+export const ShiftConfirmPage = ({ shopId, recruitmentId }: Props) => {
+  // 将来的にはuseQueryでデータ取得
+  // const recruitment = useQuery(api.recruitment.queries.getById, { recruitmentId });
+  // const shiftRequests = useQuery(api.shiftRequest.queries.listByRecruitment, { recruitmentId });
+  // const positions = useQuery(api.position.queries.listByShop, { shopId });
+  // const requiredStaffing = useQuery(api.staffing.queries.listByShop, { shopId });
+
+  // 将来的なローディング・エラー処理
+  // if (recruitment === undefined || shiftRequests === undefined) {
+  //   return <LoadingState />;
+  // }
+  // if (recruitment === null) {
+  //   return <NotFoundState />;
+  // }
+
+  return (
+    <ShiftEditor
+      shopId={shopId}
+      recruitmentId={recruitmentId}
+      recruitment={mockRecruitment}
+      shiftRequests={mockShiftRequests}
+      positions={mockPositions}
+      requiredStaffing={mockRequiredStaffing}
+    />
+  );
+};

--- a/src/components/pages/Shops/StaffingSettingsPage/index.tsx
+++ b/src/components/pages/Shops/StaffingSettingsPage/index.tsx
@@ -1,0 +1,37 @@
+import { StaffingMatrix } from "@/src/components/features/Shift/StaffingMatrix";
+
+type Props = {
+  shopId: string;
+};
+
+// モックデータ（将来的にはuseQueryで取得）
+const mockShop = {
+  _id: "shop_1",
+  shopName: "サンプル店舗",
+  openTime: "09:00",
+  closeTime: "22:00",
+};
+
+const mockPositions = [
+  { _id: "pos_1", name: "ホール" },
+  { _id: "pos_2", name: "キッチン" },
+  { _id: "pos_3", name: "その他" },
+];
+
+export const StaffingSettingsPage = ({ shopId }: Props) => {
+  // 将来的にはuseQueryでデータ取得
+  // const shop = useQuery(api.shop.queries.getById, { shopId: shopId as Id<"shops"> });
+  // const positions = useQuery(api.position.queries.listByShop, { shopId: shopId as Id<"shops"> });
+  // const requiredStaffing = useQuery(api.requiredStaffing.queries.listByShop, { shopId: shopId as Id<"shops"> });
+
+  // モック実装のため、直接データを渡す
+  const shop = { ...mockShop, _id: shopId };
+  const positions = mockPositions;
+
+  // 将来的なローディング・エラー処理
+  // if (shop === undefined || positions === undefined) {
+  //   return <LazyShow><StaffingMatrixLoading /></LazyShow>;
+  // }
+
+  return <StaffingMatrix shopId={shopId} shop={shop} positions={positions} initialStaffing={[]} />;
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -26,9 +26,12 @@ import { Route as AuthSettingsShiftTemplateAddRouteImport } from './routes/_auth
 import { Route as AuthShopsShopIdStaffsIndexRouteImport } from './routes/_auth/shops/$shopId/staffs/index'
 import { Route as AuthShopsShopIdShiftsIndexRouteImport } from './routes/_auth/shops/$shopId/shifts/index'
 import { Route as AuthShopsShopIdEditIndexRouteImport } from './routes/_auth/shops/$shopId/edit/index'
+import { Route as AuthShopsShopIdShiftsSettingsRouteImport } from './routes/_auth/shops/$shopId/shifts/settings'
 import { Route as AuthShopsShopIdStaffsStaffIdIndexRouteImport } from './routes/_auth/shops/$shopId/staffs/$staffId/index'
 import { Route as AuthShopsShopIdStaffsStaffIdEditRouteImport } from './routes/_auth/shops/$shopId/staffs/$staffId/edit'
 import { Route as AuthShopsShopIdShiftsRecruitmentsNewRouteImport } from './routes/_auth/shops/$shopId/shifts/recruitments/new'
+import { Route as AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRouteImport } from './routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/index'
+import { Route as AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRouteImport } from './routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
 
 const InviteRoute = InviteRouteImport.update({
   id: '/invite',
@@ -119,6 +122,12 @@ const AuthShopsShopIdEditIndexRoute =
     path: '/shops/$shopId/edit/',
     getParentRoute: () => AuthRoute,
   } as any)
+const AuthShopsShopIdShiftsSettingsRoute =
+  AuthShopsShopIdShiftsSettingsRouteImport.update({
+    id: '/shops/$shopId/shifts/settings',
+    path: '/shops/$shopId/shifts/settings',
+    getParentRoute: () => AuthRoute,
+  } as any)
 const AuthShopsShopIdStaffsStaffIdIndexRoute =
   AuthShopsShopIdStaffsStaffIdIndexRouteImport.update({
     id: '/shops/$shopId/staffs/$staffId/',
@@ -137,6 +146,18 @@ const AuthShopsShopIdShiftsRecruitmentsNewRoute =
     path: '/shops/$shopId/shifts/recruitments/new',
     getParentRoute: () => AuthRoute,
   } as any)
+const AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute =
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRouteImport.update({
+    id: '/shops/$shopId/shifts/recruitments/$recruitmentId/',
+    path: '/shops/$shopId/shifts/recruitments/$recruitmentId/',
+    getParentRoute: () => AuthRoute,
+  } as any)
+const AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute =
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRouteImport.update({
+    id: '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm',
+    path: '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm',
+    getParentRoute: () => AuthRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -151,12 +172,15 @@ export interface FileRoutesByFullPath {
   '/settings/shift-template': typeof AuthSettingsShiftTemplateIndexRoute
   '/shops/$shopId': typeof AuthShopsShopIdIndexRoute
   '/shops/new': typeof AuthShopsNewIndexRoute
+  '/shops/$shopId/shifts/settings': typeof AuthShopsShopIdShiftsSettingsRoute
   '/shops/$shopId/edit': typeof AuthShopsShopIdEditIndexRoute
   '/shops/$shopId/shifts': typeof AuthShopsShopIdShiftsIndexRoute
   '/shops/$shopId/staffs': typeof AuthShopsShopIdStaffsIndexRoute
   '/shops/$shopId/shifts/recruitments/new': typeof AuthShopsShopIdShiftsRecruitmentsNewRoute
   '/shops/$shopId/staffs/$staffId/edit': typeof AuthShopsShopIdStaffsStaffIdEditRoute
   '/shops/$shopId/staffs/$staffId': typeof AuthShopsShopIdStaffsStaffIdIndexRoute
+  '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute
+  '/shops/$shopId/shifts/recruitments/$recruitmentId': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -171,12 +195,15 @@ export interface FileRoutesByTo {
   '/settings/shift-template': typeof AuthSettingsShiftTemplateIndexRoute
   '/shops/$shopId': typeof AuthShopsShopIdIndexRoute
   '/shops/new': typeof AuthShopsNewIndexRoute
+  '/shops/$shopId/shifts/settings': typeof AuthShopsShopIdShiftsSettingsRoute
   '/shops/$shopId/edit': typeof AuthShopsShopIdEditIndexRoute
   '/shops/$shopId/shifts': typeof AuthShopsShopIdShiftsIndexRoute
   '/shops/$shopId/staffs': typeof AuthShopsShopIdStaffsIndexRoute
   '/shops/$shopId/shifts/recruitments/new': typeof AuthShopsShopIdShiftsRecruitmentsNewRoute
   '/shops/$shopId/staffs/$staffId/edit': typeof AuthShopsShopIdStaffsStaffIdEditRoute
   '/shops/$shopId/staffs/$staffId': typeof AuthShopsShopIdStaffsStaffIdIndexRoute
+  '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute
+  '/shops/$shopId/shifts/recruitments/$recruitmentId': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -194,12 +221,15 @@ export interface FileRoutesById {
   '/_auth/settings/shift-template/': typeof AuthSettingsShiftTemplateIndexRoute
   '/_auth/shops/$shopId/': typeof AuthShopsShopIdIndexRoute
   '/_auth/shops/new/': typeof AuthShopsNewIndexRoute
+  '/_auth/shops/$shopId/shifts/settings': typeof AuthShopsShopIdShiftsSettingsRoute
   '/_auth/shops/$shopId/edit/': typeof AuthShopsShopIdEditIndexRoute
   '/_auth/shops/$shopId/shifts/': typeof AuthShopsShopIdShiftsIndexRoute
   '/_auth/shops/$shopId/staffs/': typeof AuthShopsShopIdStaffsIndexRoute
   '/_auth/shops/$shopId/shifts/recruitments/new': typeof AuthShopsShopIdShiftsRecruitmentsNewRoute
   '/_auth/shops/$shopId/staffs/$staffId/edit': typeof AuthShopsShopIdStaffsStaffIdEditRoute
   '/_auth/shops/$shopId/staffs/$staffId/': typeof AuthShopsShopIdStaffsStaffIdIndexRoute
+  '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute
+  '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/': typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -216,12 +246,15 @@ export interface FileRouteTypes {
     | '/settings/shift-template'
     | '/shops/$shopId'
     | '/shops/new'
+    | '/shops/$shopId/shifts/settings'
     | '/shops/$shopId/edit'
     | '/shops/$shopId/shifts'
     | '/shops/$shopId/staffs'
     | '/shops/$shopId/shifts/recruitments/new'
     | '/shops/$shopId/staffs/$staffId/edit'
     | '/shops/$shopId/staffs/$staffId'
+    | '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+    | '/shops/$shopId/shifts/recruitments/$recruitmentId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -236,12 +269,15 @@ export interface FileRouteTypes {
     | '/settings/shift-template'
     | '/shops/$shopId'
     | '/shops/new'
+    | '/shops/$shopId/shifts/settings'
     | '/shops/$shopId/edit'
     | '/shops/$shopId/shifts'
     | '/shops/$shopId/staffs'
     | '/shops/$shopId/shifts/recruitments/new'
     | '/shops/$shopId/staffs/$staffId/edit'
     | '/shops/$shopId/staffs/$staffId'
+    | '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+    | '/shops/$shopId/shifts/recruitments/$recruitmentId'
   id:
     | '__root__'
     | '/'
@@ -258,12 +294,15 @@ export interface FileRouteTypes {
     | '/_auth/settings/shift-template/'
     | '/_auth/shops/$shopId/'
     | '/_auth/shops/new/'
+    | '/_auth/shops/$shopId/shifts/settings'
     | '/_auth/shops/$shopId/edit/'
     | '/_auth/shops/$shopId/shifts/'
     | '/_auth/shops/$shopId/staffs/'
     | '/_auth/shops/$shopId/shifts/recruitments/new'
     | '/_auth/shops/$shopId/staffs/$staffId/edit'
     | '/_auth/shops/$shopId/staffs/$staffId/'
+    | '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+    | '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -394,6 +433,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthShopsShopIdEditIndexRouteImport
       parentRoute: typeof AuthRoute
     }
+    '/_auth/shops/$shopId/shifts/settings': {
+      id: '/_auth/shops/$shopId/shifts/settings'
+      path: '/shops/$shopId/shifts/settings'
+      fullPath: '/shops/$shopId/shifts/settings'
+      preLoaderRoute: typeof AuthShopsShopIdShiftsSettingsRouteImport
+      parentRoute: typeof AuthRoute
+    }
     '/_auth/shops/$shopId/staffs/$staffId/': {
       id: '/_auth/shops/$shopId/staffs/$staffId/'
       path: '/shops/$shopId/staffs/$staffId'
@@ -415,6 +461,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthShopsShopIdShiftsRecruitmentsNewRouteImport
       parentRoute: typeof AuthRoute
     }
+    '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/': {
+      id: '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/'
+      path: '/shops/$shopId/shifts/recruitments/$recruitmentId'
+      fullPath: '/shops/$shopId/shifts/recruitments/$recruitmentId'
+      preLoaderRoute: typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRouteImport
+      parentRoute: typeof AuthRoute
+    }
+    '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm': {
+      id: '/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+      path: '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+      fullPath: '/shops/$shopId/shifts/recruitments/$recruitmentId/confirm'
+      preLoaderRoute: typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRouteImport
+      parentRoute: typeof AuthRoute
+    }
   }
 }
 
@@ -428,12 +488,15 @@ interface AuthRouteChildren {
   AuthSettingsShiftTemplateIndexRoute: typeof AuthSettingsShiftTemplateIndexRoute
   AuthShopsShopIdIndexRoute: typeof AuthShopsShopIdIndexRoute
   AuthShopsNewIndexRoute: typeof AuthShopsNewIndexRoute
+  AuthShopsShopIdShiftsSettingsRoute: typeof AuthShopsShopIdShiftsSettingsRoute
   AuthShopsShopIdEditIndexRoute: typeof AuthShopsShopIdEditIndexRoute
   AuthShopsShopIdShiftsIndexRoute: typeof AuthShopsShopIdShiftsIndexRoute
   AuthShopsShopIdStaffsIndexRoute: typeof AuthShopsShopIdStaffsIndexRoute
   AuthShopsShopIdShiftsRecruitmentsNewRoute: typeof AuthShopsShopIdShiftsRecruitmentsNewRoute
   AuthShopsShopIdStaffsStaffIdEditRoute: typeof AuthShopsShopIdStaffsStaffIdEditRoute
   AuthShopsShopIdStaffsStaffIdIndexRoute: typeof AuthShopsShopIdStaffsStaffIdIndexRoute
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute: typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute: typeof AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
@@ -446,6 +509,7 @@ const AuthRouteChildren: AuthRouteChildren = {
   AuthSettingsShiftTemplateIndexRoute: AuthSettingsShiftTemplateIndexRoute,
   AuthShopsShopIdIndexRoute: AuthShopsShopIdIndexRoute,
   AuthShopsNewIndexRoute: AuthShopsNewIndexRoute,
+  AuthShopsShopIdShiftsSettingsRoute: AuthShopsShopIdShiftsSettingsRoute,
   AuthShopsShopIdEditIndexRoute: AuthShopsShopIdEditIndexRoute,
   AuthShopsShopIdShiftsIndexRoute: AuthShopsShopIdShiftsIndexRoute,
   AuthShopsShopIdStaffsIndexRoute: AuthShopsShopIdStaffsIndexRoute,
@@ -454,6 +518,10 @@ const AuthRouteChildren: AuthRouteChildren = {
   AuthShopsShopIdStaffsStaffIdEditRoute: AuthShopsShopIdStaffsStaffIdEditRoute,
   AuthShopsShopIdStaffsStaffIdIndexRoute:
     AuthShopsShopIdStaffsStaffIdIndexRoute,
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute:
+    AuthShopsShopIdShiftsRecruitmentsRecruitmentIdConfirmRoute,
+  AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute:
+    AuthShopsShopIdShiftsRecruitmentsRecruitmentIdIndexRoute,
 }
 
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)

--- a/src/routes/_auth/shifts.tsx
+++ b/src/routes/_auth/shifts.tsx
@@ -1,10 +1,47 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Button } from "@chakra-ui/react";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { useAtomValue } from "jotai";
+import { useEffect } from "react";
+import { LuCalendar } from "react-icons/lu";
 import { Animation } from "@/src/components/templates/Animation";
+import { Empty } from "@/src/components/ui/Empty";
+import { selectedShopAtom } from "@/src/stores/shop";
+
+const RouteComponent = () => {
+  const navigate = useNavigate();
+  const selectedShop = useAtomValue(selectedShopAtom);
+
+  useEffect(() => {
+    if (selectedShop?.shopId) {
+      navigate({
+        to: "/shops/$shopId/shifts",
+        params: { shopId: selectedShop.shopId },
+      });
+    }
+  }, [selectedShop, navigate]);
+
+  // 店舗未選択の場合
+  if (!selectedShop) {
+    return (
+      <Animation>
+        <Empty
+          icon={LuCalendar}
+          title="店舗が選択されていません"
+          description="シフト管理を利用するには、店舗を選択してください"
+          action={
+            <Link to="/mypage">
+              <Button colorPalette="teal">マイページで店舗を選択</Button>
+            </Link>
+          }
+        />
+      </Animation>
+    );
+  }
+
+  // リダイレクト中
+  return null;
+};
 
 export const Route = createFileRoute("/_auth/shifts")({
   component: RouteComponent,
 });
-
-function RouteComponent() {
-  return <Animation>Hello "/(auth)/shifts/"!</Animation>;
-}

--- a/src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm.tsx
+++ b/src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { ShiftConfirmPage } from "@/src/components/pages/Shops/ShiftConfirmPage";
+import { Animation } from "@/src/components/templates/Animation";
+
+export const Route = createFileRoute("/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { shopId, recruitmentId } = useParams({
+    from: "/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/confirm",
+  });
+  return (
+    <Animation>
+      <ShiftConfirmPage shopId={shopId} recruitmentId={recruitmentId} />
+    </Animation>
+  );
+}

--- a/src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/index.tsx
+++ b/src/routes/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/index.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { RecruitmentDetailPage } from "@/src/components/pages/Shops/RecruitmentDetailPage";
+import { Animation } from "@/src/components/templates/Animation";
+
+export const Route = createFileRoute("/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { shopId, recruitmentId } = useParams({
+    from: "/_auth/shops/$shopId/shifts/recruitments/$recruitmentId/",
+  });
+  return (
+    <Animation>
+      <RecruitmentDetailPage shopId={shopId} recruitmentId={recruitmentId} />
+    </Animation>
+  );
+}

--- a/src/routes/_auth/shops/$shopId/shifts/settings.tsx
+++ b/src/routes/_auth/shops/$shopId/shifts/settings.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, useParams } from "@tanstack/react-router";
+import { StaffingSettingsPage } from "@/src/components/pages/Shops/StaffingSettingsPage";
+import { Animation } from "@/src/components/templates/Animation";
+
+export const Route = createFileRoute("/_auth/shops/$shopId/shifts/settings")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { shopId } = useParams({ from: "/_auth/shops/$shopId/shifts/settings" });
+  return (
+    <Animation>
+      <StaffingSettingsPage shopId={shopId} />
+    </Animation>
+  );
+}


### PR DESCRIPTION
## Summary
シフト管理機能の基盤となるコンポーネント群とページをモック実装。店舗管理者がシフトを編集・確認し、人員配置を管理するための画面を追加。

## Design

### コンポーネント構成
```mermaid
graph TD
    subgraph Pages
        A[ShiftConfirmPage] 
        B[RecruitmentDetailPage]
        C[StaffingSettingsPage]
    end
    
    subgraph Features
        D[ShiftEditor]
        E[StaffingMatrix]
        F[RequestStatus]
        G[RecruitmentList]
    end
    
    A --> D
    A --> E
    B --> F
    C --> E
```

### 画面遷移フロー
```mermaid
flowchart LR
    A[シフト一覧] --> B[募集詳細]
    B --> C[シフト確認]
    A --> D[人員設定]
```

## Changes
- **ShiftEditor**: 日別シフトの編集UI（時間帯・ポジション別の人員調整）
- **StaffingMatrix**: 人員配置マトリックス表示（曜日×時間帯）
- **RequestStatus**: シフトリクエストのステータス表示
- **RecruitmentDetailPage**: 募集詳細ページ
- **ShiftConfirmPage**: シフト確認・編集ページ
- **StaffingSettingsPage**: 人員設定ページ
- **create-pr スキル**: PRテンプレートを改善（mermaid図対応）