### PR TITLE
feat: スタッフシフト提出画面のモックUI作成・Storybook環境整備・VRTキャプチャ削減

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ convex-seeds/backup
 .serena
 
 settings.local.json
-.mcp.json
 CLAUDE.local.md
 
 character.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "storybook-mcp": {
+      "type": "http",
+      "url": "http://localhost:6006/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "storybook-mcp": {
-      "type": "http",
+      "type": "sse",
       "url": "http://localhost:6006/mcp"
     }
   }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,7 +8,7 @@ const config: StorybookConfig = {
     },
   },
   stories: ["../src/**/*.stories.@(ts|tsx)"],
-  addons: ["@storybook/addon-docs", "@storybook/addon-vitest"],
+  addons: ["@storybook/addon-docs", "@storybook/addon-vitest", "@storybook/addon-mcp"],
   framework: {
     name: "@storybook/react-vite",
     options: {},

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,7 +160,9 @@ import { bar } from "@/convex/...";
 
 - デザイン関連のファイル・ルールは `design/` ディレクトリを参照（`design/CLAUDE.md`）。
 - デザインをもとにモックを作成する場合、実装後にpencil MCP, Storybook MCP, Playwright MCPでスクショを取ってPencilのデザイン通り実装できているか確認すること（フォント差については許容）
-- VRTは無料枠で毎月のキャプチャ数に限りがあります。小さなコンポーネントはVariants Storyを作成し、1つのStoryにまとめたいです。大きいコンポーネントはそのままでOK
+- VRTは無料枠で毎月のキャプチャ数に限りがあります。小さなコンポーネントはVariants Storyを作成し、1つのStoryにまとめたいです。
+  大きいコンポーネントはそのままでOK。
+  操作用のStoryが必要なら、Interactive Storyを別途作成すること。（小さいコンポーネントのみ）
 
 ## コーディング
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,9 @@ import { bar } from "@/convex/...";
 
 ## デザイン
 
-デザイン関連のファイル・ルールは `design/` ディレクトリを参照（`design/CLAUDE.md`）。
+- デザイン関連のファイル・ルールは `design/` ディレクトリを参照（`design/CLAUDE.md`）。
+- デザインをもとにモックを作成する場合、実装後にpencil MCP, Storybook MCP, Playwright MCPでスクショを取ってPencilのデザイン通り実装できているか確認すること（フォント差については許容）
+- VRTは無料枠で毎月のキャプチャ数に限りがあります。小さなコンポーネントはVariants Storyを作成し、1つのStoryにまとめたいです。大きいコンポーネントはそのままでOK
 
 ## コーディング
 

--- a/design/designIndex.md
+++ b/design/designIndex.md
@@ -34,6 +34,16 @@
 | ~~`K5zai`~~ | ShiftBoard/Confirmed/SP | SP確定済み |
 | ~~`0sBBB`~~ | ShiftBoard/ConfirmDialog/SP | SP確定ダイアログ表示 |
 
+## shift-submit.pen — スタッフシフト提出画面
+
+| ID | Name | Description |
+|---|---|---|
+| `tuyCK` | ShiftSubmit/Unsubmitted | SP未提出＋締切前（状態A） |
+| `AnaaY` | ShiftSubmit/Submitted | SP提出済み＋締切前（状態B） |
+| `8rGfg` | ShiftSubmit/SubmittedExpired | SP提出済み＋締切後（状態C） |
+| `ZNB1Z` | ShiftSubmit/Expired | SP未提出＋締切後（状態D） |
+| `W9WOE` | ShiftSubmit/Complete | SP提出完了画面 |
+
 ## design.pen
 （画面デザイン）
 

--- a/design/shift-submit.pen
+++ b/design/shift-submit.pen
@@ -1,0 +1,2815 @@
+{
+  "version": "2.10",
+  "children": [
+    {
+      "type": "frame",
+      "id": "tuyCK",
+      "x": 0,
+      "y": 0,
+      "name": "ShiftSubmit/Unsubmitted",
+      "width": 375,
+      "fill": "$1:bg/muted",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "754Ay",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$1:teal/solid",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "PHBze",
+              "name": "ShopName",
+              "opacity": 0.8,
+              "fill": "$1:teal/contrast",
+              "content": "居酒屋さくら",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "M70pm",
+              "name": "PageTitle",
+              "fill": "$1:teal/contrast",
+              "content": "シフト希望を提出",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "KcCQG",
+          "name": "InfoBar",
+          "width": "fill_container",
+          "fill": "$1:bg/default",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$1:border/default"
+          },
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "fzHZ2",
+              "name": "InfoLeft",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Yitj5",
+                  "name": "Period",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月) 〜 4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "3nbZ0",
+                  "name": "Deadline",
+                  "fill": "$1:fg/muted",
+                  "content": "提出締切: 4/4 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NZvxI",
+              "name": "Badge",
+              "fill": "$1:orange/subtle",
+              "cornerRadius": "$1:radii/full",
+              "padding": [
+                4,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "bBiHh",
+                  "name": "BadgeText",
+                  "fill": "$1:orange/fg",
+                  "content": "未提出",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "vHvtj",
+          "name": "HelperArea",
+          "width": "fill_container",
+          "gap": 6,
+          "padding": [
+            10,
+            16,
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "BALUH",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "hand-metal",
+              "iconFontFamily": "lucide",
+              "fill": "$1:fg/subtle"
+            },
+            {
+              "type": "text",
+              "id": "LYV0K",
+              "fill": "$1:fg/muted",
+              "content": "出勤する日をタップしてください",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xs",
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "kicyy",
+          "name": "CardList",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "UT13g",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "dLVNM",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "j17vE",
+                  "name": "OffBadge",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hjTSr",
+                      "name": "OffText",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fsuMI",
+              "name": "DayCard/On",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#f0fdfa",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:teal/solid"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                8,
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "n0gi2",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/8 (火)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "Mi0fV",
+                  "name": "Spacer",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "CXHeC",
+                  "name": "TimeArea",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Hzvwt",
+                      "name": "StartSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ypbgP",
+                          "name": "startVal2",
+                          "fill": "$1:fg/default",
+                          "content": "9:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "Nr40r",
+                          "name": "startChev2",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "FWMap",
+                      "name": "tilde2",
+                      "fill": "$1:fg/muted",
+                      "content": "〜",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vmBDt",
+                      "name": "EndSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "8MDuP",
+                          "name": "endVal2",
+                          "fill": "$1:fg/default",
+                          "content": "18:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "5gcum",
+                          "name": "endChev2",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Y2WPO",
+                  "name": "CloseBtn",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$1:bg/default",
+                  "cornerRadius": "$1:radii/full",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$1:border/default"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "pbbfy",
+                      "name": "closeIcon2",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$1:fg/muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BjH2v",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "jVYIi",
+                  "name": "date3",
+                  "fill": "$1:fg/default",
+                  "content": "4/9 (水)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "zrWo4",
+                  "name": "offBadge3",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Qgt2O",
+                      "name": "offText3",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "XVoTq",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "pfcfZ",
+                  "name": "date4",
+                  "fill": "$1:fg/default",
+                  "content": "4/10 (木)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "Oca58",
+                  "name": "offBadge4",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "TiwyH",
+                      "name": "offText4",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "1Djsi",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "myu7N",
+                  "name": "date5",
+                  "fill": "$1:fg/default",
+                  "content": "4/11 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "i5sCj",
+                  "name": "offBadge5",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "6JRn7",
+                      "name": "offText5",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eOnP0",
+              "name": "DayCard/Off/Sat",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "wMP4U",
+                  "name": "date6",
+                  "fill": "$1:blue/solid",
+                  "content": "4/12 (土)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "OKdyz",
+                  "name": "offBadge6",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "JF8Z8",
+                      "name": "offText6",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "faOWz",
+              "name": "DayCard/Off/Sun",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "z20De",
+                  "name": "date7",
+                  "fill": "$1:red/solid",
+                  "content": "4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "KDxtT",
+                  "name": "offBadge7",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "SPzci",
+                      "name": "offText7",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "85sWp",
+          "name": "Footer",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            8,
+            16,
+            24,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "gQdkQ",
+              "name": "SubmitButton",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:teal/solid",
+              "cornerRadius": "$1:radii/lg",
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "A3t7d",
+                  "name": "submitText1",
+                  "fill": "$1:teal/contrast",
+                  "content": "提出する",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/md",
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ZNB1Z",
+      "x": 1275,
+      "y": 0,
+      "name": "ShiftSubmit/Expired",
+      "width": 375,
+      "height": 600,
+      "fill": "$1:bg/muted",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Os5hz",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$1:teal/solid",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "6rXWl",
+              "name": "ShopName",
+              "opacity": 0.8,
+              "fill": "$1:teal/contrast",
+              "content": "居酒屋さくら",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "BQG1l",
+              "name": "PageTitle",
+              "fill": "$1:teal/contrast",
+              "content": "シフト希望を提出",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "QcnZH",
+          "name": "Body",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "$1:bg/default",
+          "layout": "vertical",
+          "gap": 16,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "3PoHb",
+              "width": 48,
+              "height": 48,
+              "iconFontName": "calendar-x",
+              "iconFontFamily": "lucide",
+              "fill": "$1:fg/subtle"
+            },
+            {
+              "type": "text",
+              "id": "IDWnt",
+              "fill": "$1:fg/default",
+              "content": "提出締切を過ぎています",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/lg",
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "FJK2y",
+              "fill": "$1:fg/muted",
+              "textGrowth": "fixed-width",
+              "width": 280,
+              "content": "シフトの希望がある場合は、\nお店に直接ご連絡ください。",
+              "textAlign": "center",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/sm",
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "W9WOE",
+      "x": 1700,
+      "y": 0,
+      "name": "ShiftSubmit/Complete",
+      "width": 375,
+      "fill": "$1:bg/muted",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "BQLWI",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$1:teal/solid",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "3aj8H",
+              "name": "ShopName",
+              "opacity": 0.8,
+              "fill": "$1:teal/contrast",
+              "content": "居酒屋さくら",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "m3Ttc",
+              "name": "PageTitle",
+              "fill": "$1:teal/contrast",
+              "content": "シフト希望を提出",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "b9DLx",
+          "name": "SuccessArea",
+          "width": "fill_container",
+          "fill": "$1:bg/default",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            32,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "wBDz8",
+              "name": "CheckWrap",
+              "width": 56,
+              "height": 56,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "9z1qu",
+                  "x": 0,
+                  "y": 0,
+                  "name": "CheckCircle",
+                  "fill": "$1:teal/solid",
+                  "width": 56,
+                  "height": 56
+                },
+                {
+                  "type": "icon_font",
+                  "id": "pA4oF",
+                  "x": 14,
+                  "y": 14,
+                  "width": 28,
+                  "height": 28,
+                  "iconFontName": "check",
+                  "iconFontFamily": "lucide",
+                  "fill": "$1:white"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "lzV54",
+              "fill": "$1:fg/default",
+              "content": "提出しました",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "VApMl",
+              "fill": "$1:fg/muted",
+              "content": "シフトが確定したらメールでお知らせします",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/sm",
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NC9Mf",
+          "name": "SummaryCard",
+          "width": "fill_container",
+          "layout": "vertical",
+          "padding": [
+            12,
+            16,
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "sUInj",
+              "name": "SummaryInner",
+              "clip": true,
+              "width": "fill_container",
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KGiib",
+                  "name": "row1",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "32FM4",
+                      "fill": "$1:fg/default",
+                      "content": "4/7 (月)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "KwR7K",
+                      "fill": "$1:teal/solid",
+                      "content": "9:00 〜 18:00",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KoY8Y",
+                  "name": "row2",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yHRJV",
+                      "fill": "$1:fg/default",
+                      "content": "4/8 (火)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "lKu5B",
+                      "fill": "$1:teal/solid",
+                      "content": "9:00 〜 18:00",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "reJT2",
+                  "name": "row3",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "4hgS5",
+                      "fill": "$1:fg/default",
+                      "content": "4/9 (水)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ti8iG",
+                      "fill": "$1:teal/solid",
+                      "content": "10:00 〜 15:00",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mN980",
+                  "name": "row4",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gN3nI",
+                      "fill": "$1:fg/default",
+                      "content": "4/10 (木)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "fFuzU",
+                      "fill": "$1:fg/subtle",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "fP3ZZ",
+                  "name": "row5",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "7S2CP",
+                      "fill": "$1:fg/default",
+                      "content": "4/11 (金)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "uQOo4",
+                      "fill": "$1:teal/solid",
+                      "content": "9:00 〜 22:00",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WZGZ4",
+                  "name": "row6",
+                  "width": "fill_container",
+                  "height": 40,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "$1:border/default"
+                  },
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "qQbcu",
+                      "fill": "$1:blue/solid",
+                      "content": "4/12 (土)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "m23LG",
+                      "fill": "$1:fg/subtle",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8Iqaw",
+                  "name": "row7",
+                  "width": "fill_container",
+                  "height": 40,
+                  "padding": [
+                    0,
+                    14
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "4a0Pq",
+                      "fill": "$1:red/solid",
+                      "content": "4/13 (日)",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5yJ4x",
+                      "fill": "$1:fg/subtle",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/sm",
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "uRLPZ",
+          "name": "Footer",
+          "width": "fill_container",
+          "layout": "vertical",
+          "padding": [
+            8,
+            16,
+            24,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "L1Fhu",
+              "name": "EditButton",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "D256g",
+                  "fill": "$1:fg/default",
+                  "content": "内容を修正する",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/md",
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "AnaaY",
+      "x": 425,
+      "y": 0,
+      "name": "ShiftSubmit/Submitted",
+      "width": 375,
+      "fill": "$1:bg/muted",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "wTc8W",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$1:teal/solid",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "VIKJO",
+              "name": "ShopName",
+              "opacity": 0.8,
+              "fill": "$1:teal/contrast",
+              "content": "居酒屋さくら",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "ET30q",
+              "name": "PageTitle",
+              "fill": "$1:teal/contrast",
+              "content": "シフト希望を提出",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "XhWUw",
+          "name": "InfoBar",
+          "width": "fill_container",
+          "fill": "$1:bg/default",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$1:border/default"
+          },
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "RpgL1",
+              "name": "InfoLeft",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "bSQUq",
+                  "name": "Period",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月) 〜 4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "SNtVj",
+                  "name": "Deadline",
+                  "fill": "$1:fg/muted",
+                  "content": "提出締切: 4/4 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aENQ3",
+              "name": "Badge",
+              "fill": "$1:green/subtle",
+              "cornerRadius": "$1:radii/full",
+              "padding": [
+                4,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "FZHtK",
+                  "name": "BadgeText",
+                  "fill": "$1:green/fg",
+                  "content": "提出済み",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "baG2w",
+          "name": "CardList",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "l6QOC",
+              "name": "DayCard/On",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#f0fdfa",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:teal/solid"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                8,
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "WHJpj",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "Pf2jy",
+                  "name": "Spacer",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Wvuhp",
+                  "name": "TimeArea",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PfMmO",
+                      "name": "StartSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "zaWpK",
+                          "fill": "$1:fg/default",
+                          "content": "9:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "nCO3S",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "GCazB",
+                      "fill": "$1:fg/muted",
+                      "content": "〜",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bEoBn",
+                      "name": "EndSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Q7N0h",
+                          "fill": "$1:fg/default",
+                          "content": "18:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "uen5n",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "avrkx",
+                  "name": "CloseBtn",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$1:bg/default",
+                  "cornerRadius": "$1:radii/full",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$1:border/default"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "g695u",
+                      "name": "closeIc1",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$1:fg/muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "JewjP",
+              "name": "DayCard/On",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#f0fdfa",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:teal/solid"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                8,
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "MpL76",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/8 (火)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "LKbZz",
+                  "name": "Spacer",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "o1CUf",
+                  "name": "TimeArea",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "P1V4Q",
+                      "name": "StartSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vmKEt",
+                          "name": "startVal2",
+                          "fill": "$1:fg/default",
+                          "content": "9:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "graJk",
+                          "name": "startChev2",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "hFrx9",
+                      "name": "tilde2",
+                      "fill": "$1:fg/muted",
+                      "content": "〜",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "m8vOS",
+                      "name": "EndSelect",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "yVesS",
+                          "name": "endVal2",
+                          "fill": "$1:fg/default",
+                          "content": "18:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "fVfXE",
+                          "name": "endChev2",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "6O7Db",
+                  "name": "CloseBtn",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$1:bg/default",
+                  "cornerRadius": "$1:radii/full",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$1:border/default"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "nBJ8r",
+                      "name": "closeIcon2",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$1:fg/muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iI0u2",
+              "name": "DayCard/On",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#f0fdfa",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:teal/solid"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                8,
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "4nyWo",
+                  "name": "date3",
+                  "fill": "$1:fg/default",
+                  "content": "4/9 (水)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "6Tqp3",
+                  "name": "sp3",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "B5wjm",
+                  "name": "ta3",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BJWBf",
+                      "name": "ss3",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ubjrr",
+                          "fill": "$1:fg/default",
+                          "content": "10:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "iJhUZ",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "jJEAg",
+                      "fill": "$1:fg/muted",
+                      "content": "〜",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "lgP5p",
+                      "name": "es3",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "exLUt",
+                          "fill": "$1:fg/default",
+                          "content": "15:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "4yqQg",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "mTStO",
+                  "name": "CloseBtn",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$1:bg/default",
+                  "cornerRadius": "$1:radii/full",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$1:border/default"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zxez2",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$1:fg/muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zvZyA",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Tamsc",
+                  "name": "date4",
+                  "fill": "$1:fg/default",
+                  "content": "4/10 (木)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "tLZ8Q",
+                  "name": "offBadge4",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ZhEHU",
+                      "name": "offText4",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "so7Ap",
+              "name": "DayCard/On",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "#f0fdfa",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:teal/solid"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                8,
+                0,
+                14
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "PymCL",
+                  "name": "date5",
+                  "fill": "$1:fg/default",
+                  "content": "4/11 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "5qOp8",
+                  "name": "sp5",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Biaay",
+                  "name": "ta5",
+                  "gap": 4,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "FvxcC",
+                      "name": "ss5",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "7spPW",
+                          "fill": "$1:fg/default",
+                          "content": "9:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "tTeBV",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "49INO",
+                      "fill": "$1:fg/muted",
+                      "content": "〜",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EyU66",
+                      "name": "es5",
+                      "fill": "$1:bg/default",
+                      "cornerRadius": "$1:radii/md",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "$1:border/default"
+                      },
+                      "gap": 2,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "A9L9u",
+                          "fill": "$1:fg/default",
+                          "content": "22:00",
+                          "fontFamily": "Inter",
+                          "fontSize": "$1:fontSize/xs",
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "y2wrB",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "$1:fg/subtle"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BaAPQ",
+                  "name": "CloseBtn",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "$1:bg/default",
+                  "cornerRadius": "$1:radii/full",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$1:border/default"
+                  },
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "98H0n",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "$1:fg/muted"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MwYob",
+              "name": "DayCard/Off/Sat",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "c8PDV",
+                  "name": "date6",
+                  "fill": "$1:blue/solid",
+                  "content": "4/12 (土)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "kqWrO",
+                  "name": "offBadge6",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "quQBw",
+                      "name": "offText6",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "S30a5",
+              "name": "DayCard/Off/Sun",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "1sS2k",
+                  "name": "date7",
+                  "fill": "$1:red/solid",
+                  "content": "4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "6VQAz",
+                  "name": "offBadge7",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hDKNG",
+                      "name": "offText7",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "vhToo",
+          "name": "Footer",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            8,
+            16,
+            24,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "28Ihi",
+              "name": "SubmitButton",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:teal/solid",
+              "cornerRadius": "$1:radii/lg",
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "qloG5",
+                  "name": "submitText1",
+                  "fill": "$1:teal/contrast",
+                  "content": "修正して提出する",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/md",
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "6v5E7",
+              "x": 97.5,
+              "y": 64,
+              "name": "HelperText",
+              "enabled": false,
+              "fill": "$1:fg/subtle",
+              "content": "出勤する日をタップしてください",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xs",
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "8rGfg",
+      "x": 850,
+      "y": 0,
+      "name": "ShiftSubmit/SubmittedExpired",
+      "width": 375,
+      "fill": "$1:bg/muted",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "zB8X8",
+          "name": "Header",
+          "width": "fill_container",
+          "fill": "$1:teal/solid",
+          "layout": "vertical",
+          "gap": 2,
+          "padding": [
+            12,
+            16,
+            16,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "KEQRT",
+              "name": "ShopName",
+              "opacity": 0.8,
+              "fill": "$1:teal/contrast",
+              "content": "居酒屋さくら",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "2Wdve",
+              "name": "PageTitle",
+              "fill": "$1:teal/contrast",
+              "content": "シフト希望を提出",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xl",
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ozkNX",
+          "name": "InfoBar",
+          "width": "fill_container",
+          "fill": "$1:bg/default",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "$1:border/default"
+          },
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yit07",
+              "name": "InfoLeft",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "SZ6vS",
+                  "name": "Period",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月) 〜 4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "mIluR",
+                  "name": "Deadline",
+                  "fill": "$1:fg/muted",
+                  "content": "提出締切: 4/4 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "OzUXr",
+              "name": "Badge",
+              "fill": "$1:green/subtle",
+              "cornerRadius": "$1:radii/full",
+              "padding": [
+                4,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "LtZca",
+                  "name": "BadgeText",
+                  "fill": "$1:green/fg",
+                  "content": "提出済み",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/xs",
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dGPDJ",
+          "name": "InfoBanner",
+          "width": "fill_container",
+          "fill": "$1:blue/subtle",
+          "gap": 8,
+          "padding": [
+            10,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "llWCL",
+              "name": "infoIcon",
+              "width": 16,
+              "height": 16,
+              "iconFontName": "info",
+              "iconFontFamily": "lucide",
+              "fill": "$1:blue/solid"
+            },
+            {
+              "type": "text",
+              "id": "uFK5n",
+              "name": "infoText",
+              "fill": "$1:blue/fg",
+              "content": "提出締切を過ぎたため変更できません",
+              "fontFamily": "Inter",
+              "fontSize": "$1:fontSize/xs",
+              "fontWeight": "500"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "AAjoA",
+          "name": "CardList",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "KoQls",
+              "name": "DayCard/ReadOnly",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Qyluc",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/7 (月)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "CbFFI",
+                  "name": "timeRO1",
+                  "fill": "$1:teal/solid",
+                  "content": "9:00 〜 18:00",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bbKJE",
+              "name": "DayCard/ReadOnly",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "2GqPv",
+                  "name": "Date",
+                  "fill": "$1:fg/default",
+                  "content": "4/8 (火)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "F5nyX",
+                  "name": "timeRO2",
+                  "fill": "$1:teal/solid",
+                  "content": "9:00 〜 18:00",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kiO4K",
+              "name": "DayCard/ReadOnly",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "8vPgD",
+                  "name": "date3",
+                  "fill": "$1:fg/default",
+                  "content": "4/9 (水)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "2cMZV",
+                  "name": "timeRO3",
+                  "fill": "$1:teal/solid",
+                  "content": "10:00 〜 15:00",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NAyXn",
+              "name": "DayCard/Off",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "CWLjf",
+                  "name": "date4",
+                  "fill": "$1:fg/default",
+                  "content": "4/10 (木)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "8qWHS",
+                  "name": "offBadge4",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "KsZbH",
+                      "name": "offText4",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "aur7E",
+              "name": "DayCard/ReadOnly",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "gap": 8,
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "SQXy3",
+                  "name": "date5",
+                  "fill": "$1:fg/default",
+                  "content": "4/11 (金)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "nUC0I",
+                  "name": "timeRO4",
+                  "fill": "$1:teal/solid",
+                  "content": "9:00 〜 22:00",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Xjtjh",
+              "name": "DayCard/Off/Sat",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "4g5Au",
+                  "name": "date6",
+                  "fill": "$1:blue/solid",
+                  "content": "4/12 (土)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "tKLJE",
+                  "name": "offBadge6",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "0VmRD",
+                      "name": "offText6",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "7PCDF",
+              "name": "DayCard/Off/Sun",
+              "width": "fill_container",
+              "height": 48,
+              "fill": "$1:bg/default",
+              "cornerRadius": "$1:radii/lg",
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "$1:border/default"
+              },
+              "padding": [
+                0,
+                14
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "pP1Pf",
+                  "name": "date7",
+                  "fill": "$1:red/solid",
+                  "content": "4/13 (日)",
+                  "fontFamily": "Inter",
+                  "fontSize": "$1:fontSize/sm",
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "frame",
+                  "id": "RmiVa",
+                  "name": "offBadge7",
+                  "fill": "$1:bg/muted",
+                  "cornerRadius": "$1:radii/full",
+                  "padding": [
+                    2,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Td59M",
+                      "name": "offText7",
+                      "fill": "$1:fg/muted",
+                      "content": "休み",
+                      "fontFamily": "Inter",
+                      "fontSize": "$1:fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "imports": {
+    "1": "common/system.lib.pen"
+  }
+}

--- a/doc/plans/2026-04-08_スタッフ提出画面_実装計画.md
+++ b/doc/plans/2026-04-08_スタッフ提出画面_実装計画.md
@@ -1,0 +1,475 @@
+# スタッフ提出画面 実装計画
+
+> **作成日**: 2026-04-08
+> **前提ドキュメント**: 2026-04-06_pencilプロンプト_スタッフ提出画面.md, 2026-03-30_メール通知・マジックリンク設計.md
+> **対象**: Claude Code 向け実装プロンプト
+
+---
+
+## 0. 背景サマリー
+
+スタッフがマジックリンクからシフト希望を提出する画面。MVP 3ページの最後の1枚。
+スタッフはスマホ操作、Clerkアカウントなし、マジックリンク＋セッション認証。
+
+### 画面の4状態
+| 状態 | 条件 | 操作 |
+|------|------|------|
+| A. 未提出＋締切前 | 提出記録なし & now < deadline | 全日休みデフォ → 入力 → 提出 |
+| B. 提出済み＋締切前 | 提出記録あり & now < deadline | 前回データプリフィル → 修正 → 再提出 |
+| C. 提出済み＋締切後 | 提出記録あり & now >= deadline | 閲覧のみ |
+| D. 未提出＋締切後 | 提出記録なし & now >= deadline | 締切超過メッセージ |
+
+### インタラクション設計
+- 全日「休み」がデフォルト（未提出スタッフの安全設計）
+- 休みカードタップ → 出勤ON（一方通行）+ 時間selectが同行に表示
+- 出勤 → 休みは×ボタンのみ（誤タップ防止）
+- 時間の初期値は店舗の `shiftStartTime` 〜 `shiftEndTime`
+- 全日休みでも提出可能（未提出と全休みは意味が違う）
+- 締切前なら何度でも修正可能（上書き）
+
+---
+
+## 1. スキーマ変更
+
+### 1-1. `shiftSubmissions` テーブルを追加
+
+`shiftRequests` テーブルは出勤日のレコードしか持たないため、「全休み提出」と「未提出」を区別できない。提出の事実を記録するテーブルが必要。
+
+```ts
+// schema.ts に追加
+shiftSubmissions: defineTable({
+  recruitmentId: v.id("recruitments"),
+  staffId: v.id("staffs"),
+  submittedAt: v.number(), // Unix ms（最終提出日時）
+})
+  .index("by_recruitmentId", ["recruitmentId"])
+  .index("by_recruitmentId_staffId", ["recruitmentId", "staffId"]),
+```
+
+### 1-2. `createMagicLink` の有効期限を可変にする
+
+現在は24時間固定。提出リンクは提出締切まで有効にする必要がある。
+
+```ts
+// convex/email/mutations.ts
+export const createMagicLink = internalMutation({
+  args: {
+    staffId: v.id("staffs"),
+    shopId: v.id("shops"),
+    recruitmentId: v.id("recruitments"),
+    expiresAt: v.optional(v.number()), // 追加: カスタム有効期限
+  },
+  handler: async (ctx, args) => {
+    const token = generateUUID();
+    await ctx.db.insert("magicLinks", {
+      token,
+      staffId: args.staffId,
+      shopId: args.shopId,
+      recruitmentId: args.recruitmentId,
+      expiresAt: args.expiresAt ?? Date.now() + TWENTY_FOUR_HOURS_MS,
+    });
+    return { token };
+  },
+});
+```
+
+---
+
+## 2. Convex バックエンド
+
+### 2-1. `staffSessionMutation` ラッパーを追加
+
+`_lib/functions.ts` に `staffSessionQuery` は存在するが、mutation版がない。提出処理に必要。
+
+```ts
+// convex/_lib/functions.ts に追加
+
+type StaffSessionMutationCtx = {
+  staff: Doc<"staffs">;
+  shop: Doc<"shops">;
+  session: Doc<"sessions">;
+};
+
+export const staffSessionMutation = customMutation(mutation, {
+  args: { sessionToken: v.string() },
+  input: async (ctx, { sessionToken }): Promise<{ ctx: StaffSessionMutationCtx; args: Record<string, never> }> => {
+    const session = await ctx.db
+      .query("sessions")
+      .withIndex("by_sessionToken", (q) => q.eq("sessionToken", sessionToken))
+      .first();
+    if (!session || session.expiresAt < Date.now()) {
+      throw new ConvexError("Session expired");
+    }
+    const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
+    if (!staff || staff.isDeleted || !shop || shop.isDeleted) {
+      throw new ConvexError("Not found");
+    }
+    return { ctx: { staff, shop, session }, args: {} };
+  },
+});
+```
+
+### 2-2. 新規ユースケース `convex/shiftSubmission/`
+
+```
+convex/shiftSubmission/
+├── queries.ts       # getSubmissionPageData
+├── mutations.ts     # submitShiftRequests
+└── schemas.ts       # Zodバリデーション
+```
+
+#### queries.ts — `getSubmissionPageData`
+
+`staffSessionQuery` を使用。以下を返す：
+
+```ts
+{
+  shopName: string;
+  periodStart: string;       // "2026-04-07"
+  periodEnd: string;         // "2026-04-13"
+  deadline: string;          // "2026-04-04"
+  isDeadlinePassed: boolean; // now >= deadline の 翌日 0:00
+  shiftStartTime: string;    // "9:00" — 店舗のシフト時間帯
+  shiftEndTime: string;      // "22:00"
+  submission: {
+    submittedAt: number | null;  // 提出済みなら Unix ms、未提出なら null
+    requests: Array<{            // 出勤日のみ（休み日はレコードなし）
+      date: string;
+      startTime: string;
+      endTime: string;
+    }>;
+  };
+}
+```
+
+引数: `{ sessionToken: string, recruitmentId: Id<"recruitments"> }`
+
+セキュリティ:
+- セッションの `recruitmentId` と引数の `recruitmentId` が一致すること
+- recruitment の `shopId` がセッションの `shopId` と一致すること
+
+#### mutations.ts — `submitShiftRequests`
+
+`staffSessionMutation` を使用。
+
+引数:
+```ts
+{
+  sessionToken: string;
+  recruitmentId: Id<"recruitments">;
+  requests: Array<{
+    date: string;      // "2026-04-07"
+    startTime: string; // "9:00"
+    endTime: string;   // "22:00"
+  }>;
+  // requests が空配列 = 全日休み提出
+}
+```
+
+処理:
+1. recruitment の deadline チェック（過ぎていたらエラー）
+2. 既存の shiftRequests を全削除（by_recruitmentId_staffId）
+3. 新しい requests を全挿入
+4. shiftSubmissions を upsert（既存あれば `submittedAt` を更新、なければ insert）
+5. レートリミット適用（連打防止）
+
+セキュリティ:
+- セッションの `recruitmentId` と引数一致チェック
+- deadline 超過チェック
+- `startTime < endTime` バリデーション
+- `date` が recruitment の `periodStart` 〜 `periodEnd` 範囲内であること
+- requests 配列の最大件数チェック（31件 = 1ヶ月分）
+
+#### schemas.ts
+
+```ts
+import { z } from "zod";
+
+export const shiftRequestSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  startTime: z.string().regex(/^\d{1,2}:\d{2}$/),
+  endTime: z.string().regex(/^\d{1,2}:\d{2}$/),
+});
+
+export const submitShiftRequestsSchema = z.object({
+  requests: z.array(shiftRequestSchema).max(31),
+});
+```
+
+### 2-3. レートリミット追加
+
+```ts
+// convex/_lib/rateLimits.ts に追加
+submitShiftRequests: {
+  kind: "token bucket",
+  rate: 5,
+  period: MINUTE,
+  capacity: 5,
+},
+```
+
+---
+
+## 3. 募集開始メール
+
+### 3-1. 概要
+
+田中さんが募集を作成 → 全スタッフに「シフト希望を出してね」メールが自動送信される。
+確定メールとは別のマジックリンク（提出画面に飛ぶ）が入る。
+
+### 3-2. メール仕様
+
+**件名:**
+```
+【{店舗名}】{開始日}〜{終了日} シフト希望の提出をお願いします
+```
+
+**本文構成:**
+```
+{スタッフ名}さん
+
+{開始日}〜{終了日} のシフト希望を提出してください。
+
+提出締切: {締切日}
+
+      [シフト希望を提出する]
+
+このリンクは提出締切まで有効です。
+提出後も締切前であれば修正できます。
+
+──────────────────────────────
+シフトについてのご質問は
+お店に直接ご連絡ください。
+※ このメールに返信しても届きません。
+```
+
+### 3-3. バックエンド実装
+
+#### email/actions.ts — `sendRecruitmentNotificationEmails`
+
+`internalAction`。`createRecruitment` mutation から `ctx.scheduler` 経由で呼ばれる。
+
+処理:
+1. recruitment + shop + 全スタッフ（isDeleted=false）を取得
+2. 各スタッフに対して:
+   - `createMagicLink` を呼ぶ（expiresAt = deadline の翌日 0:00）
+   - マジックリンクURL: `${APP_URL}/shifts/submit?token=${token}`
+   - Resend でメール送信
+
+#### email/templates.ts — `buildRecruitmentEmailHtml`
+
+確定メールテンプレート（`buildConfirmationEmailHtml`）と類似構造。
+個人のシフト一覧は不要（まだ決まっていないため）。CTAボタン＋締切日を強調。
+
+#### email/queries.ts — `getRecruitmentEmailData`
+
+`internalQuery`。recruitment + shop + スタッフ一覧を返す。
+
+### 3-4. 募集作成時の自動送信トリガー
+
+既存の `createRecruitment` mutation（`convex/recruitment/mutations.ts` or `convex/dashboard/mutations.ts`）に、メール送信のスケジュールを追加:
+
+```ts
+await ctx.scheduler.runAfter(0, internal.email.actions.sendRecruitmentNotificationEmails, {
+  recruitmentId,
+});
+```
+
+**注意**: 既存のフローを確認し、適切な場所に追加すること。
+
+---
+
+## 4. フロントエンド
+
+### 4-1. 新規ルート
+
+`src/routes/_unregistered/shifts.submit.tsx`
+
+既存の `shifts.view.tsx` のセッション管理パターン（localStorage + verifyToken）をそのまま流用する。
+
+URL: `/shifts/submit?token=xxx`
+
+構造:
+```
+ShiftSubmitRoute
+├── セッション管理（verifyToken → localStorage）
+├── ShiftSubmitContent
+│   ├── useQuery(getSubmissionPageData)
+│   └── 状態に応じて描画分岐
+│       ├── 状態A: SubmissionForm（全日休みデフォ）
+│       ├── 状態B: SubmissionForm（前回データプリフィル）
+│       ├── 状態C: SubmissionReadonly（閲覧のみ）
+│       └── 状態D: DeadlinePassedView（締切超過）
+└── SubmissionCompleteView（提出完了画面）
+```
+
+### 4-2. コンポーネント構成
+
+```
+src/components/features/StaffSubmission/
+├── SubmissionForm.tsx          # メインフォーム（状態A/B共用）
+├── SubmissionReadonly.tsx      # 閲覧のみ（状態C）
+├── SubmissionComplete.tsx      # 提出完了画面
+├── DeadlinePassedView.tsx      # 締切超過画面（状態D）
+├── DayCard.tsx                 # 日ごとのカード（休み/出勤切替）
+└── types.ts                    # ローカル型定義
+```
+
+### 4-3. DayCard コンポーネント仕様
+
+props:
+```ts
+{
+  date: string;           // "2026-04-07"
+  dayOfWeek: string;      // "月"
+  isWeekend: boolean;
+  isSaturday: boolean;
+  isOn: boolean;          // 出勤ON/OFF
+  startTime: string;
+  endTime: string;
+  shiftStartTime: string; // 店舗のシフト開始
+  shiftEndTime: string;   // 店舗のシフト終了
+  onToggleOn: () => void;    // 休み → 出勤
+  onToggleOff: () => void;   // 出勤 → 休み（×ボタン）
+  onChangeStart: (v: string) => void;
+  onChangeEnd: (v: string) => void;
+  disabled?: boolean;     // 状態C用
+}
+```
+
+レイアウト:
+- 休み状態: `[日付 (曜日)] .............. [休みバッジ]`
+- 出勤状態: `[日付 (曜)] [開始select] 〜 [終了select] [×]`
+- **高さ固定**（どちらの状態も同じ高さ、レイアウトシフトなし）
+
+### 4-4. SubmissionForm の状態管理
+
+```ts
+// ローカルstateで管理（Jotai不要、この画面だけで完結）
+type DayState = {
+  on: boolean;
+  startTime: string;
+  endTime: string;
+};
+const [days, setDays] = useState<Record<string, DayState>>({});
+// 初期化: 状態A → 全日 { on: false, startTime: shop.shiftStartTime, endTime: shop.shiftEndTime }
+// 初期化: 状態B → 前回データから { on: true, startTime, endTime } or { on: false, ... }
+```
+
+### 4-5. 提出処理
+
+```ts
+const submit = useMutation(api.shiftSubmission.mutations.submitShiftRequests);
+
+const handleSubmit = async () => {
+  const requests = Object.entries(days)
+    .filter(([_, d]) => d.on)
+    .map(([date, d]) => ({ date, startTime: d.startTime, endTime: d.endTime }));
+
+  await submit({
+    sessionToken,
+    recruitmentId,
+    requests, // 全休みなら空配列
+  });
+
+  setShowComplete(true); // 完了画面に切替
+};
+```
+
+### 4-6. StaffLayout 再利用
+
+既存の `StaffLayout` コンポーネントをそのまま使う。ヘッダーに店舗名を表示するレイアウト。
+
+---
+
+## 5. 実装順序
+
+依存関係を考慮した順番:
+
+### Step 1: スキーマ＋ラッパー
+1. `schema.ts` に `shiftSubmissions` テーブル追加
+2. `_lib/functions.ts` に `staffSessionMutation` 追加
+3. `_lib/rateLimits.ts` に `submitShiftRequests` 追加
+
+### Step 2: 提出 query/mutation
+4. `convex/shiftSubmission/schemas.ts` 作成
+5. `convex/shiftSubmission/queries.ts` — `getSubmissionPageData`
+6. `convex/shiftSubmission/mutations.ts` — `submitShiftRequests`
+
+### Step 3: 募集メール
+7. `email/mutations.ts` — `createMagicLink` に `expiresAt` 引数追加
+8. `email/queries.ts` — `getRecruitmentEmailData` 追加
+9. `email/templates.ts` — `buildRecruitmentEmailHtml` 追加
+10. `email/actions.ts` — `sendRecruitmentNotificationEmails` 追加
+11. 既存の募集作成 mutation にメール送信スケジュール追加
+
+### Step 4: フロントエンド
+12. `DayCard` コンポーネント
+13. `SubmissionForm` / `SubmissionReadonly` / `SubmissionComplete` / `DeadlinePassedView`
+14. `shifts.submit.tsx` ルート
+
+### Step 5: テスト
+15. `convex/shiftSubmission/mutations.test.ts` — 提出・修正・締切超過・全休み提出
+16. E2E シナリオ追加（既存の `first-shift-delivery.test.ts` の拡張 or 新規シナリオ）
+
+---
+
+## 6. 既存コードへの影響まとめ
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `convex/schema.ts` | `shiftSubmissions` テーブル追加 |
+| `convex/_lib/functions.ts` | `staffSessionMutation` ラッパー追加 |
+| `convex/_lib/rateLimits.ts` | `submitShiftRequests` リミット追加 |
+| `convex/email/mutations.ts` | `createMagicLink` に `expiresAt` 引数追加（オプショナル、後方互換） |
+| `convex/email/actions.ts` | `sendRecruitmentNotificationEmails` 追加 |
+| `convex/email/templates.ts` | `buildRecruitmentEmailHtml` 追加 |
+| `convex/email/queries.ts` | `getRecruitmentEmailData` 追加 |
+| 募集作成 mutation | メール送信スケジュール追加（1行） |
+
+### 新規ファイル
+| ファイル | 内容 |
+|---------|------|
+| `convex/shiftSubmission/schemas.ts` | Zodバリデーション |
+| `convex/shiftSubmission/queries.ts` | `getSubmissionPageData` |
+| `convex/shiftSubmission/mutations.ts` | `submitShiftRequests` |
+| `src/routes/_unregistered/shifts.submit.tsx` | ルート（セッション管理） |
+| `src/components/features/StaffSubmission/DayCard.tsx` | 日カード |
+| `src/components/features/StaffSubmission/SubmissionForm.tsx` | 入力フォーム |
+| `src/components/features/StaffSubmission/SubmissionReadonly.tsx` | 閲覧のみ |
+| `src/components/features/StaffSubmission/SubmissionComplete.tsx` | 完了画面 |
+| `src/components/features/StaffSubmission/DeadlinePassedView.tsx` | 締切超過 |
+| `src/components/features/StaffSubmission/types.ts` | 型定義 |
+
+---
+
+## 7. スコープ外（今回やらないこと）
+
+- 「前回と同じで提出」ボタン（将来フェーズ）
+- 「よく使う時間」チップ（将来フェーズ）
+- PC レイアウト（スマホのみ）
+- 提出リマインダーメール
+- 希望度（◎/○/△）や備考入力
+- 提出時の確認ダイアログ（完了画面から「修正する」で戻れるため不要）
+
+---
+
+## 8. 参照ファイル一覧
+
+プロンプト実行時に以下のファイルを参照すること:
+
+```
+convex/schema.ts
+convex/CLAUDE.md
+convex/_lib/functions.ts
+convex/_lib/rateLimits.ts
+convex/email/mutations.ts
+convex/email/actions.ts
+convex/email/templates.ts
+convex/email/queries.ts
+convex/staffAuth/mutations.ts
+convex/staffAuth/queries.ts
+src/routes/_unregistered/shifts.view.tsx        # セッション管理パターンの参考
+src/components/features/StaffView/              # 既存スタッフ画面の参考
+src/components/templates/StaffLayout/           # レイアウト再利用
+```

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@edge-runtime/vm": "^5.0.0",
     "@playwright/test": "1.57.0",
     "@storybook/addon-docs": "9.1.17",
+    "@storybook/addon-mcp": "^0.5.0",
     "@storybook/addon-vitest": "9.1.17",
     "@storybook/react-vite": "9.1.17",
     "@tanstack/react-devtools": "0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       convex-helpers:
         specifier: ^0.1.114
-        version: 0.1.114(convex@1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1)
+        version: 0.1.114(@standard-schema/spec@1.1.0)(convex@1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1)
       dayjs:
         specifier: ^1.11.19
         version: 1.11.19
@@ -84,6 +84,9 @@ importers:
       '@storybook/addon-docs':
         specifier: 9.1.17
         version: 9.1.17(@types/react@19.2.7)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))
+      '@storybook/addon-mcp':
+        specifier: ^0.5.0
+        version: 0.5.0(@storybook/addon-vitest@9.1.17(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(vitest@3.2.4))(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(typescript@5.9.3)
       '@storybook/addon-vitest':
         specifier: 9.1.17
         version: 9.1.17(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(vitest@3.2.4)
@@ -1265,6 +1268,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1272,6 +1278,15 @@ packages:
     resolution: {integrity: sha512-yc4hlgkrwNi045qk210dRuIMijkgbLmo3ft6F4lOdpPRn4IUnPDj7FfZR8syGzUzKidxRfNtLx5m0yHIz83xtA==}
     peerDependencies:
       storybook: ^9.1.17
+
+  '@storybook/addon-mcp@0.5.0':
+    resolution: {integrity: sha512-yaw6S7a0596sgsAQpfhaatImRwlm+XfxLG28xZSGHXlVfaIYz9+5k1PFh6yWeKPPeJ+B6oUWD1pZCGcK5FOoYw==}
+    peerDependencies:
+      '@storybook/addon-vitest': ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      storybook: ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    peerDependenciesMeta:
+      '@storybook/addon-vitest':
+        optional: true
 
   '@storybook/addon-vitest@9.1.17':
     resolution: {integrity: sha512-2EIvZPz0N+mnIUnUHW3+GIgwJRIqjZrK5BFyHsi82NhOQ1LCh/1GqbcB+kNoaiXioRcAgOsHUDWbQZrvyx3GhQ==}
@@ -1311,6 +1326,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+
+  '@storybook/mcp@0.6.2':
+    resolution: {integrity: sha512-zND9XHI2G4+sjpcxx79AZOg3ShWAA8Kj1W+GS+URT40l8Bml1t9K/72/Juco1uxAkh7+uxybR5OR0lPmg1kGUg==}
 
   '@storybook/react-dom-shim@9.1.17':
     resolution: {integrity: sha512-Ss/lNvAy0Ziynu+KniQIByiNuyPz3dq7tD62hqSC/pHw190X+M7TKU3zcZvXhx2AQx1BYyxtdSHIZapb+P5mxQ==}
@@ -1485,6 +1503,26 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tmcp/adapter-valibot@0.1.5':
+    resolution: {integrity: sha512-9P2wrVYPngemNK0UvPb/opC722/jfd09QxXmme1TRp/wPsl98vpSk/MXt24BCMqBRv4Dvs0xxJH4KHDcjXW52Q==}
+    peerDependencies:
+      tmcp: ^1.17.0
+      valibot: ^1.1.0
+
+  '@tmcp/session-manager@0.2.1':
+    resolution: {integrity: sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.5':
+    resolution: {integrity: sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1552,6 +1590,11 @@ packages:
 
   '@types/unzipper@0.10.11':
     resolution: {integrity: sha512-D25im2zjyMCcgL9ag6N46+wbtJBnXIr7SI4zHf9eJD2Dw2tEB5e+p5MYkrxKIVRscs5QV0EhtU9rgXSPx90oJg==}
+
+  '@valibot/to-json-schema@1.6.0':
+    resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
+    peerDependencies:
+      valibot: ^1.3.0
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -2307,6 +2350,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -2687,6 +2733,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2974,6 +3023,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  picoquery@2.5.0:
+    resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -3268,6 +3320,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -3408,6 +3463,9 @@ packages:
     resolution: {integrity: sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==}
     hasBin: true
 
+  tmcp@1.19.3:
+    resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -3526,6 +3584,9 @@ packages:
   uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -3542,6 +3603,14 @@ packages:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
     hasBin: true
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   valid-filename@4.0.0:
     resolution: {integrity: sha512-VEYTpTVPMgO799f2wI7zWf0x2C54bPX6NAfbZ2Z8kZn76p+3rEYCTYVYzMUcVSMvakxMQTriBf24s3+WeXJtEg==}
@@ -4702,6 +4771,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-docs@9.1.17(@types/react@19.2.7)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))':
@@ -4716,6 +4787,21 @@ snapshots:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
+
+  '@storybook/addon-mcp@0.5.0(@storybook/addon-vitest@9.1.17(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(vitest@3.2.4))(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/mcp': 0.6.2(typescript@5.9.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.9.3))
+      picoquery: 2.5.0
+      storybook: 9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0))
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    optionalDependencies:
+      '@storybook/addon-vitest': 9.1.17(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(vitest@3.2.4)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/addon-vitest@9.1.17(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))(vitest@3.2.4)':
     dependencies:
@@ -4750,6 +4836,16 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@storybook/mcp@0.6.2(typescript@5.9.3)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.9.3))
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/react-dom-shim@9.1.17(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)))':
     dependencies:
