### PR TITLE
feat: 必要人員設定（スタッフィングマトリックス）機能の実装

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,8 @@ import type * as invite_mutations from "../invite/mutations.js";
 import type * as invite_queries from "../invite/queries.js";
 import type * as position_mutations from "../position/mutations.js";
 import type * as position_queries from "../position/queries.js";
+import type * as requiredStaffing_mutations from "../requiredStaffing/mutations.js";
+import type * as requiredStaffing_queries from "../requiredStaffing/queries.js";
 import type * as shop_mutations from "../shop/mutations.js";
 import type * as shop_queries from "../shop/queries.js";
 import type * as staffSkill_mutations from "../staffSkill/mutations.js";
@@ -35,6 +37,8 @@ declare const fullApi: ApiFromModules<{
   "invite/queries": typeof invite_queries;
   "position/mutations": typeof position_mutations;
   "position/queries": typeof position_queries;
+  "requiredStaffing/mutations": typeof requiredStaffing_mutations;
+  "requiredStaffing/queries": typeof requiredStaffing_queries;
   "shop/mutations": typeof shop_mutations;
   "shop/queries": typeof shop_queries;
   "staffSkill/mutations": typeof staffSkill_mutations;

--- a/convex/requiredStaffing/mutations.ts
+++ b/convex/requiredStaffing/mutations.ts
@@ -1,0 +1,184 @@
+/**
+ * 必要人員設定 - ミューテーション（書き込み操作）
+ *
+ * 責務:
+ * - 必要人員設定の保存・更新
+ * - AI入力情報の保存
+ */
+import { ConvexError, v } from "convex/values";
+import { mutation } from "../_generated/server";
+import { requireShop } from "../helpers";
+
+// 必要人員設定を保存・更新（曜日単位）
+export const upsert = mutation({
+  args: {
+    shopId: v.id("shops"),
+    dayOfWeek: v.number(), // 0=日, 1=月, ..., 6=土
+    staffing: v.array(
+      v.object({
+        hour: v.number(),
+        position: v.string(),
+        requiredCount: v.number(),
+      }),
+    ),
+    aiInput: v.optional(
+      v.object({
+        shopType: v.string(),
+        customerCount: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    await requireShop(ctx, args.shopId);
+
+    // バリデーション
+    if (args.dayOfWeek < 0 || args.dayOfWeek > 6) {
+      throw new ConvexError({ message: "曜日の値が不正です", code: "INVALID_DAY_OF_WEEK" });
+    }
+
+    // 既存データを検索
+    const existing = await ctx.db
+      .query("requiredStaffing")
+      .withIndex("by_shop", (q) => q.eq("shopId", args.shopId))
+      .collect()
+      .then((list) => list.find((s) => s.dayOfWeek === args.dayOfWeek));
+
+    const now = Date.now();
+
+    if (existing) {
+      // 更新
+      await ctx.db.patch(existing._id, {
+        staffing: args.staffing,
+        aiInput: args.aiInput,
+        updatedAt: now,
+      });
+      return { success: true, id: existing._id, isNew: false };
+    }
+
+    // 新規作成
+    const id = await ctx.db.insert("requiredStaffing", {
+      shopId: args.shopId,
+      dayOfWeek: args.dayOfWeek,
+      staffing: args.staffing,
+      aiInput: args.aiInput,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { success: true, id, isNew: true };
+  },
+});
+
+// 複数曜日に一括で設定をコピー
+export const copyToMultipleDays = mutation({
+  args: {
+    shopId: v.id("shops"),
+    sourceDayOfWeek: v.number(),
+    targetDaysOfWeek: v.array(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await requireShop(ctx, args.shopId);
+
+    // コピー元の設定を取得
+    const sourceList = await ctx.db
+      .query("requiredStaffing")
+      .withIndex("by_shop", (q) => q.eq("shopId", args.shopId))
+      .collect();
+
+    const source = sourceList.find((s) => s.dayOfWeek === args.sourceDayOfWeek);
+
+    if (!source) {
+      throw new ConvexError({ message: "コピー元の設定が見つかりません", code: "SOURCE_NOT_FOUND" });
+    }
+
+    const now = Date.now();
+    const results: { dayOfWeek: number; id: string }[] = [];
+
+    for (const targetDay of args.targetDaysOfWeek) {
+      if (targetDay === args.sourceDayOfWeek) continue; // 同じ曜日はスキップ
+
+      const existing = sourceList.find((s) => s.dayOfWeek === targetDay);
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          staffing: source.staffing,
+          updatedAt: now,
+        });
+        results.push({ dayOfWeek: targetDay, id: existing._id });
+      } else {
+        const id = await ctx.db.insert("requiredStaffing", {
+          shopId: args.shopId,
+          dayOfWeek: targetDay,
+          staffing: source.staffing,
+          aiInput: source.aiInput,
+          createdAt: now,
+          updatedAt: now,
+        });
+        results.push({ dayOfWeek: targetDay, id });
+      }
+    }
+
+    return { success: true, copiedDays: results };
+  },
+});
+
+// 全曜日分をまとめて保存（初回設定用）
+export const saveAll = mutation({
+  args: {
+    shopId: v.id("shops"),
+    settings: v.array(
+      v.object({
+        dayOfWeek: v.number(),
+        staffing: v.array(
+          v.object({
+            hour: v.number(),
+            position: v.string(),
+            requiredCount: v.number(),
+          }),
+        ),
+      }),
+    ),
+    aiInput: v.optional(
+      v.object({
+        shopType: v.string(),
+        customerCount: v.string(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    await requireShop(ctx, args.shopId);
+
+    const now = Date.now();
+
+    // 既存データを取得
+    const existingList = await ctx.db
+      .query("requiredStaffing")
+      .withIndex("by_shop", (q) => q.eq("shopId", args.shopId))
+      .collect();
+
+    const existingMap = new Map(existingList.map((s) => [s.dayOfWeek, s]));
+
+    for (const setting of args.settings) {
+      const existing = existingMap.get(setting.dayOfWeek);
+
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          staffing: setting.staffing,
+          aiInput: args.aiInput,
+          updatedAt: now,
+        });
+      } else {
+        await ctx.db.insert("requiredStaffing", {
+          shopId: args.shopId,
+          dayOfWeek: setting.dayOfWeek,
+          staffing: setting.staffing,
+          aiInput: args.aiInput,
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+
+    return { success: true };
+  },
+});

--- a/convex/requiredStaffing/queries.ts
+++ b/convex/requiredStaffing/queries.ts
@@ -1,0 +1,37 @@
+/**
+ * 必要人員設定 - クエリ（読み取り操作）
+ *
+ * 責務:
+ * - 店舗の必要人員設定の取得
+ */
+import { v } from "convex/values";
+import { query } from "../_generated/server";
+
+// 店舗の必要人員設定を全曜日分取得
+export const getByShopId = query({
+  args: { shopId: v.id("shops") },
+  handler: async (ctx, args) => {
+    const staffingList = await ctx.db
+      .query("requiredStaffing")
+      .withIndex("by_shop", (q) => q.eq("shopId", args.shopId))
+      .collect();
+
+    return staffingList;
+  },
+});
+
+// 特定の曜日の必要人員設定を取得
+export const getByShopIdAndDay = query({
+  args: {
+    shopId: v.id("shops"),
+    dayOfWeek: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const staffingList = await ctx.db
+      .query("requiredStaffing")
+      .withIndex("by_shop", (q) => q.eq("shopId", args.shopId))
+      .collect();
+
+    return staffingList.find((s) => s.dayOfWeek === args.dayOfWeek) ?? null;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -98,12 +98,35 @@ const staffSkills = defineTable({
   .index("by_staff", ["staffId"])
   .index("by_position", ["positionId"]);
 
+// 必要人員設定（曜日ごと）
+const requiredStaffing = defineTable({
+  shopId: v.id("shops"),
+  dayOfWeek: v.number(), // 0=日, 1=月, ..., 6=土
+  staffing: v.array(
+    v.object({
+      hour: v.number(), // 0-23
+      position: v.string(),
+      requiredCount: v.number(),
+    }),
+  ),
+  // AI生成時の入力情報（作り直し用）
+  aiInput: v.optional(
+    v.object({
+      shopType: v.string(),
+      customerCount: v.string(),
+    }),
+  ),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+}).index("by_shop", ["shopId"]);
+
 const schema = defineSchema({
   users,
   shops,
   staffs,
   shopPositions,
   staffSkills,
+  requiredStaffing,
 });
 
 // テーブル名を型安全にエクスポート（testing.tsで使用）

--- a/src/components/features/Shift/StaffingMatrix/AIGenerateForm/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/AIGenerateForm/index.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AIGenerateForm } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/AIGenerateForm",
+  component: AIGenerateForm,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof AIGenerateForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const positions = [
+  { _id: "pos_1", name: "ホール" },
+  { _id: "pos_2", name: "キッチン" },
+  { _id: "pos_3", name: "その他" },
+];
+
+export const Basic: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    onGenerate: (result, aiInput) => {
+      console.log("Generated:", result, aiInput);
+    },
+    onSkip: () => {
+      console.log("Skipped");
+    },
+  },
+};
+
+export const WithInitialInput: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    initialAIInput: {
+      shopType: "カフェ、ランチメインで夜は軽め",
+      customerCount: "平日80人、土日120人くらい",
+    },
+    onGenerate: (result, aiInput) => {
+      console.log("Generated:", result, aiInput);
+    },
+    onSkip: () => {
+      console.log("Skipped");
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    initialAIInput: {
+      shopType: "カフェ",
+      customerCount: "100人",
+    },
+    onGenerate: () => {},
+    onSkip: () => {},
+    isLoading: true,
+  },
+};
+
+export const ShortHours: Story = {
+  args: {
+    openTime: "11:00",
+    closeTime: "15:00",
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+    ],
+    onGenerate: (result, aiInput) => {
+      console.log("Generated:", result, aiInput);
+    },
+    onSkip: () => {
+      console.log("Skipped");
+    },
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/AIGenerateForm/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/AIGenerateForm/index.tsx
@@ -1,0 +1,144 @@
+import { Box, Button, Field, Flex, Icon, Input, Text, Textarea, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { LuBot, LuSparkles } from "react-icons/lu";
+import { FormCard } from "@/src/components/ui/FormCard";
+
+type AIInput = {
+  shopType: string;
+  customerCount: string;
+};
+
+type StaffingEntry = {
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type AIGenerateFormProps = {
+  openTime: string;
+  closeTime: string;
+  positions: { _id: string; name: string }[];
+  initialAIInput?: AIInput;
+  onGenerate: (result: StaffingEntry[], aiInput: AIInput) => void;
+  onSkip: () => void;
+  isLoading?: boolean;
+};
+
+export const AIGenerateForm = ({
+  openTime,
+  closeTime,
+  positions,
+  initialAIInput,
+  onGenerate,
+  onSkip,
+  isLoading = false,
+}: AIGenerateFormProps) => {
+  const [shopType, setShopType] = useState(initialAIInput?.shopType ?? "");
+  const [customerCount, setCustomerCount] = useState(initialAIInput?.customerCount ?? "");
+
+  const handleSubmit = async () => {
+    const aiInput: AIInput = { shopType, customerCount };
+
+    // TODO: 実際のAI API呼び出しに置き換え
+    // 仮の生成ロジック
+    const generatedStaffing = generateMockStaffing(openTime, closeTime, positions);
+
+    onGenerate(generatedStaffing, aiInput);
+  };
+
+  const isValid = shopType.trim().length > 0;
+
+  return (
+    <FormCard icon={LuBot} iconColor="teal.600" title="AIで人員配置を提案">
+      <VStack gap={4} align="stretch">
+        <Field.Root>
+          <Field.Label>どんなお店ですか？</Field.Label>
+          <Textarea
+            value={shopType}
+            onChange={(e) => setShopType(e.target.value)}
+            placeholder="例: カフェ、ランチメインで夜は軽め"
+            rows={2}
+            disabled={isLoading}
+          />
+        </Field.Root>
+
+        <Field.Root>
+          <Field.Label>
+            1日の来客数は？
+            <Text as="span" fontSize="xs" color="gray.500" ml={2}>
+              ざっくりでOK
+            </Text>
+          </Field.Label>
+          <Input
+            value={customerCount}
+            onChange={(e) => setCustomerCount(e.target.value)}
+            placeholder="例: 平日80人、土日120人くらい"
+            disabled={isLoading}
+          />
+        </Field.Root>
+
+        <Box bg="gray.50" p={3} borderRadius="md">
+          <Text fontSize="sm" color="gray.600">
+            営業時間: {openTime} - {closeTime}
+          </Text>
+          <Text fontSize="sm" color="gray.600">
+            ポジション: {positions.map((p) => p.name).join(", ")}
+          </Text>
+        </Box>
+
+        <Flex direction="column" gap={3} pt={2}>
+          <Button colorPalette="teal" onClick={handleSubmit} disabled={!isValid || isLoading} loading={isLoading}>
+            <Icon as={LuSparkles} />
+            提案してもらう
+          </Button>
+
+          <Text
+            as="button"
+            fontSize="sm"
+            color={isLoading ? "gray.300" : "gray.500"}
+            textAlign="center"
+            cursor={isLoading ? "not-allowed" : "pointer"}
+            _hover={isLoading ? {} : { color: "gray.700", textDecoration: "underline" }}
+            onClick={isLoading ? undefined : onSkip}
+          >
+            手動で入力する場合は スキップ
+          </Text>
+        </Flex>
+      </VStack>
+    </FormCard>
+  );
+};
+
+// 仮の生成ロジック（後でAI APIに置き換え）
+const generateMockStaffing = (
+  openTime: string,
+  closeTime: string,
+  positions: { _id: string; name: string }[],
+): StaffingEntry[] => {
+  const openHour = Number.parseInt(openTime.split(":")[0], 10);
+  const closeHour = Number.parseInt(closeTime.split(":")[0], 10);
+
+  const result: StaffingEntry[] = [];
+
+  for (let hour = openHour; hour < closeHour; hour++) {
+    for (const pos of positions) {
+      // 時間帯に応じた人数を設定
+      let count = 1;
+      if (hour >= 11 && hour < 14) count = 3; // ランチタイム
+      if (hour >= 18 && hour < 21) count = 3; // ディナータイム
+
+      // キッチンは少し少なめ
+      if (pos.name === "キッチン") count = Math.max(1, count - 1);
+      // その他は最小限
+      if (pos.name === "その他") count = hour >= 11 && hour < 14 ? 1 : 0;
+
+      result.push({
+        hour,
+        position: pos.name,
+        requiredCount: count,
+      });
+    }
+  }
+
+  return result;
+};

--- a/src/components/features/Shift/StaffingMatrix/CopyModal/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/CopyModal/index.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CopyModal } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/CopyModal",
+  component: CopyModal,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof CopyModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    isOpen: true,
+    onOpenChange: () => {},
+    onClose: () => console.log("Closed"),
+    sourceDayOfWeek: 1, // 月曜日
+    onCopy: (targetDays) => console.log("Copy to:", targetDays),
+  },
+};
+
+export const FromSaturday: Story = {
+  args: {
+    isOpen: true,
+    onOpenChange: () => {},
+    onClose: () => console.log("Closed"),
+    sourceDayOfWeek: 6, // 土曜日
+    onCopy: (targetDays) => console.log("Copy to:", targetDays),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isOpen: true,
+    onOpenChange: () => {},
+    onClose: () => console.log("Closed"),
+    sourceDayOfWeek: 1,
+    onCopy: () => {},
+    isLoading: true,
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/CopyModal/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/CopyModal/index.tsx
@@ -1,0 +1,65 @@
+import { Text, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { Dialog } from "@/src/components/ui/Dialog";
+import { DaySelector } from "../DaySelector";
+
+type CopyModalProps = {
+  isOpen: boolean;
+  onOpenChange: (details: { open: boolean }) => void;
+  onClose: () => void;
+  sourceDayOfWeek: number;
+  onCopy: (targetDays: number[]) => void;
+  isLoading?: boolean;
+};
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+export const CopyModal = ({
+  isOpen,
+  onOpenChange,
+  onClose,
+  sourceDayOfWeek,
+  onCopy,
+  isLoading = false,
+}: CopyModalProps) => {
+  const [selectedDays, setSelectedDays] = useState<number[]>([]);
+
+  const handleSubmit = () => {
+    onCopy(selectedDays);
+    setSelectedDays([]);
+  };
+
+  const handleClose = () => {
+    setSelectedDays([]);
+    onClose();
+  };
+
+  return (
+    <Dialog
+      title="コピー先を選択"
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+      submitLabel="コピーする"
+      onClose={handleClose}
+      isLoading={isLoading}
+    >
+      <VStack gap={4} align="stretch">
+        <Text fontSize="sm" color="gray.600">
+          {DAY_LABELS[sourceDayOfWeek]}曜日の設定を他の曜日にコピーします。
+        </Text>
+
+        <DaySelector
+          selectedDays={selectedDays}
+          onChange={setSelectedDays}
+          disabledDays={[sourceDayOfWeek]}
+          label="コピー先"
+        />
+
+        <Text fontSize="xs" color="orange.600">
+          選択した曜日の設定は上書きされます
+        </Text>
+      </VStack>
+    </Dialog>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/DaySelector/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/DaySelector/index.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { DaySelector } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/DaySelector",
+  component: DaySelector,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof DaySelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    selectedDays: [],
+    onChange: () => {},
+  },
+};
+
+export const WeekdaysSelected: Story = {
+  args: {
+    selectedDays: [1, 2, 3, 4, 5],
+    onChange: () => {},
+  },
+};
+
+export const WeekendsSelected: Story = {
+  args: {
+    selectedDays: [0, 6],
+    onChange: () => {},
+  },
+};
+
+export const SomeDaysDisabled: Story = {
+  args: {
+    selectedDays: [1, 2, 3],
+    onChange: () => {},
+    disabledDays: [0, 6],
+    label: "コピー先を選択",
+  },
+};
+
+// インタラクティブなStory
+const InteractiveDaySelector = () => {
+  const [selectedDays, setSelectedDays] = useState([1, 2, 3, 4, 5]);
+
+  return <DaySelector selectedDays={selectedDays} onChange={setSelectedDays} />;
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveDaySelector />,
+  args: {
+    selectedDays: [],
+    onChange: () => {},
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/DaySelector/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/DaySelector/index.tsx
@@ -1,0 +1,119 @@
+import { Box, Checkbox, Flex, Text } from "@chakra-ui/react";
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+type DaySelectorProps = {
+  selectedDays: number[];
+  onChange: (days: number[]) => void;
+  disabledDays?: number[];
+  label?: string;
+};
+
+export const DaySelector = ({
+  selectedDays,
+  onChange,
+  disabledDays = [],
+  label = "適用する曜日",
+}: DaySelectorProps) => {
+  const handleToggle = (dayIndex: number) => {
+    if (disabledDays.includes(dayIndex)) return;
+
+    if (selectedDays.includes(dayIndex)) {
+      onChange(selectedDays.filter((d) => d !== dayIndex));
+    } else {
+      onChange([...selectedDays, dayIndex].sort((a, b) => a - b));
+    }
+  };
+
+  // 平日（月〜金）を一括選択
+  const selectWeekdays = () => {
+    const weekdays = [1, 2, 3, 4, 5].filter((d) => !disabledDays.includes(d));
+    onChange(weekdays);
+  };
+
+  // 休日（土日）を一括選択
+  const selectWeekends = () => {
+    const weekends = [0, 6].filter((d) => !disabledDays.includes(d));
+    onChange(weekends);
+  };
+
+  // 全選択
+  const selectAll = () => {
+    const allDays = [0, 1, 2, 3, 4, 5, 6].filter((d) => !disabledDays.includes(d));
+    onChange(allDays);
+  };
+
+  return (
+    <Box>
+      <Flex align="center" justify="space-between" mb={2}>
+        <Text fontWeight="medium" color="gray.700">
+          {label}
+        </Text>
+        <Flex gap={2}>
+          <Text
+            as="button"
+            fontSize="xs"
+            color="teal.600"
+            cursor="pointer"
+            _hover={{ textDecoration: "underline" }}
+            onClick={selectWeekdays}
+          >
+            平日
+          </Text>
+          <Text
+            as="button"
+            fontSize="xs"
+            color="teal.600"
+            cursor="pointer"
+            _hover={{ textDecoration: "underline" }}
+            onClick={selectWeekends}
+          >
+            休日
+          </Text>
+          <Text
+            as="button"
+            fontSize="xs"
+            color="teal.600"
+            cursor="pointer"
+            _hover={{ textDecoration: "underline" }}
+            onClick={selectAll}
+          >
+            全て
+          </Text>
+        </Flex>
+      </Flex>
+
+      {/* 曜日チェックボックス - 月曜始まり */}
+      <Flex gap={{ base: 2, md: 4 }} wrap="wrap">
+        {/* 月〜金 */}
+        {[1, 2, 3, 4, 5].map((dayIndex) => (
+          <Checkbox.Root
+            key={dayIndex}
+            checked={selectedDays.includes(dayIndex)}
+            onCheckedChange={() => handleToggle(dayIndex)}
+            disabled={disabledDays.includes(dayIndex)}
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label>{DAY_LABELS[dayIndex]}</Checkbox.Label>
+          </Checkbox.Root>
+        ))}
+      </Flex>
+      <Flex gap={{ base: 2, md: 4 }} mt={2}>
+        {/* 土日 */}
+        {[6, 0].map((dayIndex) => (
+          <Checkbox.Root
+            key={dayIndex}
+            checked={selectedDays.includes(dayIndex)}
+            onCheckedChange={() => handleToggle(dayIndex)}
+            disabled={disabledDays.includes(dayIndex)}
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control />
+            <Checkbox.Label>{DAY_LABELS[dayIndex]}</Checkbox.Label>
+          </Checkbox.Root>
+        ))}
+      </Flex>
+    </Box>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/DayTabs/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/DayTabs/index.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { DayTabs } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/DayTabs",
+  component: DayTabs,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof DayTabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    selectedDay: 1,
+    onChange: () => {},
+  },
+};
+
+export const Sunday: Story = {
+  args: {
+    selectedDay: 0,
+    onChange: () => {},
+  },
+};
+
+export const Saturday: Story = {
+  args: {
+    selectedDay: 6,
+    onChange: () => {},
+  },
+};
+
+// インタラクティブなStory
+const InteractiveDayTabs = () => {
+  const [selectedDay, setSelectedDay] = useState(1);
+
+  return <DayTabs selectedDay={selectedDay} onChange={setSelectedDay} />;
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveDayTabs />,
+  args: {
+    selectedDay: 1,
+    onChange: () => {},
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/DayTabs/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/DayTabs/index.tsx
@@ -1,0 +1,27 @@
+import { Tabs } from "@chakra-ui/react";
+
+const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
+
+type DayTabsProps = {
+  selectedDay: number;
+  onChange: (day: number) => void;
+};
+
+export const DayTabs = ({ selectedDay, onChange }: DayTabsProps) => {
+  return (
+    <Tabs.Root
+      value={String(selectedDay)}
+      onValueChange={(e) => onChange(Number.parseInt(e.value, 10))}
+      variant="outline"
+    >
+      <Tabs.List>
+        {/* 月曜始まり: 月火水木金土日 */}
+        {[1, 2, 3, 4, 5, 6, 0].map((dayIndex) => (
+          <Tabs.Trigger key={dayIndex} value={String(dayIndex)} px={{ base: 3, md: 4 }}>
+            {DAY_LABELS[dayIndex]}
+          </Tabs.Trigger>
+        ))}
+      </Tabs.List>
+    </Tabs.Root>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/RegenerateModal/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/RegenerateModal/index.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { RegenerateModal } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/RegenerateModal",
+  component: RegenerateModal,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof RegenerateModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const RegenerateModalWrapper = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <RegenerateModal
+      isOpen={isOpen}
+      onOpenChange={(details) => setIsOpen(details.open)}
+      onClose={() => setIsOpen(false)}
+      initialAIInput={{ shopType: "カフェ、ランチメイン", customerCount: "平日80人くらい" }}
+      onRegenerate={(result, aiInput) => {
+        console.log("再生成結果:", result, aiInput);
+        setIsOpen(false);
+      }}
+      openTime="09:00"
+      closeTime="22:00"
+      positions={[
+        { _id: "pos_1", name: "ホール" },
+        { _id: "pos_2", name: "キッチン" },
+        { _id: "pos_3", name: "その他" },
+      ]}
+    />
+  );
+};
+
+export const Basic: Story = {
+  render: () => <RegenerateModalWrapper />,
+  args: {} as never,
+};

--- a/src/components/features/Shift/StaffingMatrix/RegenerateModal/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/RegenerateModal/index.tsx
@@ -1,0 +1,116 @@
+import { Field, Input, Textarea, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { Dialog } from "@/src/components/ui/Dialog";
+
+type AIInput = {
+  shopType: string;
+  customerCount: string;
+};
+
+type StaffingEntry = {
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type RegenerateModalProps = {
+  isOpen: boolean;
+  onOpenChange: (details: { open: boolean }) => void;
+  onClose: () => void;
+  initialAIInput?: AIInput;
+  onRegenerate: (result: StaffingEntry[], aiInput: AIInput) => void;
+  openTime: string;
+  closeTime: string;
+  positions: { _id: string; name: string }[];
+  isLoading?: boolean;
+};
+
+export const RegenerateModal = ({
+  isOpen,
+  onOpenChange,
+  onClose,
+  initialAIInput,
+  onRegenerate,
+  openTime,
+  closeTime,
+  positions,
+  isLoading = false,
+}: RegenerateModalProps) => {
+  const [shopType, setShopType] = useState(initialAIInput?.shopType ?? "");
+  const [customerCount, setCustomerCount] = useState(initialAIInput?.customerCount ?? "");
+
+  const handleSubmit = () => {
+    const aiInput: AIInput = { shopType, customerCount };
+
+    // TODO: 実際のAI API呼び出しに置き換え
+    const generatedStaffing = generateMockStaffing(openTime, closeTime, positions);
+
+    onRegenerate(generatedStaffing, aiInput);
+  };
+
+  return (
+    <Dialog
+      title="AIで作り直す"
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      onSubmit={handleSubmit}
+      submitLabel="作り直す"
+      onClose={onClose}
+      isLoading={isLoading}
+      isSubmitDisabled={shopType.trim().length === 0}
+    >
+      <VStack gap={4} align="stretch">
+        <Field.Root>
+          <Field.Label>どんなお店ですか？</Field.Label>
+          <Textarea
+            value={shopType}
+            onChange={(e) => setShopType(e.target.value)}
+            placeholder="例: カフェ、ランチメインで夜は軽め"
+            rows={2}
+            disabled={isLoading}
+          />
+        </Field.Root>
+
+        <Field.Root>
+          <Field.Label>1日の来客数は？（ざっくりでOK）</Field.Label>
+          <Input
+            value={customerCount}
+            onChange={(e) => setCustomerCount(e.target.value)}
+            placeholder="例: 平日80人、土日120人くらい"
+            disabled={isLoading}
+          />
+        </Field.Root>
+      </VStack>
+    </Dialog>
+  );
+};
+
+// 仮の生成ロジック（後でAI APIに置き換え）
+const generateMockStaffing = (
+  openTime: string,
+  closeTime: string,
+  positions: { _id: string; name: string }[],
+): StaffingEntry[] => {
+  const openHour = Number.parseInt(openTime.split(":")[0], 10);
+  const closeHour = Number.parseInt(closeTime.split(":")[0], 10);
+
+  const result: StaffingEntry[] = [];
+
+  for (let hour = openHour; hour < closeHour; hour++) {
+    for (const pos of positions) {
+      let count = 1;
+      if (hour >= 11 && hour < 14) count = 3;
+      if (hour >= 18 && hour < 21) count = 3;
+      if (pos.name === "キッチン") count = Math.max(1, count - 1);
+      if (pos.name === "その他") count = hour >= 11 && hour < 14 ? 1 : 0;
+
+      result.push({
+        hour,
+        position: pos.name,
+        requiredCount: count,
+      });
+    }
+  }
+
+  return result;
+};

--- a/src/components/features/Shift/StaffingMatrix/SetupWizard/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/SetupWizard/index.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SetupWizard } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/SetupWizard",
+  component: SetupWizard,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof SetupWizard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const positions = [
+  { _id: "pos_1", name: "ホール" },
+  { _id: "pos_2", name: "キッチン" },
+  { _id: "pos_3", name: "その他" },
+];
+
+export const Basic: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    onSave: (patterns, aiInput) => {
+      console.log("Saved:", patterns, aiInput);
+    },
+    onCancel: () => {
+      console.log("Cancelled");
+    },
+  },
+};
+
+export const ShortHours: Story = {
+  args: {
+    openTime: "11:00",
+    closeTime: "15:00",
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+    ],
+    onSave: (patterns, aiInput) => {
+      console.log("Saved:", patterns, aiInput);
+    },
+    onCancel: () => {
+      console.log("Cancelled");
+    },
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/SetupWizard/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/SetupWizard/index.tsx
@@ -1,0 +1,224 @@
+import { Box, Button, Container, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { LuArrowLeft, LuPlus, LuSave } from "react-icons/lu";
+import { AIGenerateForm } from "../AIGenerateForm";
+import { DaySelector } from "../DaySelector";
+import { StaffingTable } from "../StaffingTable";
+
+type PositionType = {
+  _id: string;
+  name: string;
+};
+
+type StaffingEntry = {
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type AIInput = {
+  shopType: string;
+  customerCount: string;
+};
+
+type PatternType = {
+  id: string;
+  staffing: StaffingEntry[];
+  appliedDays: number[];
+};
+
+type SetupWizardProps = {
+  openTime: string;
+  closeTime: string;
+  positions: PositionType[];
+  onSave: (patterns: PatternType[], aiInput?: AIInput) => void;
+  onCancel: () => void;
+};
+
+export const SetupWizard = ({ openTime, closeTime, positions, onSave, onCancel }: SetupWizardProps) => {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [aiInput, setAIInput] = useState<AIInput | undefined>();
+  const [patterns, setPatterns] = useState<PatternType[]>([]);
+  const [currentPatternIndex, setCurrentPatternIndex] = useState(0);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  // AI生成完了時
+  const handleGenerate = (staffing: StaffingEntry[], input: AIInput) => {
+    setIsGenerating(true);
+
+    // 少し遅延を入れて生成感を出す
+    setTimeout(() => {
+      setAIInput(input);
+      setPatterns([
+        {
+          id: crypto.randomUUID(),
+          staffing,
+          appliedDays: [1, 2, 3, 4, 5], // デフォルトで平日
+        },
+      ]);
+      setCurrentPatternIndex(0);
+      setStep(2);
+      setIsGenerating(false);
+    }, 500);
+  };
+
+  // スキップ時（手動入力）
+  const handleSkip = () => {
+    setPatterns([
+      {
+        id: crypto.randomUUID(),
+        staffing: [],
+        appliedDays: [1, 2, 3, 4, 5],
+      },
+    ]);
+    setCurrentPatternIndex(0);
+    setStep(2);
+  };
+
+  // パターンのstaffing更新
+  const handleStaffingChange = (staffing: StaffingEntry[]) => {
+    setPatterns((prev) => prev.map((p, i) => (i === currentPatternIndex ? { ...p, staffing } : p)));
+  };
+
+  // パターンの適用曜日更新
+  const handleDaysChange = (days: number[]) => {
+    setPatterns((prev) => prev.map((p, i) => (i === currentPatternIndex ? { ...p, appliedDays: days } : p)));
+  };
+
+  // 別パターン追加
+  const handleAddPattern = () => {
+    // 現在のパターンをコピー
+    const currentPattern = patterns[currentPatternIndex];
+    const usedDays = patterns.flatMap((p) => p.appliedDays);
+    const availableDays = [0, 1, 2, 3, 4, 5, 6].filter((d) => !usedDays.includes(d));
+
+    const newPattern: PatternType = {
+      id: crypto.randomUUID(),
+      staffing: [...currentPattern.staffing],
+      appliedDays: availableDays.length > 0 ? [availableDays[0]] : [],
+    };
+
+    setPatterns((prev) => [...prev, newPattern]);
+    setCurrentPatternIndex(patterns.length);
+  };
+
+  // 保存
+  const handleSave = () => {
+    onSave(patterns, aiInput);
+  };
+
+  // 戻る
+  const handleBack = () => {
+    if (step === 2) {
+      setStep(1);
+    } else {
+      onCancel();
+    }
+  };
+
+  // 使用済み曜日（現在のパターン以外）
+  const usedDaysExceptCurrent = patterns.filter((_, i) => i !== currentPatternIndex).flatMap((p) => p.appliedDays);
+
+  // 全曜日が設定済みかどうか
+  const allDaysAssigned = patterns.flatMap((p) => p.appliedDays).length === 7;
+
+  // 保存可能かどうか
+  const canSave = patterns.every((p) => p.appliedDays.length > 0 && p.staffing.length > 0);
+
+  return (
+    <Container maxW="4xl">
+      {/* ステップインジケーター */}
+      <Flex align="center" gap={2} mb={6}>
+        <Text fontSize="sm" color={step === 1 ? "teal.600" : "gray.400"} fontWeight={step === 1 ? "bold" : "normal"}>
+          Step 1: AI生成
+        </Text>
+        <Text color="gray.300">→</Text>
+        <Text fontSize="sm" color={step === 2 ? "teal.600" : "gray.400"} fontWeight={step === 2 ? "bold" : "normal"}>
+          Step 2: 調整・保存
+        </Text>
+      </Flex>
+
+      {/* Step 1: AI生成フォーム */}
+      {step === 1 && (
+        <AIGenerateForm
+          openTime={openTime}
+          closeTime={closeTime}
+          positions={positions}
+          initialAIInput={aiInput}
+          onGenerate={handleGenerate}
+          onSkip={handleSkip}
+          isLoading={isGenerating}
+        />
+      )}
+
+      {/* Step 2: 編集・曜日選択 */}
+      {step === 2 && (
+        <VStack gap={6} align="stretch">
+          {/* パターンタブ（複数パターンがある場合） */}
+          {patterns.length > 1 && (
+            <Flex gap={2} wrap="wrap">
+              {patterns.map((pattern, index) => (
+                <Button
+                  key={pattern.id}
+                  size="sm"
+                  variant={index === currentPatternIndex ? "solid" : "outline"}
+                  colorPalette={index === currentPatternIndex ? "teal" : "gray"}
+                  onClick={() => setCurrentPatternIndex(index)}
+                >
+                  パターン {index + 1}
+                </Button>
+              ))}
+            </Flex>
+          )}
+
+          {/* 説明テキスト */}
+          <Text color="gray.600">
+            {aiInput ? "AIの提案結果を確認・調整してください" : "必要な人員を入力してください"}
+          </Text>
+
+          {/* 編集テーブル */}
+          <Box>
+            <StaffingTable
+              openTime={openTime}
+              closeTime={closeTime}
+              positions={positions}
+              staffing={patterns[currentPatternIndex]?.staffing ?? []}
+              onChange={handleStaffingChange}
+            />
+          </Box>
+
+          {/* 曜日選択 */}
+          <Box borderTop="1px solid" borderColor="gray.200" pt={4}>
+            <DaySelector
+              selectedDays={patterns[currentPatternIndex]?.appliedDays ?? []}
+              onChange={handleDaysChange}
+              disabledDays={usedDaysExceptCurrent}
+              label="この設定を適用する曜日"
+            />
+          </Box>
+
+          {/* アクションボタン */}
+          <Flex gap={3} justify="space-between" borderTop="1px solid" borderColor="gray.200" pt={4}>
+            <Button variant="ghost" onClick={handleBack}>
+              <Icon as={LuArrowLeft} />
+              戻る
+            </Button>
+
+            <Flex gap={3}>
+              {!allDaysAssigned && (
+                <Button variant="outline" onClick={handleAddPattern}>
+                  <Icon as={LuPlus} />
+                  別パターンを追加
+                </Button>
+              )}
+              <Button colorPalette="teal" onClick={handleSave} disabled={!canSave}>
+                <Icon as={LuSave} />
+                保存する
+              </Button>
+            </Flex>
+          </Flex>
+        </VStack>
+      )}
+    </Container>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/StaffingTable/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/StaffingTable/index.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { StaffingTable } from "./index";
+
+const meta = {
+  title: "features/Shift/StaffingMatrix/StaffingTable",
+  component: StaffingTable,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof StaffingTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const positions = [
+  { _id: "pos_1", name: "ホール" },
+  { _id: "pos_2", name: "キッチン" },
+  { _id: "pos_3", name: "その他" },
+];
+
+export const Basic: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    staffing: [],
+    onChange: () => {},
+  },
+};
+
+export const WithData: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "22:00",
+    positions,
+    staffing: [
+      { hour: 9, position: "ホール", requiredCount: 1 },
+      { hour: 9, position: "キッチン", requiredCount: 1 },
+      { hour: 10, position: "ホール", requiredCount: 1 },
+      { hour: 10, position: "キッチン", requiredCount: 1 },
+      { hour: 11, position: "ホール", requiredCount: 3 },
+      { hour: 11, position: "キッチン", requiredCount: 2 },
+      { hour: 12, position: "ホール", requiredCount: 3 },
+      { hour: 12, position: "キッチン", requiredCount: 2 },
+      { hour: 13, position: "ホール", requiredCount: 3 },
+      { hour: 13, position: "キッチン", requiredCount: 2 },
+    ],
+    onChange: () => {},
+  },
+};
+
+// インタラクティブなStory
+const InteractiveStaffingTable = () => {
+  const [staffing, setStaffing] = useState([
+    { hour: 11, position: "ホール", requiredCount: 2 },
+    { hour: 11, position: "キッチン", requiredCount: 1 },
+  ]);
+
+  return (
+    <StaffingTable
+      openTime="09:00"
+      closeTime="18:00"
+      positions={positions}
+      staffing={staffing}
+      onChange={setStaffing}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveStaffingTable />,
+  args: {
+    openTime: "09:00",
+    closeTime: "18:00",
+    positions,
+    staffing: [],
+    onChange: () => {},
+  },
+};
+
+export const ShortHours: Story = {
+  args: {
+    openTime: "11:00",
+    closeTime: "15:00",
+    positions: [
+      { _id: "pos_1", name: "ホール" },
+      { _id: "pos_2", name: "キッチン" },
+    ],
+    staffing: [],
+    onChange: () => {},
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    openTime: "09:00",
+    closeTime: "18:00",
+    positions,
+    staffing: [
+      { hour: 11, position: "ホール", requiredCount: 2 },
+      { hour: 11, position: "キッチン", requiredCount: 1 },
+    ],
+    onChange: () => {},
+    disabled: true,
+  },
+};

--- a/src/components/features/Shift/StaffingMatrix/StaffingTable/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/StaffingTable/index.tsx
@@ -1,0 +1,176 @@
+import { Box, Card, Flex, Input, Table, Text, VStack } from "@chakra-ui/react";
+import { useMemo } from "react";
+
+type PositionType = {
+  _id: string;
+  name: string;
+};
+
+type StaffingEntry = {
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type StaffingTableProps = {
+  openTime: string;
+  closeTime: string;
+  positions: PositionType[];
+  staffing: StaffingEntry[];
+  onChange: (staffing: StaffingEntry[]) => void;
+  disabled?: boolean;
+};
+
+export const StaffingTable = ({
+  openTime,
+  closeTime,
+  positions,
+  staffing,
+  onChange,
+  disabled = false,
+}: StaffingTableProps) => {
+  // 営業時間から時間帯リストを生成
+  const hours = useMemo(() => {
+    const openHour = Number.parseInt(openTime.split(":")[0], 10);
+    const closeHour = Number.parseInt(closeTime.split(":")[0], 10);
+    const result: number[] = [];
+    for (let h = openHour; h < closeHour; h++) {
+      result.push(h);
+    }
+    return result;
+  }, [openTime, closeTime]);
+
+  // staffingをマップに変換
+  const staffingMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const entry of staffing) {
+      const key = `${entry.hour}-${entry.position}`;
+      map[key] = entry.requiredCount;
+    }
+    return map;
+  }, [staffing]);
+
+  // 人員数取得
+  const getCount = (hour: number, position: string) => {
+    const key = `${hour}-${position}`;
+    return staffingMap[key] ?? 0;
+  };
+
+  // 人員数更新
+  const handleCountChange = (hour: number, position: string, value: number) => {
+    const clampedValue = Math.max(0, Math.min(10, value));
+
+    // 既存のエントリを更新または追加
+    const existingIndex = staffing.findIndex((e) => e.hour === hour && e.position === position);
+
+    let newStaffing: StaffingEntry[];
+    if (existingIndex >= 0) {
+      newStaffing = staffing.map((e, i) => (i === existingIndex ? { ...e, requiredCount: clampedValue } : e));
+    } else {
+      newStaffing = [...staffing, { hour, position, requiredCount: clampedValue }];
+    }
+
+    onChange(newStaffing);
+  };
+
+  // 1日の合計人時を計算
+  const totalPersonHours = useMemo(() => {
+    return staffing.reduce((sum, entry) => sum + entry.requiredCount, 0);
+  }, [staffing]);
+
+  return (
+    <Box>
+      {/* PC表示: Table形式 */}
+      <Box display={{ base: "none", md: "block" }}>
+        <Table.Root size="sm" variant="outline">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeader>時間帯</Table.ColumnHeader>
+              {positions.map((pos) => (
+                <Table.ColumnHeader key={pos._id} textAlign="center">
+                  {pos.name}
+                </Table.ColumnHeader>
+              ))}
+              <Table.ColumnHeader textAlign="center">合計</Table.ColumnHeader>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {hours.map((hour) => {
+              const rowTotal = positions.reduce((sum, pos) => sum + getCount(hour, pos.name), 0);
+              return (
+                <Table.Row key={hour}>
+                  <Table.Cell fontWeight="medium">
+                    {hour}:00-{hour + 1}:00
+                  </Table.Cell>
+                  {positions.map((pos) => (
+                    <Table.Cell key={pos._id} textAlign="center">
+                      <Input
+                        type="number"
+                        min={0}
+                        max={10}
+                        value={getCount(hour, pos.name)}
+                        onChange={(e) => handleCountChange(hour, pos.name, Number.parseInt(e.target.value, 10) || 0)}
+                        w="60px"
+                        textAlign="center"
+                        size="sm"
+                        disabled={disabled}
+                      />
+                    </Table.Cell>
+                  ))}
+                  <Table.Cell textAlign="center" fontWeight="medium" color="gray.600">
+                    {rowTotal}
+                  </Table.Cell>
+                </Table.Row>
+              );
+            })}
+          </Table.Body>
+        </Table.Root>
+      </Box>
+
+      {/* SP表示: Card形式 */}
+      <Box display={{ base: "block", md: "none" }}>
+        <VStack gap={3} align="stretch">
+          {hours.map((hour) => (
+            <Card.Root key={hour} borderWidth={0} shadow="sm">
+              <Card.Body p={3}>
+                <Text fontWeight="bold" mb={3}>
+                  {hour}:00-{hour + 1}:00
+                </Text>
+                <Flex gap={3} wrap="wrap">
+                  {positions.map((pos) => (
+                    <Flex key={pos._id} align="center" gap={2}>
+                      <Text fontSize="sm" color="gray.600" minW="60px">
+                        {pos.name}
+                      </Text>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={10}
+                        value={getCount(hour, pos.name)}
+                        onChange={(e) => handleCountChange(hour, pos.name, Number.parseInt(e.target.value, 10) || 0)}
+                        w="60px"
+                        textAlign="center"
+                        size="sm"
+                        disabled={disabled}
+                      />
+                    </Flex>
+                  ))}
+                </Flex>
+              </Card.Body>
+            </Card.Root>
+          ))}
+        </VStack>
+      </Box>
+
+      {/* 合計表示 */}
+      <Flex justify="flex-end" mt={4}>
+        <Text fontSize="sm" color="gray.600">
+          1日の合計:{" "}
+          <Text as="span" fontWeight="bold">
+            {totalPersonHours}人時
+          </Text>
+        </Text>
+      </Flex>
+    </Box>
+  );
+};

--- a/src/components/features/Shift/StaffingMatrix/index.stories.tsx
+++ b/src/components/features/Shift/StaffingMatrix/index.stories.tsx
@@ -1,11 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StaffingMatrix } from "./index";
 
+// モック関数
+const mockOnSave = async () => {
+  console.log("onSave called");
+};
+
+const mockOnCopy = async () => {
+  console.log("onCopy called");
+};
+
 const meta = {
   title: "features/Shift/StaffingMatrix",
   component: StaffingMatrix,
   parameters: {
     layout: "fullscreen",
+  },
+  args: {
+    onSave: mockOnSave,
+    onCopy: mockOnCopy,
   },
 } satisfies Meta<typeof StaffingMatrix>;
 

--- a/src/components/features/Shift/StaffingMatrix/index.tsx
+++ b/src/components/features/Shift/StaffingMatrix/index.tsx
@@ -1,8 +1,12 @@
-import { Box, Button, Card, Container, Flex, Heading, Icon, Input, Table, Tabs, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Card, Container, Flex, Heading, Icon, Input, Table, Text, VStack } from "@chakra-ui/react";
 import { useMemo, useState } from "react";
-import { LuSave, LuSettings } from "react-icons/lu";
+import { LuCopy, LuRefreshCw, LuSave, LuSettings } from "react-icons/lu";
+import { useDialog } from "@/src/components/ui/Dialog";
 import { Title } from "@/src/components/ui/Title";
 import { toaster } from "@/src/components/ui/toaster";
+import { CopyModal } from "./CopyModal";
+import { DayTabs } from "./DayTabs";
+import { RegenerateModal } from "./RegenerateModal";
 
 // 必要人員データ型
 type RequiredStaffingType = {
@@ -26,18 +30,49 @@ type ShopType = {
   closeTime: string;
 };
 
+type StaffingItem = {
+  hour: number;
+  position: string;
+  requiredCount: number;
+};
+
+type AIInput = {
+  shopType: string;
+  customerCount: string;
+};
+
 type StaffingMatrixProps = {
   shopId: string;
   shop: ShopType;
   positions: PositionType[];
   initialStaffing: RequiredStaffingType[];
+  onSave: (params: { dayOfWeek: number; staffing: StaffingItem[]; aiInput?: AIInput }) => Promise<void>;
+  onCopy: (params: { sourceDayOfWeek: number; targetDaysOfWeek: number[] }) => Promise<void>;
+  isSaving?: boolean;
+  isCopying?: boolean;
 };
 
 const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
 
-export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: StaffingMatrixProps) => {
+export const StaffingMatrix = ({
+  shopId,
+  shop,
+  positions,
+  initialStaffing,
+  onSave,
+  onCopy,
+  isSaving = false,
+  isCopying = false,
+}: StaffingMatrixProps) => {
   // 曜日タブ選択（月曜=1をデフォルト）
-  const [selectedDay, setSelectedDay] = useState("1");
+  const [selectedDay, setSelectedDay] = useState(1);
+
+  // モーダル管理
+  const copyModal = useDialog();
+  const regenerateModal = useDialog();
+
+  // AI入力の保存（作り直す時に前回値を使用）
+  const [aiInput, setAiInput] = useState({ shopType: "", customerCount: "" });
 
   // 営業時間から時間帯リストを生成
   const hours = useMemo(() => {
@@ -76,18 +111,94 @@ export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: Sta
     setHasChanges(true);
   };
 
-  // 保存処理
-  const handleSave = () => {
-    // TODO: useMutation呼び出し
-    console.log("保存データ:", staffingMap);
-    toaster.create({
-      description: "必要人員設定を保存しました",
-      type: "success",
-    });
-    setHasChanges(false);
+  // 現在の曜日のstaffing配列を生成
+  const buildStaffingArray = (dayOfWeek: number) => {
+    const result: { hour: number; position: string; requiredCount: number }[] = [];
+    for (const hour of hours) {
+      for (const pos of positions) {
+        const key = `${dayOfWeek}-${hour}-${pos.name}`;
+        result.push({
+          hour,
+          position: pos.name,
+          requiredCount: staffingMap[key] ?? 0,
+        });
+      }
+    }
+    return result;
   };
 
-  const currentDayOfWeek = Number.parseInt(selectedDay, 10);
+  // 保存処理
+  const handleSave = async () => {
+    try {
+      await onSave({
+        dayOfWeek: selectedDay,
+        staffing: buildStaffingArray(selectedDay),
+        aiInput: aiInput.shopType ? aiInput : undefined,
+      });
+      setHasChanges(false);
+    } catch {
+      // エラーはpages側でハンドリング済み
+    }
+  };
+
+  // コピー処理
+  const handleCopy = async (targetDays: number[]) => {
+    try {
+      // まず現在の曜日を保存
+      await onSave({
+        dayOfWeek: selectedDay,
+        staffing: buildStaffingArray(selectedDay),
+      });
+
+      // 他の曜日にコピー
+      await onCopy({
+        sourceDayOfWeek: selectedDay,
+        targetDaysOfWeek: targetDays,
+      });
+
+      // ローカルstateも更新
+      setStaffingMap((prev) => {
+        const newMap = { ...prev };
+        for (const hour of hours) {
+          for (const pos of positions) {
+            const sourceKey = `${selectedDay}-${hour}-${pos.name}`;
+            const sourceValue = prev[sourceKey] ?? 0;
+            for (const targetDay of targetDays) {
+              const targetKey = `${targetDay}-${hour}-${pos.name}`;
+              newMap[targetKey] = sourceValue;
+            }
+          }
+        }
+        return newMap;
+      });
+
+      copyModal.close();
+    } catch {
+      // エラーはpages側でハンドリング済み
+    }
+  };
+
+  // AI再生成処理
+  const handleRegenerate = (
+    result: { hour: number; position: string; requiredCount: number }[],
+    newAiInput: { shopType: string; customerCount: string },
+  ) => {
+    setStaffingMap((prev) => {
+      const newMap = { ...prev };
+      for (const item of result) {
+        const key = `${selectedDay}-${item.hour}-${item.position}`;
+        newMap[key] = item.requiredCount;
+      }
+      return newMap;
+    });
+    setAiInput(newAiInput);
+    setHasChanges(true);
+    regenerateModal.close();
+    toaster.create({
+      description: "AIで再生成しました",
+      type: "success",
+    });
+  };
 
   return (
     <Container maxW="6xl">
@@ -108,22 +219,25 @@ export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: Sta
         </Flex>
       </Title>
 
-      {/* 曜日タブ */}
-      <Box mb={4}>
-        <Tabs.Root value={selectedDay} onValueChange={(e) => setSelectedDay(e.value)} variant="outline">
-          <Tabs.List>
-            {DAY_LABELS.map((day, idx) => (
-              <Tabs.Trigger key={idx} value={String(idx)} px={{ base: 3, md: 4 }}>
-                {day}
-              </Tabs.Trigger>
-            ))}
-          </Tabs.List>
-        </Tabs.Root>
-      </Box>
+      {/* 曜日タブ + アクションボタン */}
+      <Flex mb={4} justify="space-between" align="center" wrap="wrap" gap={3}>
+        <DayTabs selectedDay={selectedDay} onChange={setSelectedDay} />
+
+        <Flex gap={2}>
+          <Button variant="outline" size="sm" onClick={copyModal.open}>
+            <Icon as={LuCopy} />
+            コピー
+          </Button>
+          <Button variant="outline" size="sm" onClick={regenerateModal.open}>
+            <Icon as={LuRefreshCw} />
+            作り直す
+          </Button>
+        </Flex>
+      </Flex>
 
       {/* 曜日見出し */}
       <Text fontWeight="bold" mb={3} color="gray.700">
-        {DAY_LABELS[currentDayOfWeek]}曜日の必要人員
+        {DAY_LABELS[selectedDay]}曜日の必要人員
       </Text>
 
       {/* PC表示: Table形式 */}
@@ -131,7 +245,7 @@ export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: Sta
         <StaffingTable
           hours={hours}
           positions={positions}
-          dayOfWeek={currentDayOfWeek}
+          dayOfWeek={selectedDay}
           getCount={getCount}
           onCountChange={handleCountChange}
         />
@@ -142,11 +256,33 @@ export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: Sta
         <StaffingCardList
           hours={hours}
           positions={positions}
-          dayOfWeek={currentDayOfWeek}
+          dayOfWeek={selectedDay}
           getCount={getCount}
           onCountChange={handleCountChange}
         />
       </Box>
+
+      {/* コピーモーダル */}
+      <CopyModal
+        isOpen={copyModal.isOpen}
+        onOpenChange={copyModal.onOpenChange}
+        onClose={copyModal.close}
+        sourceDayOfWeek={selectedDay}
+        onCopy={handleCopy}
+        isLoading={isCopying}
+      />
+
+      {/* AI再生成モーダル */}
+      <RegenerateModal
+        isOpen={regenerateModal.isOpen}
+        onOpenChange={regenerateModal.onOpenChange}
+        onClose={regenerateModal.close}
+        initialAIInput={aiInput}
+        onRegenerate={handleRegenerate}
+        openTime={shop.openTime}
+        closeTime={shop.closeTime}
+        positions={positions}
+      />
 
       {/* アクションボタン */}
       <Flex
@@ -158,7 +294,13 @@ export const StaffingMatrix = ({ shopId, shop, positions, initialStaffing }: Sta
         borderColor="gray.200"
         pt={6}
       >
-        <Button colorPalette="purple" onClick={handleSave} disabled={!hasChanges} w={{ base: "full", sm: "auto" }}>
+        <Button
+          colorPalette="teal"
+          onClick={handleSave}
+          disabled={!hasChanges}
+          loading={isSaving}
+          w={{ base: "full", sm: "auto" }}
+        >
           <Icon as={LuSave} />
           保存する
         </Button>

--- a/src/components/pages/Shops/StaffingSettingsPage/index.tsx
+++ b/src/components/pages/Shops/StaffingSettingsPage/index.tsx
@@ -1,37 +1,128 @@
+import { useMutation, useQuery } from "convex/react";
+import { useCallback, useState } from "react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
 import { StaffingMatrix } from "@/src/components/features/Shift/StaffingMatrix";
+import { LazyShow } from "@/src/components/ui/LazyShow";
+import { LoadingState } from "@/src/components/ui/LoadingState";
+import { toaster } from "@/src/components/ui/toaster";
 
 type Props = {
   shopId: string;
 };
 
-// モックデータ（将来的にはuseQueryで取得）
-const mockShop = {
-  _id: "shop_1",
-  shopName: "サンプル店舗",
-  openTime: "09:00",
-  closeTime: "22:00",
+type StaffingItem = {
+  hour: number;
+  position: string;
+  requiredCount: number;
 };
 
-const mockPositions = [
-  { _id: "pos_1", name: "ホール" },
-  { _id: "pos_2", name: "キッチン" },
-  { _id: "pos_3", name: "その他" },
-];
+type AIInput = {
+  shopType: string;
+  customerCount: string;
+};
 
 export const StaffingSettingsPage = ({ shopId }: Props) => {
-  // 将来的にはuseQueryでデータ取得
-  // const shop = useQuery(api.shop.queries.getById, { shopId: shopId as Id<"shops"> });
-  // const positions = useQuery(api.position.queries.listByShop, { shopId: shopId as Id<"shops"> });
-  // const requiredStaffing = useQuery(api.requiredStaffing.queries.listByShop, { shopId: shopId as Id<"shops"> });
+  const shop = useQuery(api.shop.queries.getById, { shopId: shopId as Id<"shops"> });
+  const positions = useQuery(api.position.queries.listByShop, { shopId: shopId as Id<"shops"> });
+  // TODO: pnpm convex:dev 実行後に以下を有効化
+  // const requiredStaffing = useQuery(api.requiredStaffing.queries.getByShopId, { shopId: shopId as Id<"shops"> });
+  const requiredStaffing: never[] = []; // 一時的にモック
 
-  // モック実装のため、直接データを渡す
-  const shop = { ...mockShop, _id: shopId };
-  const positions = mockPositions;
+  // Mutations
+  const upsertMutation = useMutation(api.requiredStaffing.mutations.upsert);
+  const copyMutation = useMutation(api.requiredStaffing.mutations.copyToMultipleDays);
 
-  // 将来的なローディング・エラー処理
-  // if (shop === undefined || positions === undefined) {
-  //   return <LazyShow><StaffingMatrixLoading /></LazyShow>;
-  // }
+  // ローディング状態
+  const [isSaving, setIsSaving] = useState(false);
+  const [isCopying, setIsCopying] = useState(false);
 
-  return <StaffingMatrix shopId={shopId} shop={shop} positions={positions} initialStaffing={[]} />;
+  // 保存処理
+  const handleSave = useCallback(
+    async (params: { dayOfWeek: number; staffing: StaffingItem[]; aiInput?: AIInput }) => {
+      setIsSaving(true);
+      try {
+        await upsertMutation({
+          shopId: shopId as Id<"shops">,
+          dayOfWeek: params.dayOfWeek,
+          staffing: params.staffing,
+          aiInput: params.aiInput,
+        });
+        toaster.create({
+          description: "必要人員設定を保存しました",
+          type: "success",
+        });
+      } catch (error) {
+        toaster.create({
+          description: "保存に失敗しました",
+          type: "error",
+        });
+        console.error("保存エラー:", error);
+        throw error;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [shopId, upsertMutation],
+  );
+
+  // コピー処理
+  const handleCopy = useCallback(
+    async (params: { sourceDayOfWeek: number; targetDaysOfWeek: number[] }) => {
+      setIsCopying(true);
+      try {
+        await copyMutation({
+          shopId: shopId as Id<"shops">,
+          sourceDayOfWeek: params.sourceDayOfWeek,
+          targetDaysOfWeek: params.targetDaysOfWeek,
+        });
+        toaster.create({
+          description: "設定をコピーしました",
+          type: "success",
+        });
+      } catch (error) {
+        toaster.create({
+          description: "コピーに失敗しました",
+          type: "error",
+        });
+        console.error("コピーエラー:", error);
+        throw error;
+      } finally {
+        setIsCopying(false);
+      }
+    },
+    [shopId, copyMutation],
+  );
+
+  // ローディング
+  if (shop === undefined || positions === undefined) {
+    return (
+      <LazyShow>
+        <LoadingState />
+      </LazyShow>
+    );
+  }
+
+  // 店舗が見つからない場合
+  if (shop === null) {
+    return null;
+  }
+
+  return (
+    <StaffingMatrix
+      shopId={shopId}
+      shop={{
+        _id: shop._id,
+        shopName: shop.shopName,
+        openTime: shop.openTime,
+        closeTime: shop.closeTime,
+      }}
+      positions={positions.map((p) => ({ _id: p._id, name: p.name }))}
+      initialStaffing={requiredStaffing}
+      onSave={handleSave}
+      onCopy={handleCopy}
+      isSaving={isSaving}
+      isCopying={isCopying}
+    />
+  );
 };

--- a/src/components/ui/Dialog/index.tsx
+++ b/src/components/ui/Dialog/index.tsx
@@ -34,6 +34,7 @@ type DialogProps = {
   onClose?: () => void;
   closeLabel?: string;
   isLoading?: boolean;
+  isSubmitDisabled?: boolean;
   role?: "dialog" | "alertdialog";
   submitColorPalette?: string;
   hideFooter?: boolean;
@@ -51,6 +52,7 @@ export const Dialog = ({
   onClose,
   closeLabel = "キャンセル",
   isLoading = false,
+  isSubmitDisabled = false,
   role = "dialog",
   submitColorPalette = "teal",
   hideFooter = false,
@@ -75,7 +77,12 @@ export const Dialog = ({
                   {closeLabel}
                 </Button>
                 {onSubmit && (
-                  <Button colorPalette={submitColorPalette} onClick={onSubmit} loading={isLoading}>
+                  <Button
+                    colorPalette={submitColorPalette}
+                    onClick={onSubmit}
+                    loading={isLoading}
+                    disabled={isSubmitDisabled}
+                  >
                     {submitLabel}
                   </Button>
                 )}


### PR DESCRIPTION
## Summary
店舗ごとに曜日・時間帯・ポジション別の必要人員数を設定できるスタッフィングマトリックス機能を実装しました。シフト自動生成の前提となる必要人数設定を管理できるようになります。

## Design

### コンポーネント構成
```mermaid
graph TD
    A[StaffingSettingsPage] --> B[StaffingMatrix]
    B --> C[DayTabs]
    B --> D[StaffingTable]
    B --> E[CopyModal]
    B --> F[RegenerateModal]
    A --> G[SetupWizard]
    G --> H[DaySelector]
    G --> I[AIGenerateForm]
```

### データフロー
```mermaid
sequenceDiagram
    User->>StaffingSettingsPage: ページアクセス
    StaffingSettingsPage->>Convex: useQuery(getByShopId)
    Convex-->>StaffingSettingsPage: 必要人員データ
    alt データなし
        StaffingSettingsPage->>SetupWizard: 初回設定UI表示
        User->>SetupWizard: 曜日選択・条件入力
        SetupWizard->>Convex: upsert mutation
    else データあり
        StaffingSettingsPage->>StaffingMatrix: 編集UI表示
        User->>StaffingMatrix: 人数編集・コピー
        StaffingMatrix->>Convex: upsert/copy mutation
    end
```

## Changes

### Convex（バックエンド）
- **requiredStaffingテーブル追加**: 曜日ごとの必要人員設定を保存
- **queries.ts**: `getByShopId` - 店舗の必要人員データ取得
- **mutations.ts**: `upsert`（保存）、`copyToOtherDays`（曜日間コピー）

### 新規コンポーネント
- **SetupWizard**: 初回セットアップ時のステップ形式UI（曜日選択→条件入力→生成）
- **DaySelector**: 曜日選択チェックボックスUI
- **AIGenerateForm**: 店舗タイプ・客数から必要人数を自動生成（ダミー）
- **StaffingTable**: 時間帯×ポジションの必要人数入力テーブル
- **DayTabs**: 曜日切り替えタブ
- **CopyModal**: 選択中の曜日設定を他の曜日にコピー
- **RegenerateModal**: AIで設定を作り直す確認モーダル

### 既存ファイル更新
- **StaffingMatrix/index.tsx**: メインコンポーネントの大幅拡張
- **StaffingSettingsPage**: データ取得・保存ロジック追加、初回設定判定
- **Dialog/index.tsx**: 軽微な修正