@@ -4978,6 +5074,23 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@valibot/to-json-schema': 1.6.0(valibot@1.2.0(typescript@5.9.3))
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+
+  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@5.9.3))':
+    dependencies:
+      tmcp: 1.19.3(typescript@5.9.3)
+
+  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.19.3(typescript@5.9.3)
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -5050,6 +5163,10 @@ snapshots:
   '@types/unzipper@0.10.11':
     dependencies:
       '@types/node': 24.10.4
+
+  '@valibot/to-json-schema@1.6.0(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.2.0(typescript@5.9.3)
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
@@ -5920,10 +6037,11 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  convex-helpers@0.1.114(convex@1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1):
+  convex-helpers@0.1.114(@standard-schema/spec@1.1.0)(convex@1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(zod@4.2.1):
     dependencies:
       convex: 1.34.1(@clerk/clerk-react@5.59.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
     optionalDependencies:
+      '@standard-schema/spec': 1.1.0
       react: 19.2.3
       typescript: 5.9.3
       zod: 4.2.1
@@ -6153,6 +6271,8 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  esm-env@1.2.2: {}
 
   esprima@4.0.1: {}
 
@@ -6501,6 +6621,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-rpc-2.0@1.7.1: {}
+
   json5@2.2.3: {}
 
   kleur@3.0.3: {}
@@ -6843,6 +6965,8 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  picoquery@2.5.0: {}
+
   playwright-core@1.57.0: {}
 
   playwright@1.57.0:
@@ -7156,6 +7280,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sqids@0.3.0: {}
+
   stackback@0.0.2: {}
 
   standardwebhooks@1.0.0:
@@ -7303,6 +7429,16 @@ snapshots:
     dependencies:
       tldts-core: 7.0.15
 
+  tmcp@1.19.3(typescript@5.9.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -7418,6 +7554,8 @@ snapshots:
 
   uqr@0.1.2: {}
 
+  uri-template-matcher@1.1.2: {}
+
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -7432,6 +7570,10 @@ snapshots:
       diff: 5.2.0
       kleur: 4.1.5
       sade: 1.8.1
+
+  valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   valid-filename@4.0.0:
     dependencies:

--- a/src/components/features/Dashboard/RecruitmentCard/index.stories.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { mockRecruitments } from "../storyMocks";
 import { RecruitmentCard } from "./index";
@@ -13,16 +14,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Open: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      募集中
+    </Text>
+    <RecruitmentCard recruitment={mockRecruitments[0]} onOpenShiftBoard={() => {}} />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      完了
+    </Text>
+    <RecruitmentCard recruitment={mockRecruitments[1]} onOpenShiftBoard={() => {}} />
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     recruitment: mockRecruitments[0],
-    onOpenShiftBoard: () => {},
-  },
-};
-
-export const Completed: Story = {
-  args: {
-    recruitment: mockRecruitments[1],
     onOpenShiftBoard: () => {},
   },
 };

--- a/src/components/features/Dashboard/StaffListItem/index.stories.tsx
+++ b/src/components/features/Dashboard/StaffListItem/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { mockStaffs } from "../storyMocks";
 import { StaffListItem } from "./index";
@@ -9,29 +9,33 @@ const meta = {
   parameters: {
     layout: "padded",
   },
-  decorators: [
-    (Story) => (
-      <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
-        <Story />
-      </Box>
-    ),
-  ],
 } satisfies Meta<typeof StaffListItem>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Admin: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      管理者
+    </Text>
+    <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
+      <StaffListItem staff={mockStaffs[0]} onEdit={() => {}} onDelete={() => {}} />
+    </Box>
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      スタッフ
+    </Text>
+    <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
+      <StaffListItem staff={mockStaffs[1]} onEdit={() => {}} onDelete={() => {}} />
+    </Box>
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     staff: mockStaffs[0],
-    onEdit: () => {},
-    onDelete: () => {},
-  },
-};
-
-export const Staff: Story = {
-  args: {
-    staff: mockStaffs[1],
     onEdit: () => {},
     onDelete: () => {},
   },

--- a/src/components/features/ShiftBoard/ShiftBoardHeader/index.stories.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardHeader/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ShiftBoardHeader } from "./index";
 
@@ -12,20 +13,39 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Normal: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" px={4} pt={4}>
+      未確定
+    </Text>
+    <ShiftBoardHeader
+      periodLabel="1/20(月)〜1/26(日) のシフト"
+      confirmedAt={null}
+      onConfirm={() => {}}
+      viewMode="daily"
+      onViewModeChange={() => {}}
+    />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" px={4} mt={2}>
+      確定済み
+    </Text>
+    <ShiftBoardHeader
+      periodLabel="1/20(月)〜1/26(日) のシフト"
+      confirmedAt={new Date("2026-03-28T23:15:00")}
+      onConfirm={() => {}}
+      viewMode="overview"
+      onViewModeChange={() => {}}
+    />
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     periodLabel: "1/20(月)〜1/26(日) のシフト",
     confirmedAt: null,
     onConfirm: () => {},
     viewMode: "daily",
     onViewModeChange: () => {},
-  },
-};
-
-export const Confirmed: Story = {
-  args: {
-    ...Normal.args,
-    confirmedAt: new Date("2026-03-28T23:15:00"),
-    viewMode: "overview",
   },
 };

--- a/src/components/features/ShiftBoard/ShiftBoardSPHeader/index.stories.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardSPHeader/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ShiftBoardSPHeader } from "./index";
 
@@ -15,20 +16,39 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Normal: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" px={4} pt={4}>
+      未確定
+    </Text>
+    <ShiftBoardSPHeader
+      periodLabel="1/20(月)〜1/26(日) のシフト"
+      confirmedAt={null}
+      onConfirm={() => {}}
+      viewMode="daily"
+      onViewModeChange={() => {}}
+    />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" px={4} mt={2}>
+      確定済み
+    </Text>
+    <ShiftBoardSPHeader
+      periodLabel="1/20(月)〜1/26(日) のシフト"
+      confirmedAt={new Date("2026-03-28T23:15:00")}
+      onConfirm={() => {}}
+      viewMode="overview"
+      onViewModeChange={() => {}}
+    />
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     periodLabel: "1/20(月)〜1/26(日) のシフト",
     confirmedAt: null,
     onConfirm: () => {},
     viewMode: "daily",
     onViewModeChange: () => {},
-  },
-};
-
-export const Confirmed: Story = {
-  args: {
-    ...Normal.args,
-    confirmedAt: new Date("2026-03-28T23:15:00"),
-    viewMode: "overview",
   },
 };

--- a/src/components/features/StaffSubmit/DayCard/index.stories.tsx
+++ b/src/components/features/StaffSubmit/DayCard/index.stories.tsx
@@ -1,0 +1,122 @@
+import { Flex, Text } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { generateTimeOptions } from "../utils/timeOptions";
+import { DayCard, type DayEntry } from "./index";
+
+const timeOptions = generateTimeOptions("09:00", "22:00");
+const noop = () => {};
+
+const AllVariants = () => (
+  <Flex direction="column" gap={3} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      休み（平日 / 土曜 / 日曜）
+    </Text>
+    <DayCard
+      entry={{ date: "2026-04-07", isWorking: false, startTime: "09:00", endTime: "22:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+    />
+    <DayCard
+      entry={{ date: "2026-04-11", isWorking: false, startTime: "09:00", endTime: "22:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+    />
+    <DayCard
+      entry={{ date: "2026-04-12", isWorking: false, startTime: "09:00", endTime: "22:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+    />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      出勤
+    </Text>
+    <DayCard
+      entry={{ date: "2026-04-08", isWorking: true, startTime: "09:00", endTime: "18:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+    />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      読み取り専用（出勤 / 休み）
+    </Text>
+    <DayCard
+      entry={{ date: "2026-04-07", isWorking: true, startTime: "09:00", endTime: "18:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+      isReadOnly
+    />
+    <DayCard
+      entry={{ date: "2026-04-08", isWorking: false, startTime: "09:00", endTime: "22:00" }}
+      timeOptions={timeOptions}
+      onToggleWorking={noop}
+      onTimeChange={noop}
+      onClear={noop}
+      isReadOnly
+    />
+  </Flex>
+);
+
+const InteractiveDemo = () => {
+  const [entry, setEntry] = useState<DayEntry>({
+    date: "2026-04-07",
+    isWorking: false,
+    startTime: "09:00",
+    endTime: "22:00",
+  });
+
+  return (
+    <div style={{ padding: 16 }}>
+      <DayCard
+        entry={entry}
+        timeOptions={timeOptions}
+        onToggleWorking={() => setEntry((e) => ({ ...e, isWorking: true }))}
+        onTimeChange={(field, value) => setEntry((e) => ({ ...e, [field]: value }))}
+        onClear={() => setEntry((e) => ({ ...e, isWorking: false, startTime: "09:00", endTime: "22:00" }))}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: "features/StaffSubmit/DayCard",
+  component: DayCard,
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof DayCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
+  args: {
+    entry: { date: "2026-04-07", isWorking: false, startTime: "09:00", endTime: "22:00" },
+    timeOptions: [],
+    onToggleWorking: () => {},
+    onTimeChange: () => {},
+    onClear: () => {},
+  },
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
+  args: {
+    entry: { date: "2026-04-07", isWorking: false, startTime: "09:00", endTime: "22:00" },
+    timeOptions: [],
+    onToggleWorking: () => {},
+    onTimeChange: () => {},
+    onClear: () => {},
+  },
+};

--- a/src/components/features/StaffSubmit/DayCard/index.tsx
+++ b/src/components/features/StaffSubmit/DayCard/index.tsx
@@ -1,0 +1,133 @@
+import { Box, Flex, IconButton, Text } from "@chakra-ui/react";
+import { LuX } from "react-icons/lu";
+import { formatDateWithWeekday } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import { Select, type SelectItemType } from "@/src/components/ui/Select";
+import { formatTime, getDateColor } from "../utils/timeOptions";
+
+export type DayEntry = {
+  date: string;
+  isWorking: boolean;
+  startTime: string;
+  endTime: string;
+};
+
+type Props = {
+  entry: DayEntry;
+  timeOptions: SelectItemType[];
+  onToggleWorking: () => void;
+  onTimeChange: (field: "startTime" | "endTime", value: string) => void;
+  onClear: () => void;
+  isReadOnly?: boolean;
+};
+
+export const DayCard = ({ entry, timeOptions, onToggleWorking, onTimeChange, onClear, isReadOnly = false }: Props) => {
+  const dateColor = getDateColor(entry.date);
+  const dateLabel = formatDateWithWeekday(entry.date);
+
+  if (isReadOnly) {
+    return (
+      <Flex
+        w="full"
+        h="48px"
+        px={4}
+        align="center"
+        justify="space-between"
+        bg="white"
+        borderRadius="lg"
+        borderWidth={1}
+        borderColor="border.default"
+      >
+        <Text fontSize="sm" fontWeight="medium" color={dateColor}>
+          {dateLabel}
+        </Text>
+        {entry.isWorking ? (
+          <Text fontSize="sm" fontWeight="medium" color="teal.600">
+            {formatTime(entry.startTime)} 〜 {formatTime(entry.endTime)}
+          </Text>
+        ) : (
+          <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+            休み
+          </Text>
+        )}
+      </Flex>
+    );
+  }
+
+  if (!entry.isWorking) {
+    return (
+      <Flex
+        w="full"
+        h="48px"
+        px={4}
+        align="center"
+        justify="space-between"
+        bg="white"
+        borderRadius="lg"
+        borderWidth={1}
+        borderColor="border.default"
+        cursor="pointer"
+        onClick={onToggleWorking}
+        _hover={{ bg: "gray.50" }}
+      >
+        <Text fontSize="sm" fontWeight="medium" color={dateColor}>
+          {dateLabel}
+        </Text>
+        <Box bg="gray.100" px={2.5} py={0.5} borderRadius="full">
+          <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+            休み
+          </Text>
+        </Box>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      w="full"
+      h="48px"
+      px={2}
+      pl={4}
+      align="center"
+      gap={2}
+      bg="#f0fdfa"
+      borderRadius="lg"
+      borderWidth={1}
+      borderColor="teal.600"
+    >
+      <Text fontSize="sm" fontWeight="medium" color={dateColor} flexShrink={0}>
+        {dateLabel}
+      </Text>
+      <Box flex={1} />
+      <Select
+        items={timeOptions}
+        value={entry.startTime}
+        onChange={(v) => onTimeChange("startTime", v)}
+        placeholder=""
+        size="xs"
+        w="80px"
+      />
+      <Text fontSize="xs" color="fg.muted">
+        〜
+      </Text>
+      <Select
+        items={timeOptions}
+        value={entry.endTime}
+        onChange={(v) => onTimeChange("endTime", v)}
+        placeholder=""
+        size="xs"
+        w="80px"
+      />
+      <IconButton
+        aria-label="休みに戻す"
+        size="xs"
+        variant="outline"
+        borderRadius="full"
+        onClick={onClear}
+        colorPalette="gray"
+        bg="white"
+      >
+        <LuX />
+      </IconButton>
+    </Flex>
+  );
+};

--- a/src/components/features/StaffSubmit/ExpiredSubmitView/index.stories.tsx
+++ b/src/components/features/StaffSubmit/ExpiredSubmitView/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExpiredSubmitView } from "./index";
+
+const meta = {
+  title: "features/StaffSubmit/ExpiredSubmitView",
+  component: ExpiredSubmitView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof ExpiredSubmitView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    shopName: "居酒屋さくら",
+  },
+};

--- a/src/components/features/StaffSubmit/ExpiredSubmitView/index.tsx
+++ b/src/components/features/StaffSubmit/ExpiredSubmitView/index.tsx
@@ -1,0 +1,37 @@
+import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { LuCalendarX } from "react-icons/lu";
+
+type Props = {
+  shopName: string;
+};
+
+export const ExpiredSubmitView = ({ shopName }: Props) => {
+  return (
+    <Flex direction="column" minH="100dvh" bg="gray.50">
+      {/* Header */}
+      <Box bg="teal.600" px={4} pt={3} pb={4}>
+        <Text fontSize="xs" color="white" opacity={0.8}>
+          {shopName}
+        </Text>
+        <Text fontSize="xl" fontWeight="bold" color="white">
+          シフト希望を提出
+        </Text>
+      </Box>
+
+      {/* Content */}
+      <Flex flex={1} align="center" justify="center" bg="white">
+        <VStack gap={4}>
+          <Icon color="fg.subtle" boxSize={12}>
+            <LuCalendarX />
+          </Icon>
+          <Text fontSize="lg" fontWeight="semibold">
+            提出締切を過ぎています
+          </Text>
+          <Text fontSize="sm" color="fg.muted" textAlign="center">
+            シフトの希望がある場合は、{"\n"}お店に直接ご連絡ください。
+          </Text>
+        </VStack>
+      </Flex>
+    </Flex>
+  );
+};

--- a/src/components/features/StaffSubmit/ReadOnlySubmitView/index.stories.tsx
+++ b/src/components/features/StaffSubmit/ReadOnlySubmitView/index.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SubmissionData } from "../SubmitFormView";
+import { ReadOnlySubmitView } from "./index";
+
+const mockData: SubmissionData = {
+  shopName: "居酒屋さくら",
+  staffName: "田中太郎",
+  periodStart: "2026-04-07",
+  periodEnd: "2026-04-13",
+  deadline: "2026-04-04",
+  isBeforeDeadline: false,
+  hasSubmitted: true,
+  existingRequests: [
+    { date: "2026-04-07", startTime: "09:00", endTime: "18:00" },
+    { date: "2026-04-08", startTime: "09:00", endTime: "18:00" },
+    { date: "2026-04-09", startTime: "10:00", endTime: "15:00" },
+    { date: "2026-04-11", startTime: "09:00", endTime: "22:00" },
+  ],
+  timeRange: { startTime: "09:00", endTime: "22:00" },
+};
+
+const meta = {
+  title: "features/StaffSubmit/ReadOnlySubmitView",
+  component: ReadOnlySubmitView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof ReadOnlySubmitView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    data: mockData,
+  },
+};

--- a/src/components/features/StaffSubmit/ReadOnlySubmitView/index.tsx
+++ b/src/components/features/StaffSubmit/ReadOnlySubmitView/index.tsx
@@ -1,0 +1,79 @@
+import { Box, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { useMemo } from "react";
+import { LuInfo } from "react-icons/lu";
+import { getDateRange } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import { DayCard } from "../DayCard";
+import type { SubmissionData } from "../SubmitFormView";
+import { buildEntries, formatPeriodLabel } from "../utils/timeOptions";
+
+type Props = {
+  data: SubmissionData;
+};
+
+export const ReadOnlySubmitView = ({ data }: Props) => {
+  const dates = useMemo(() => getDateRange(data.periodStart, data.periodEnd), [data.periodStart, data.periodEnd]);
+
+  const entries = useMemo(
+    () => buildEntries(dates, data.existingRequests, data.timeRange),
+    [dates, data.existingRequests, data.timeRange],
+  );
+
+  return (
+    <Flex direction="column" minH="100dvh" bg="gray.50">
+      {/* Header */}
+      <Box bg="teal.600" px={4} pt={3} pb={4}>
+        <Text fontSize="xs" color="white" opacity={0.8}>
+          {data.shopName}
+        </Text>
+        <Text fontSize="xl" fontWeight="bold" color="white">
+          シフト希望を提出
+        </Text>
+      </Box>
+
+      {/* Info Banner */}
+      <Flex bg="blue.50" px={4} py={2.5} gap={2} align="center">
+        <Icon color="blue.600" boxSize={4}>
+          <LuInfo />
+        </Icon>
+        <Text fontSize="xs" fontWeight="medium" color="blue.800">
+          提出締切を過ぎたため変更できません
+        </Text>
+      </Flex>
+
+      {/* InfoBar */}
+      <Flex
+        bg="white"
+        px={4}
+        py={3}
+        justify="space-between"
+        align="center"
+        borderBottomWidth={1}
+        borderColor="border.default"
+      >
+        <Text fontSize="sm" fontWeight="semibold">
+          {formatPeriodLabel(data.periodStart, data.periodEnd)}
+        </Text>
+        <Box bg="green.50" px={2.5} py={1} borderRadius="full">
+          <Text fontSize="xs" fontWeight="semibold" color="green.800">
+            提出済み
+          </Text>
+        </Box>
+      </Flex>
+
+      {/* Card List */}
+      <VStack px={4} py={3} gap={2}>
+        {entries.map((entry) => (
+          <DayCard
+            key={entry.date}
+            entry={entry}
+            timeOptions={[]}
+            onToggleWorking={() => {}}
+            onTimeChange={() => {}}
+            onClear={() => {}}
+            isReadOnly
+          />
+        ))}
+      </VStack>
+    </Flex>
+  );
+};

--- a/src/components/features/StaffSubmit/ShiftSubmitPage/index.stories.tsx
+++ b/src/components/features/StaffSubmit/ShiftSubmitPage/index.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SubmissionData } from "../SubmitFormView";
+import { ShiftSubmitPage } from "./index";
+
+const baseData: SubmissionData = {
+  shopName: "居酒屋さくら",
+  staffName: "田中太郎",
+  periodStart: "2026-04-07",
+  periodEnd: "2026-04-13",
+  deadline: "2026-04-04",
+  isBeforeDeadline: true,
+  hasSubmitted: false,
+  existingRequests: [],
+  timeRange: { startTime: "09:00", endTime: "22:00" },
+};
+
+const meta = {
+  title: "features/StaffSubmit/ShiftSubmitPage",
+  component: ShiftSubmitPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof ShiftSubmitPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StateA_Unsubmitted: Story = {
+  args: {
+    data: baseData,
+  },
+};
+
+export const StateB_Submitted: Story = {
+  args: {
+    data: {
+      ...baseData,
+      hasSubmitted: true,
+      existingRequests: [
+        { date: "2026-04-07", startTime: "09:00", endTime: "18:00" },
+        { date: "2026-04-09", startTime: "10:00", endTime: "15:00" },
+        { date: "2026-04-11", startTime: "09:00", endTime: "22:00" },
+      ],
+    },
+  },
+};
+
+export const StateC_SubmittedExpired: Story = {
+  args: {
+    data: {
+      ...baseData,
+      isBeforeDeadline: false,
+      hasSubmitted: true,
+      existingRequests: [
+        { date: "2026-04-07", startTime: "09:00", endTime: "18:00" },
+        { date: "2026-04-08", startTime: "09:00", endTime: "18:00" },
+        { date: "2026-04-09", startTime: "10:00", endTime: "15:00" },
+        { date: "2026-04-11", startTime: "09:00", endTime: "22:00" },
+      ],
+    },
+  },
+};
+
+export const StateD_Expired: Story = {
+  args: {
+    data: {
+      ...baseData,
+      isBeforeDeadline: false,
+      hasSubmitted: false,
+    },
+  },
+};

--- a/src/components/features/StaffSubmit/ShiftSubmitPage/index.tsx
+++ b/src/components/features/StaffSubmit/ShiftSubmitPage/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import type { DayEntry } from "../DayCard";
+import { ExpiredSubmitView } from "../ExpiredSubmitView";
+import { ReadOnlySubmitView } from "../ReadOnlySubmitView";
+import { SubmitCompleteView } from "../SubmitCompleteView";
+import { type SubmissionData, SubmitFormView } from "../SubmitFormView";
+
+type Props = {
+  data: SubmissionData;
+};
+
+export const ShiftSubmitPage = ({ data }: Props) => {
+  const [showCompletion, setShowCompletion] = useState(false);
+  const [submittedEntries, setSubmittedEntries] = useState<DayEntry[] | null>(null);
+
+  // 状態D: 未提出＋締切後
+  if (!data.isBeforeDeadline && !data.hasSubmitted) {
+    return <ExpiredSubmitView shopName={data.shopName} />;
+  }
+
+  // 状態C: 提出済み＋締切後
+  if (!data.isBeforeDeadline && data.hasSubmitted) {
+    return <ReadOnlySubmitView data={data} />;
+  }
+
+  // 画面5: 提出完了
+  if (showCompletion && submittedEntries) {
+    return (
+      <SubmitCompleteView shopName={data.shopName} entries={submittedEntries} onEdit={() => setShowCompletion(false)} />
+    );
+  }
+
+  // 状態A/B: 締切前（編集可能）
+  return (
+    <SubmitFormView
+      data={data}
+      onSubmit={(entries) => {
+        setSubmittedEntries(entries);
+        setShowCompletion(true);
+      }}
+    />
+  );
+};

--- a/src/components/features/StaffSubmit/SubmitCompleteView/index.stories.tsx
+++ b/src/components/features/StaffSubmit/SubmitCompleteView/index.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { DayEntry } from "../DayCard";
+import { SubmitCompleteView } from "./index";
+
+const mockEntries: DayEntry[] = [
+  { date: "2026-04-07", isWorking: true, startTime: "09:00", endTime: "18:00" },
+  { date: "2026-04-08", isWorking: true, startTime: "09:00", endTime: "18:00" },
+  { date: "2026-04-09", isWorking: true, startTime: "10:00", endTime: "15:00" },
+  { date: "2026-04-10", isWorking: false, startTime: "09:00", endTime: "22:00" },
+  { date: "2026-04-11", isWorking: true, startTime: "09:00", endTime: "22:00" },
+  { date: "2026-04-12", isWorking: false, startTime: "09:00", endTime: "22:00" },
+  { date: "2026-04-13", isWorking: false, startTime: "09:00", endTime: "22:00" },
+];
+
+const meta = {
+  title: "features/StaffSubmit/SubmitCompleteView",
+  component: SubmitCompleteView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof SubmitCompleteView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    shopName: "居酒屋さくら",
+    entries: mockEntries,
+    onEdit: () => {},
+  },
+};

--- a/src/components/features/StaffSubmit/SubmitCompleteView/index.tsx
+++ b/src/components/features/StaffSubmit/SubmitCompleteView/index.tsx
@@ -1,0 +1,79 @@
+import { Box, Button, Circle, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { LuCheck } from "react-icons/lu";
+import { formatDateWithWeekday } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import type { DayEntry } from "../DayCard";
+import { formatTime, getDateColor } from "../utils/timeOptions";
+
+type Props = {
+  shopName: string;
+  entries: DayEntry[];
+  onEdit: () => void;
+};
+
+export const SubmitCompleteView = ({ shopName, entries, onEdit }: Props) => {
+  return (
+    <Flex direction="column" minH="100dvh" bg="gray.50">
+      {/* Header */}
+      <Box bg="teal.600" px={4} pt={3} pb={4}>
+        <Text fontSize="xs" color="white" opacity={0.8}>
+          {shopName}
+        </Text>
+        <Text fontSize="xl" fontWeight="bold" color="white">
+          シフト希望を提出
+        </Text>
+      </Box>
+
+      {/* Success Area */}
+      <VStack bg="white" px={4} pt={8} pb={6} gap={2}>
+        <Circle size="56px" bg="teal.600">
+          <Icon color="white" boxSize={7}>
+            <LuCheck />
+          </Icon>
+        </Circle>
+        <Text fontSize="xl" fontWeight="bold">
+          提出しました
+        </Text>
+        <Text fontSize="sm" color="fg.muted">
+          シフトが確定したらメールでお知らせします
+        </Text>
+      </VStack>
+
+      {/* Summary */}
+      <Box px={4} pt={3}>
+        <Box borderRadius="lg" borderWidth={1} borderColor="border.default" bg="white" overflow="hidden">
+          {entries.map((entry, i) => (
+            <Flex
+              key={entry.date}
+              h="40px"
+              px={4}
+              align="center"
+              justify="space-between"
+              borderBottomWidth={i < entries.length - 1 ? 1 : 0}
+              borderColor="border.default"
+            >
+              <Text fontSize="sm" fontWeight="medium" color={getDateColor(entry.date)}>
+                {formatDateWithWeekday(entry.date)}
+              </Text>
+              {entry.isWorking ? (
+                <Text fontSize="sm" fontWeight="medium" color="teal.600">
+                  {formatTime(entry.startTime)} 〜 {formatTime(entry.endTime)}
+                </Text>
+              ) : (
+                <Text fontSize="sm" color="fg.subtle">
+                  休み
+                </Text>
+              )}
+            </Flex>
+          ))}
+        </Box>
+      </Box>
+
+      {/* Edit Button */}
+      <Box px={4} pt={4} pb={6}>
+        <Button w="full" h="48px" variant="outline" borderRadius="lg" fontWeight="semibold" bg="white" onClick={onEdit}>
+          内容を修正する
+        </Button>
+      </Box>
+    </Flex>
+  );
+};

--- a/src/components/features/StaffSubmit/SubmitFormView/index.stories.tsx
+++ b/src/components/features/StaffSubmit/SubmitFormView/index.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { SubmissionData } from "./index";
+import { SubmitFormView } from "./index";
+
+const baseData: SubmissionData = {
+  shopName: "居酒屋さくら",
+  staffName: "田中太郎",
+  periodStart: "2026-04-07",
+  periodEnd: "2026-04-13",
+  deadline: "2026-04-04",
+  isBeforeDeadline: true,
+  hasSubmitted: false,
+  existingRequests: [],
+  timeRange: { startTime: "09:00", endTime: "22:00" },
+};
+
+const submittedData: SubmissionData = {
+  ...baseData,
+  hasSubmitted: true,
+  existingRequests: [
+    { date: "2026-04-07", startTime: "09:00", endTime: "18:00" },
+    { date: "2026-04-09", startTime: "10:00", endTime: "15:00" },
+    { date: "2026-04-11", startTime: "09:00", endTime: "22:00" },
+  ],
+};
+
+const meta = {
+  title: "features/StaffSubmit/SubmitFormView",
+  component: SubmitFormView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+} satisfies Meta<typeof SubmitFormView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unsubmitted: Story = {
+  args: {
+    data: baseData,
+    onSubmit: () => {},
+  },
+};
+
+export const Submitted: Story = {
+  args: {
+    data: submittedData,
+    onSubmit: () => {},
+  },
+};

--- a/src/components/features/StaffSubmit/SubmitFormView/index.tsx
+++ b/src/components/features/StaffSubmit/SubmitFormView/index.tsx
@@ -1,0 +1,133 @@
+import { Box, Button, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { useMemo, useState } from "react";
+import { LuPointer } from "react-icons/lu";
+import { formatDateWithWeekday, getDateRange } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import { DayCard, type DayEntry } from "../DayCard";
+import { buildEntries, formatPeriodLabel, generateTimeOptions } from "../utils/timeOptions";
+
+export type SubmissionData = {
+  shopName: string;
+  staffName: string;
+  periodStart: string;
+  periodEnd: string;
+  deadline: string;
+  isBeforeDeadline: boolean;
+  hasSubmitted: boolean;
+  existingRequests: { date: string; startTime: string; endTime: string }[];
+  timeRange: { startTime: string; endTime: string };
+};
+
+type Props = {
+  data: SubmissionData;
+  onSubmit: (entries: DayEntry[]) => void;
+};
+
+export const SubmitFormView = ({ data, onSubmit }: Props) => {
+  const dates = useMemo(() => getDateRange(data.periodStart, data.periodEnd), [data.periodStart, data.periodEnd]);
+  const timeOptions = useMemo(
+    () => generateTimeOptions(data.timeRange.startTime, data.timeRange.endTime),
+    [data.timeRange.startTime, data.timeRange.endTime],
+  );
+
+  const [entries, setEntries] = useState<DayEntry[]>(() => buildEntries(dates, data.existingRequests, data.timeRange));
+
+  const handleToggleWorking = (date: string) => {
+    setEntries((prev) => prev.map((e) => (e.date === date ? { ...e, isWorking: true } : e)));
+  };
+
+  const handleTimeChange = (date: string, field: "startTime" | "endTime", value: string) => {
+    setEntries((prev) => prev.map((e) => (e.date === date ? { ...e, [field]: value } : e)));
+  };
+
+  const handleClear = (date: string) => {
+    setEntries((prev) =>
+      prev.map((e) =>
+        e.date === date
+          ? { ...e, isWorking: false, startTime: data.timeRange.startTime, endTime: data.timeRange.endTime }
+          : e,
+      ),
+    );
+  };
+
+  const handleSubmit = () => {
+    onSubmit(entries);
+  };
+
+  return (
+    <Flex direction="column" minH="100dvh" bg="gray.50">
+      {/* Header */}
+      <Box bg="teal.600" px={4} pt={3} pb={4}>
+        <Text fontSize="xs" color="white" opacity={0.8}>
+          {data.shopName}
+        </Text>
+        <Text fontSize="xl" fontWeight="bold" color="white">
+          シフト希望を提出
+        </Text>
+      </Box>
+
+      {/* InfoBar */}
+      <Flex
+        bg="white"
+        px={4}
+        py={3}
+        justify="space-between"
+        align="center"
+        borderBottomWidth={1}
+        borderColor="border.default"
+      >
+        <Box>
+          <Text fontSize="sm" fontWeight="semibold">
+            {formatPeriodLabel(data.periodStart, data.periodEnd)}
+          </Text>
+          <Text fontSize="xs" color="fg.muted">
+            提出締切: {formatDateWithWeekday(data.deadline)}
+          </Text>
+        </Box>
+        {data.hasSubmitted ? (
+          <Box bg="green.50" px={2.5} py={1} borderRadius="full">
+            <Text fontSize="xs" fontWeight="semibold" color="green.800">
+              提出済み
+            </Text>
+          </Box>
+        ) : (
+          <Box bg="orange.50" px={2.5} py={1} borderRadius="full">
+            <Text fontSize="xs" fontWeight="semibold" color="orange.800">
+              未提出
+            </Text>
+          </Box>
+        )}
+      </Flex>
+
+      {/* Helper */}
+      <Flex px={4} pt={3} gap={1.5} align="center">
+        <Icon color="fg.subtle" boxSize={3.5}>
+          <LuPointer />
+        </Icon>
+        <Text fontSize="xs" fontWeight="medium" color="fg.muted">
+          出勤する日をタップしてください
+        </Text>
+      </Flex>
+
+      {/* Card List */}
+      <VStack px={4} py={3} gap={2}>
+        {entries.map((entry) => (
+          <DayCard
+            key={entry.date}
+            entry={entry}
+            timeOptions={timeOptions}
+            onToggleWorking={() => handleToggleWorking(entry.date)}
+            onTimeChange={(field, value) => handleTimeChange(entry.date, field, value)}
+            onClear={() => handleClear(entry.date)}
+          />
+        ))}
+      </VStack>
+
+      {/* Submit Button */}
+      <Box px={4} pt={2} pb={6}>
+        <Button w="full" h="48px" colorPalette="teal" borderRadius="lg" fontWeight="semibold" onClick={handleSubmit}>
+          {data.hasSubmitted ? "修正して提出する" : "提出する"}
+        </Button>
+      </Box>
+    </Flex>
+  );
+};

--- a/src/components/features/StaffSubmit/utils/timeOptions.ts
+++ b/src/components/features/StaffSubmit/utils/timeOptions.ts
@@ -1,0 +1,60 @@
+import { formatDateWithWeekday, isSaturday, isSunday } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import type { SelectItemType } from "@/src/components/ui/Select";
+import type { DayEntry } from "../DayCard";
+
+/**
+ * 30分刻みの時間セレクトオプションを生成
+ * @param startTime "HH:MM" 形式（例: "09:00"）
+ * @param endTime "HH:MM" 形式（例: "22:00"）
+ */
+export function generateTimeOptions(startTime: string, endTime: string): SelectItemType[] {
+  const [startH, startM] = startTime.split(":").map(Number);
+  const [endH, endM] = endTime.split(":").map(Number);
+
+  const startMinutes = startH * 60 + startM;
+  const endMinutes = endH * 60 + endM;
+
+  const options: SelectItemType[] = [];
+  for (let m = startMinutes; m <= endMinutes; m += 30) {
+    const h = Math.floor(m / 60);
+    const min = m % 60;
+    const value = `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
+    const label = `${h}:${String(min).padStart(2, "0")}`;
+    options.push({ value, label });
+  }
+
+  return options;
+}
+
+/** "09:00" → "9:00" のように先頭ゼロを除去 */
+export function formatTime(time: string): string {
+  const [h, m] = time.split(":");
+  return `${Number(h)}:${m}`;
+}
+
+/** 日付の曜日に応じた色を返す（日曜: 赤、土曜: 青、平日: デフォルト） */
+export function getDateColor(date: string): string {
+  if (isSunday(date)) return "red.600";
+  if (isSaturday(date)) return "blue.600";
+  return "fg.default";
+}
+
+/** 期間ラベルをフォーマット（例: "4/7(月) 〜 4/13(日)"） */
+export function formatPeriodLabel(start: string, end: string): string {
+  return `${formatDateWithWeekday(start)} 〜 ${formatDateWithWeekday(end)}`;
+}
+
+/** 既存リクエストと日付リストからDayEntry配列を生成 */
+export function buildEntries(
+  dates: string[],
+  existingRequests: { date: string; startTime: string; endTime: string }[],
+  defaultTimeRange: { startTime: string; endTime: string },
+): DayEntry[] {
+  const requestMap = new Map(existingRequests.map((r) => [r.date, r]));
+  return dates.map((date) => {
+    const existing = requestMap.get(date);
+    return existing
+      ? { date, isWorking: true, startTime: existing.startTime, endTime: existing.endTime }
+      : { date, isWorking: false, startTime: defaultTimeRange.startTime, endTime: defaultTimeRange.endTime };
+  });
+}

--- a/src/components/features/StaffView/ExpiredView/index.stories.tsx
+++ b/src/components/features/StaffView/ExpiredView/index.stories.tsx
@@ -1,22 +1,32 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ExpiredView } from "./index";
 
 const meta = {
-  title: "features/StaffView/ExpiredView",
+  title: "Features/StaffView/ExpiredView",
   component: ExpiredView,
 } satisfies Meta<typeof ExpiredView>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithReissueLink: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      再発行リンクあり
+    </Text>
+    <ExpiredView recruitmentId="abc123" />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      再発行リンクなし
+    </Text>
+    <ExpiredView recruitmentId={null} />
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     recruitmentId: "abc123",
-  },
-};
-
-export const WithoutReissueLink: Story = {
-  args: {
-    recruitmentId: null,
   },
 };

--- a/src/components/features/StaffView/ReissueForm/index.stories.tsx
+++ b/src/components/features/StaffView/ReissueForm/index.stories.tsx
@@ -1,8 +1,9 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ReissueForm } from "./index";
 
 const meta = {
-  title: "features/StaffView/ReissueForm",
+  title: "Features/StaffView/ReissueForm",
   component: ReissueForm,
   decorators: [
     (Story) => (
@@ -16,16 +17,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      通常
+    </Text>
+    <ReissueForm onSubmit={() => {}} isSubmitting={false} />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      送信中
+    </Text>
+    <ReissueForm onSubmit={() => {}} isSubmitting={true} />
+  </Flex>
+);
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     onSubmit: () => {},
     isSubmitting: false,
-  },
-};
-
-export const Submitting: Story = {
-  args: {
-    onSubmit: () => {},
-    isSubmitting: true,
   },
 };

--- a/src/components/ui/Empty/index.stories.tsx
+++ b/src/components/ui/Empty/index.stories.tsx
@@ -1,10 +1,10 @@
-import { Button, Icon } from "@chakra-ui/react";
+import { Button, Flex, Icon, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { LuInbox, LuPlus, LuSearch, LuUsers } from "react-icons/lu";
 import { Empty } from ".";
 
 const meta = {
-  title: "ui/Empty",
+  title: "UI/Empty",
   component: Empty,
   args: {
     title: "データがありません",
@@ -13,34 +13,40 @@ const meta = {
 } satisfies Meta<typeof Empty>;
 export default meta;
 
-export const Basic: StoryObj<typeof meta> = {};
+const AllVariants = () => (
+  <Flex direction="column" gap={4} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      基本
+    </Text>
+    <Empty title="データがありません" description="新しいデータを追加してください" />
 
-export const WithIcon: StoryObj<typeof meta> = {
-  args: {
-    icon: LuInbox,
-    title: "受信トレイは空です",
-    description: "新しいメッセージはありません",
-  },
-};
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      アイコン付き
+    </Text>
+    <Empty icon={LuInbox} title="受信トレイは空です" description="新しいメッセージはありません" />
 
-export const WithAction: StoryObj<typeof meta> = {
-  args: {
-    icon: LuUsers,
-    title: "スタッフがいません",
-    description: "スタッフを追加して始めましょう",
-    action: (
-      <Button colorPalette="teal">
-        <Icon as={LuPlus} mr={1} />
-        スタッフを追加
-      </Button>
-    ),
-  },
-};
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      アクション付き
+    </Text>
+    <Empty
+      icon={LuUsers}
+      title="スタッフがいません"
+      description="スタッフを追加して始めましょう"
+      action={
+        <Button colorPalette="teal">
+          <Icon as={LuPlus} mr={1} />
+          スタッフを追加
+        </Button>
+      }
+    />
 
-export const SearchNoResults: StoryObj<typeof meta> = {
-  args: {
-    icon: LuSearch,
-    title: "検索結果が見つかりません",
-    description: "別のキーワードで検索してみてください",
-  },
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      検索結果なし
+    </Text>
+    <Empty icon={LuSearch} title="検索結果が見つかりません" description="別のキーワードで検索してみてください" />
+  </Flex>
+);
+
+export const Variants: StoryObj<typeof meta> = {
+  render: () => <AllVariants />,
 };

--- a/src/components/ui/ErrorBoundary/index.stories.tsx
+++ b/src/components/ui/ErrorBoundary/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ErrorBoundary } from ".";
 
@@ -7,28 +7,40 @@ function ThrowingComponent({ message }: { message: string }): never {
 }
 
 const meta = {
-  title: "ui/ErrorBoundary",
+  title: "UI/ErrorBoundary",
   component: ErrorBoundary,
 } satisfies Meta<typeof ErrorBoundary>;
 export default meta;
 
-export const NoError: StoryObj<typeof meta> = {
+const AllVariants = () => (
+  <Flex direction="column" gap={4} p={4}>
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      エラーなし（正常表示）
+    </Text>
+    <ErrorBoundary fallback={<Text>エラーが発生しました</Text>}>
+      <Text>正常にレンダリングされています</Text>
+    </ErrorBoundary>
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      静的フォールバック
+    </Text>
+    <ErrorBoundary fallback={<Text color="red.500">エラーが発生しました。再度お試しください。</Text>}>
+      <ThrowingComponent message="Test error" />
+    </ErrorBoundary>
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      関数フォールバック（エラーメッセージ表示）
+    </Text>
+    <ErrorBoundary fallback={(error: Error) => <Text color="red.500">エラー: {error.message}</Text>}>
+      <ThrowingComponent message="Something went wrong" />
+    </ErrorBoundary>
+  </Flex>
+);
+
+export const Variants: StoryObj<typeof meta> = {
+  render: () => <AllVariants />,
   args: {
     fallback: <Text>エラーが発生しました</Text>,
     children: <Text>正常にレンダリングされています</Text>,
-  },
-};
-
-export const WithStaticFallback: StoryObj<typeof meta> = {
-  args: {
-    fallback: <Text color="red.500">エラーが発生しました。再度お試しください。</Text>,
-    children: <ThrowingComponent message="Test error" />,
-  },
-};
-
-export const WithRenderFunctionFallback: StoryObj<typeof meta> = {
-  args: {
-    fallback: (error: Error) => <Text color="red.500">エラー: {error.message}</Text>,
-    children: <ThrowingComponent message="Something went wrong" />,
   },
 };

--- a/src/components/ui/Select/index.stories.tsx
+++ b/src/components/ui/Select/index.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { Select, type SelectItemType } from ".";
@@ -17,54 +18,56 @@ const items = [
   { value: "1", label: "選択肢1" },
   { value: "2", label: "選択肢2" },
   { value: "3", label: "選択肢3" },
-] as SelectItemType[];
+] satisfies SelectItemType[];
 
-export const Basic: Story = {
+const AllVariants = () => (
+  <Flex direction="column" gap={3} p={4} minW="240px">
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+      選択済み
+    </Text>
+    <Select items={items} value="1" onChange={() => {}} />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      未選択（プレースホルダー）
+    </Text>
+    <Select items={items} value={undefined} onChange={() => {}} placeholder="選択してください" />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      エラー状態
+    </Text>
+    <Select items={items} value={undefined} onChange={() => {}} invalid placeholder="必須項目です" />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      Portal あり
+    </Text>
+    <Select items={items} value="1" onChange={() => {}} usePortal={true} />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      Portal なし
+    </Text>
+    <Select items={items} value="1" onChange={() => {}} usePortal={false} />
+  </Flex>
+);
+
+const InteractiveDemo = () => {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  return (
+    <div style={{ padding: 16, minWidth: 240 }}>
+      <Select items={items} value={value} onChange={setValue} placeholder="選択してください" />
+    </div>
+  );
+};
+
+export const Variants: Story = {
+  render: () => <AllVariants />,
   args: {
     onChange: () => {},
-  },
-  render: () => {
-    const [value, setValue] = useState<string>("1");
-    return <Select items={items} value={value} onChange={setValue} />;
   },
 };
 
-export const Unselected: Story = {
+export const Interactive: Story = {
+  render: () => <InteractiveDemo />,
   args: {
     onChange: () => {},
-  },
-  render: () => {
-    const [value, setValue] = useState<string | undefined>(undefined);
-    return <Select items={items} value={value} onChange={setValue} placeholder="選択してください" />;
-  },
-};
-
-export const WithError: Story = {
-  args: {
-    onChange: () => {},
-  },
-  render: () => {
-    const [value, setValue] = useState<string | undefined>(undefined);
-    return <Select items={items} value={value} onChange={setValue} invalid={!value} placeholder="必須項目です" />;
-  },
-};
-
-export const WithPortal: Story = {
-  args: {
-    onChange: () => {},
-  },
-  render: () => {
-    const [value, setValue] = useState<string>("1");
-    return <Select items={items} value={value} onChange={setValue} usePortal={true} />;
-  },
-};
-
-export const WithoutPortal: Story = {
-  args: {
-    onChange: () => {},
-  },
-  render: () => {
-    const [value, setValue] = useState<string>("1");
-    return <Select items={items} value={value} onChange={setValue} usePortal={false} />;
   },
 };


### PR DESCRIPTION
## Summary
スタッフ向けシフト提出画面のモックUIを新規作成し、Storybook MCP addon導入とVRTキャプチャ数の削減を行った。

## Changes
- **スタッフシフト提出画面**: pencilデザインをもとに、ShiftSubmitPage / SubmitFormView / ReadOnlySubmitView / SubmitCompleteView / ExpiredSubmitView / DayCard の各コンポーネントとStoriesを作成
- **Storybook MCP addon**: `.mcp.json` の追加と `.storybook/main.ts` への addon 設定
- **VRTキャプチャ削減**: 小コンポーネント（Select, Empty, ErrorBoundary, ExpiredView, ReissueForm, RecruitmentCard, StaffListItem, ShiftBoardHeader, ShiftBoardSPHeader）の複数Storyを Variants パターンに統合（24 → 12 キャプチャ）