### PR TITLE
feat: ダッシュボード改善 / SEO・GTM整備 / UI改善

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -40,6 +40,7 @@ jobs:
         id: playwright
         run: pnpm e2e
         env:
+          TZ: Asia/Tokyo
           VITE_CONVEX_URL: ${{ steps.preview.outputs.PREVIEW_URL }}
           CONVEX_PREVIEW_NAME: ${{ env.CONVEX_PREVIEW_NAME }}
           E2E_CLERK_USER: ${{ vars.E2E_CLERK_USER }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ pnpm e2e e2e/path/to/file.spec.ts                       # 特定E2Eファイル
 - 実装完了後、SubAgentで`pnpm lint`, `pnpm type-check`, `pnpm test` を実行すること（Context消費したくない）
 - `lint`はwarningでも修正すること
 - 上記完了後、SubAgentで`/simplify`を実行してリファクタを行うこと（Context消費したくない）
+- 次に`/review`を実行して、レビュー結果を要修正、不要で分けて提示してください。最終的にどこまで修正するかはこちらで決めます。
 
 ### フロントエンド（UIあり）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,8 @@ pnpm e2e e2e/path/to/file.spec.ts                       # 特定E2Eファイル
 
 - 実装完了後、SubAgentで`pnpm lint`, `pnpm type-check`, `pnpm test` を実行すること（Context消費したくない）
 - `lint`はwarningでも修正すること
+- 次に`/review`を実行して、レビュー結果を要修正、不要で分けて提示してください。
 - 上記完了後、SubAgentで`/simplify`を実行してリファクタを行うこと（Context消費したくない）
-- 次に`/review`を実行して、レビュー結果を要修正、不要で分けて提示してください。最終的にどこまで修正するかはこちらで決めます。
 
 ### フロントエンド（UIあり）
 

--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -3,95 +3,41 @@ import { describe, expect, it } from "vitest";
 import { api } from "../_generated/api";
 import { modules, schema } from "../_test/setup.test-helper";
 
+const PAGINATION_FIRST_PAGE = { paginationOpts: { numItems: 10, cursor: null } };
+
 describe("dashboard/queries", () => {
-  describe("getDashboardData", () => {
+  describe("getDashboardShop", () => {
     it("未認証の場合 null を返す", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.query(api.dashboard.queries.getDashboardData, {});
+      const result = await t.query(api.dashboard.queries.getDashboardShop, {});
       expect(result).toBeNull();
     });
 
-    it("認証済みだが店舗未登録の場合 shop: null を返す", async () => {
+    it("認証済みだが店舗未登録の場合 null を返す", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardData, {});
-      expect(result).toEqual({ shop: null, recruitments: [], staffs: [] });
+      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardShop, {});
+      expect(result).toBeNull();
     });
 
-    it("店舗登録済みの場合、店舗情報・募集・スタッフを返す", async () => {
+    it("店舗登録済みの場合、店舗情報を返す", async () => {
       const t = convexTest(schema, modules);
-
-      // データセットアップ
-      const shopId = await t.run(async (ctx) => {
-        await ctx.db.insert("users", {
-          clerkId: "user_123",
-          name: "テスト管理者",
-          email: "test@example.com",
-          role: "manager",
-          isDeleted: false,
-        });
-        const id = await ctx.db.insert("shops", {
+      await t.run(async (ctx) => {
+        await ctx.db.insert("shops", {
           name: "テスト店舗",
           shiftStartTime: "09:00",
           shiftEndTime: "22:00",
           ownerId: "user_123",
           isDeleted: false,
         });
-        return id;
       });
 
-      await t.run(async (ctx) => {
-        await ctx.db.insert("staffs", {
-          shopId,
-          name: "田中太郎",
-          email: "tanaka@example.com",
-          isDeleted: false,
-        });
-        await ctx.db.insert("staffs", {
-          shopId,
-          name: "削除済みスタッフ",
-          email: "deleted@example.com",
-          isDeleted: true,
-        });
-        await ctx.db.insert("recruitments", {
-          shopId,
-          periodStart: "2026-04-01",
-          periodEnd: "2026-04-07",
-          deadline: "2026-03-28",
-          status: "open",
-          isDeleted: false,
-        });
-        await ctx.db.insert("recruitments", {
-          shopId,
-          periodStart: "2026-03-01",
-          periodEnd: "2026-03-07",
-          deadline: "2026-02-25",
-          status: "confirmed",
-          isDeleted: true,
-        });
-      });
-
-      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardData, {});
-
-      expect(result?.shop).toEqual({ name: "テスト店舗", shiftStartTime: "09:00", shiftEndTime: "22:00" });
-      expect(result?.recruitments).toHaveLength(1);
-      expect(result?.recruitments[0].status).toBe("open");
-      expect(result?.recruitments[0].responseCount).toBe(0);
-      expect(result?.recruitments[0].totalStaffCount).toBe(1);
-      expect(result?.staffs).toHaveLength(1);
-      expect(result?.staffs[0].name).toBe("田中太郎");
+      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardShop, {});
+      expect(result).toEqual({ name: "テスト店舗", shiftStartTime: "09:00", shiftEndTime: "22:00" });
     });
 
-    it("論理削除された店舗は shop: null を返す", async () => {
+    it("論理削除された店舗は null を返す", async () => {
       const t = convexTest(schema, modules);
-
       await t.run(async (ctx) => {
-        await ctx.db.insert("users", {
-          clerkId: "user_deleted",
-          name: "削除店舗",
-          email: "del@example.com",
-          role: "manager",
-          isDeleted: false,
-        });
         await ctx.db.insert("shops", {
           name: "削除済み店舗",
           shiftStartTime: "09:00",
@@ -103,13 +49,92 @@ describe("dashboard/queries", () => {
 
       const result = await t
         .withIdentity({ subject: "user_deleted" })
-        .query(api.dashboard.queries.getDashboardData, {});
-      expect(result).toEqual({ shop: null, recruitments: [], staffs: [] });
+        .query(api.dashboard.queries.getDashboardShop, {});
+      expect(result).toBeNull();
+    });
+
+    it("返り値に不要なフィールドが含まれない", async () => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("shops", {
+          name: "店舗",
+          shiftStartTime: "09:00",
+          shiftEndTime: "22:00",
+          ownerId: "user_fields",
+          isDeleted: false,
+        });
+      });
+
+      const result = await t.withIdentity({ subject: "user_fields" }).query(api.dashboard.queries.getDashboardShop, {});
+      expect(Object.keys(result ?? {}).sort()).toEqual(["name", "shiftEndTime", "shiftStartTime"]);
+    });
+  });
+
+  describe("getDashboardRecruitments", () => {
+    it("未認証の場合、エラーをthrowする", async () => {
+      const t = convexTest(schema, modules);
+      await expect(t.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE)).rejects.toThrow(
+        "Unauthenticated",
+      );
+    });
+
+    it("認証済みだが店舗未登録の場合、空ページを返す", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t
+        .withIdentity({ subject: "user_no_shop" })
+        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+      expect(result.page).toEqual([]);
+      expect(result.isDone).toBe(true);
+    });
+
+    it("募集をページネーションで返す", async () => {
+      const t = convexTest(schema, modules);
+      const shopId = await t.run(async (ctx) => {
+        await ctx.db.insert("users", {
+          clerkId: "user_rec",
+          name: "管理者",
+          email: "m@example.com",
+          role: "manager",
+          isDeleted: false,
+        });
+        const id = await ctx.db.insert("shops", {
+          name: "店舗",
+          shiftStartTime: "09:00",
+          shiftEndTime: "22:00",
+          ownerId: "user_rec",
+          isDeleted: false,
+        });
+        return id;
+      });
+
+      await t.run(async (ctx) => {
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "スタッフ1",
+          email: "s1@example.com",
+          isDeleted: false,
+        });
+        await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-04-01",
+          periodEnd: "2026-04-07",
+          deadline: "2026-03-28",
+          status: "open",
+          isDeleted: false,
+        });
+      });
+
+      const result = await t
+        .withIdentity({ subject: "user_rec" })
+        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+
+      expect(result.page).toHaveLength(1);
+      expect(result.page[0].status).toBe("open");
+      expect(result.page[0].responseCount).toBe(0);
     });
 
     it("responseCount は shiftRequests の staffId ユニーク数を返す", async () => {
       const t = convexTest(schema, modules);
-
       await t.run(async (ctx) => {
         await ctx.db.insert("users", {
           clerkId: "user_rc",
@@ -145,7 +170,6 @@ describe("dashboard/queries", () => {
           status: "open",
           isDeleted: false,
         });
-        // staff1 が2日分提出
         await ctx.db.insert("shiftRequests", {
           recruitmentId,
           staffId: staff1,
@@ -160,7 +184,6 @@ describe("dashboard/queries", () => {
           startTime: "09:00",
           endTime: "17:00",
         });
-        // staff2 が1日分提出
         await ctx.db.insert("shiftRequests", {
           recruitmentId,
           staffId: staff2,
@@ -170,17 +193,35 @@ describe("dashboard/queries", () => {
         });
       });
 
-      const result = await t.withIdentity({ subject: "user_rc" }).query(api.dashboard.queries.getDashboardData, {});
-      expect(result?.recruitments[0].responseCount).toBe(2);
-      expect(result?.recruitments[0].totalStaffCount).toBe(2);
+      const result = await t
+        .withIdentity({ subject: "user_rc" })
+        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+      expect(result.page[0].responseCount).toBe(2);
+    });
+  });
+
+  describe("getDashboardStaffs", () => {
+    it("未認証の場合、エラーをthrowする", async () => {
+      const t = convexTest(schema, modules);
+      await expect(t.query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE)).rejects.toThrow(
+        "Unauthenticated",
+      );
     });
 
-    it("返り値に不要なフィールドが含まれない", async () => {
+    it("認証済みだが店舗未登録の場合、空ページを返す", async () => {
       const t = convexTest(schema, modules);
+      const result = await t
+        .withIdentity({ subject: "user_no_shop" })
+        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+      expect(result.page).toEqual([]);
+      expect(result.isDone).toBe(true);
+    });
 
+    it("スタッフをページネーションで返し、削除済みは除外される", async () => {
+      const t = convexTest(schema, modules);
       await t.run(async (ctx) => {
         await ctx.db.insert("users", {
-          clerkId: "user_fields",
+          clerkId: "user_staff",
           name: "管理者",
           email: "m@example.com",
           role: "manager",
@@ -190,7 +231,46 @@ describe("dashboard/queries", () => {
           name: "店舗",
           shiftStartTime: "09:00",
           shiftEndTime: "22:00",
-          ownerId: "user_fields",
+          ownerId: "user_staff",
+          isDeleted: false,
+        });
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "田中太郎",
+          email: "tanaka@example.com",
+          isDeleted: false,
+        });
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "削除済みスタッフ",
+          email: "deleted@example.com",
+          isDeleted: true,
+        });
+      });
+
+      const result = await t
+        .withIdentity({ subject: "user_staff" })
+        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+
+      expect(result.page).toHaveLength(1);
+      expect(result.page[0].name).toBe("田中太郎");
+    });
+
+    it("返り値に不要なフィールドが含まれない", async () => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        await ctx.db.insert("users", {
+          clerkId: "user_sf",
+          name: "管理者",
+          email: "m@example.com",
+          role: "manager",
+          isDeleted: false,
+        });
+        const shopId = await ctx.db.insert("shops", {
+          name: "店舗",
+          shiftStartTime: "09:00",
+          shiftEndTime: "22:00",
+          ownerId: "user_sf",
           isDeleted: false,
         });
         await ctx.db.insert("staffs", {
@@ -201,12 +281,10 @@ describe("dashboard/queries", () => {
         });
       });
 
-      const result = await t.withIdentity({ subject: "user_fields" }).query(api.dashboard.queries.getDashboardData, {});
-      expect(result).not.toBeNull();
-      // shop に ownerId, isDeleted 等の内部フィールドが漏れていないこと
-      expect(Object.keys(result?.shop ?? {}).sort()).toEqual(["name", "shiftEndTime", "shiftStartTime"]);
-      // staffs に shopId, isDeleted が漏れていないこと
-      expect(Object.keys(result?.staffs[0] ?? {}).sort()).toEqual(["_id", "email", "isOwner", "name"]);
+      const result = await t
+        .withIdentity({ subject: "user_sf" })
+        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+      expect(Object.keys(result.page[0]).sort()).toEqual(["_id", "email", "isOwner", "name"]);
     });
   });
 

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -1,41 +1,57 @@
+import type { GenericDatabaseReader } from "convex/server";
+import { paginationOptsValidator } from "convex/server";
+import { ConvexError } from "convex/values";
+import type { DataModel } from "../_generated/dataModel";
 import { authenticatedQuery } from "../_lib/functions";
 
-const MAX_RECRUITMENTS = 50;
-const MAX_STAFFS = 200;
 const MAX_SHIFT_REQUESTS = 1000;
 
-export const getDashboardData = authenticatedQuery({
+// shop未登録のsetup中に paginated query が走ってもエラーログを出さないための空結果
+const EMPTY_PAGE = { page: [], isDone: true, continueCursor: "" } as {
+  page: never[];
+  isDone: boolean;
+  continueCursor: string;
+};
+
+async function getOwnerShop(ctx: { db: GenericDatabaseReader<DataModel>; identity: { subject: string } | null }) {
+  if (!ctx.identity) return null;
+  const subject = ctx.identity.subject;
+  const shop = await ctx.db
+    .query("shops")
+    .withIndex("by_ownerId", (q) => q.eq("ownerId", subject))
+    .first();
+  return shop && !shop.isDeleted ? shop : null;
+}
+
+export const getDashboardShop = authenticatedQuery({
   args: {},
   handler: async (ctx) => {
-    const { identity } = ctx;
-    if (!identity) return null;
+    const shop = await getOwnerShop(ctx);
+    if (!shop) return null;
 
-    const shop = await ctx.db
-      .query("shops")
-      .withIndex("by_ownerId", (q) => q.eq("ownerId", identity.subject))
-      .first();
+    return {
+      name: shop.name,
+      shiftStartTime: shop.shiftStartTime,
+      shiftEndTime: shop.shiftEndTime,
+    };
+  },
+});
 
-    if (!shop || shop.isDeleted) {
-      return { shop: null, recruitments: [], staffs: [] };
-    }
+export const getDashboardRecruitments = authenticatedQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    if (!ctx.identity) throw new ConvexError("Unauthenticated");
+    const shop = await getOwnerShop(ctx);
+    if (!shop) return EMPTY_PAGE;
 
-    const [allRecruitments, allStaffs] = await Promise.all([
-      ctx.db
-        .query("recruitments")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shop._id))
-        .order("desc")
-        .take(MAX_RECRUITMENTS),
-      ctx.db
-        .query("staffs")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shop._id))
-        .take(MAX_STAFFS),
-    ]);
-    const recruitments = allRecruitments.filter((r) => !r.isDeleted);
-    const staffs = allStaffs.filter((s) => !s.isDeleted);
-    const totalStaffCount = staffs.length;
+    const paginatedResult = await ctx.db
+      .query("recruitments")
+      .withIndex("by_shopId", (q) => q.eq("shopId", shop._id))
+      .order("desc")
+      .paginate(args.paginationOpts);
 
-    const recruitmentsWithCounts = await Promise.all(
-      recruitments.map(async (r) => {
+    const page = await Promise.all(
+      paginatedResult.page.map(async (r) => {
         const requests = await ctx.db
           .query("shiftRequests")
           .withIndex("by_recruitmentId", (q) => q.eq("recruitmentId", r._id))
@@ -48,19 +64,39 @@ export const getDashboardData = authenticatedQuery({
           deadline: r.deadline,
           status: r.status,
           responseCount: uniqueStaffIds.size,
-          totalStaffCount,
         };
       }),
     );
 
     return {
-      shop: {
-        name: shop.name,
-        shiftStartTime: shop.shiftStartTime,
-        shiftEndTime: shop.shiftEndTime,
-      },
-      recruitments: recruitmentsWithCounts,
-      staffs: staffs.map((s) => ({ _id: s._id, name: s.name, email: s.email, isOwner: s.userId === ctx.user?._id })),
+      ...paginatedResult,
+      page,
+    };
+  },
+});
+
+export const getDashboardStaffs = authenticatedQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, args) => {
+    if (!ctx.identity) throw new ConvexError("Unauthenticated");
+    const shop = await getOwnerShop(ctx);
+    if (!shop) return EMPTY_PAGE;
+
+    const paginatedResult = await ctx.db
+      .query("staffs")
+      .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shop._id).eq("isDeleted", false))
+      .paginate(args.paginationOpts);
+
+    const page = paginatedResult.page.map((s) => ({
+      _id: s._id,
+      name: s.name,
+      email: s.email,
+      isOwner: s.userId === ctx.user?._id,
+    }));
+
+    return {
+      ...paginatedResult,
+      page,
     };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,7 @@ const schema = defineSchema({
     isDeleted: v.boolean(),
   })
     .index("by_shopId", ["shopId"])
+    .index("by_shopId_isDeleted", ["shopId", "isDeleted"])
     .index("by_email", ["email"]),
 
   // ========================================

--- a/convex/staff/mutations.ts
+++ b/convex/staff/mutations.ts
@@ -52,10 +52,12 @@ export const editStaff = managerMutation({
       }
     }
 
-    await ctx.db.patch(args.staffId, {
-      name: args.name.trim(),
-      email: trimmedEmail,
-    });
+    const trimmedName = args.name.trim();
+    const patches = [ctx.db.patch(args.staffId, { name: trimmedName, email: trimmedEmail })];
+    if (staff.userId === ctx.user._id) {
+      patches.push(ctx.db.patch(ctx.user._id, { name: trimmedName, email: trimmedEmail }));
+    }
+    await Promise.all(patches);
   },
 });
 

--- a/convex/testing.ts
+++ b/convex/testing.ts
@@ -79,6 +79,50 @@ export const seedShiftData = internalMutation({
 });
 
 /**
+ * E2Eテスト用：ページネーション検証データをセットアップ
+ * completeSetup でshop/user作成済み前提。staffs 12人 + recruitments 8件を投入
+ */
+export const seedPaginationTestData = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const shop = await ctx.db.query("shops").order("desc").first();
+    if (!shop) throw new Error("No shop found. Run completeSetup first.");
+
+    // スタッフ12人を追加
+    for (let i = 1; i <= 12; i++) {
+      await ctx.db.insert("staffs", {
+        shopId: shop._id,
+        name: `スタッフ${String(i).padStart(2, "0")}`,
+        email: `staff${i}@example.com`,
+        isDeleted: false,
+      });
+    }
+
+    // シフト募集8件を作成（1週間ずつずらす）
+    const baseDate = new Date("2026-05-04"); // 日曜始まり
+    for (let i = 0; i < 8; i++) {
+      const start = new Date(baseDate);
+      start.setDate(start.getDate() + i * 7);
+      const end = new Date(start);
+      end.setDate(end.getDate() + 6);
+      const deadline = new Date(start);
+      deadline.setDate(deadline.getDate() - 1);
+
+      await ctx.db.insert("recruitments", {
+        shopId: shop._id,
+        periodStart: start.toISOString().slice(0, 10),
+        periodEnd: end.toISOString().slice(0, 10),
+        deadline: deadline.toISOString().slice(0, 10),
+        status: "open",
+        isDeleted: false,
+      });
+    }
+
+    return { staffsInserted: 12, recruitmentsInserted: 8 };
+  },
+});
+
+/**
  * 探索的テスト用：シフト提出画面のテストデータを一括セットアップ
  * shop + staff + recruitment + magicLink + session を作成し、sessionTokenを返す
  */

--- a/design/dashboard.pen
+++ b/design/dashboard.pen
@@ -512,7 +512,7 @@
                                   "id": "5F4k8",
                                   "name": "card1BadgeText",
                                   "fill": "$i:teal/fg",
-                                  "content": "収集・編集中",
+                                  "content": "収集中",
                                   "fontFamily": "Inter",
                                   "fontSize": "$fontSize/xs",
                                   "fontWeight": "500"

--- a/design/dashboard.pen
+++ b/design/dashboard.pen
@@ -701,6 +701,47 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WnPm5",
+                  "name": "LoadMoreButton",
+                  "width": "fill_container",
+                  "cornerRadius": "$radii/md",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border/default"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "1FVzd",
+                      "name": "pcLoadMoreIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "$fg/muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "TLcfJ",
+                      "name": "pcLoadMoreText",
+                      "fill": "$fg/muted",
+                      "content": "もっと見る",
+                      "fontFamily": "Inter",
+                      "fontSize": "$fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
                 }
               ]
             },
@@ -1081,6 +1122,47 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AUacf",
+                  "name": "ShowAllButton",
+                  "width": "fill_container",
+                  "cornerRadius": "$radii/md",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border/default"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "OkznT",
+                      "name": "pcShowAllIcon",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "chevrons-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "$fg/muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XEnZ6",
+                      "name": "pcShowAllText",
+                      "fill": "$fg/muted",
+                      "content": "すべて表示",
+                      "fontFamily": "Inter",
+                      "fontSize": "$fontSize/sm",
+                      "fontWeight": "500"
+                    }
+                  ]
                 }
               ]
             }
@@ -1092,7 +1174,7 @@
       "type": "frame",
       "id": "IdakJ",
       "x": -12,
-      "y": 781,
+      "y": 1035,
       "name": "Dashboard/CreateRecruitmentModal",
       "width": 480,
       "height": 360,
@@ -1805,6 +1887,47 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JOUpM",
+                  "name": "LoadMoreButton",
+                  "width": "fill_container",
+                  "cornerRadius": "$radii/md",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border/default"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "u5Zm5",
+                      "name": "spLoadMoreIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "$fg/muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w9WP4",
+                      "name": "spLoadMoreText",
+                      "fill": "$fg/muted",
+                      "content": "もっと見る",
+                      "fontFamily": "Inter",
+                      "fontSize": "$fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
                 }
               ]
             },
@@ -2186,6 +2309,47 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wIG6I",
+                  "name": "ShowAllButton",
+                  "width": "fill_container",
+                  "cornerRadius": "$radii/md",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "$border/default"
+                  },
+                  "gap": 6,
+                  "padding": [
+                    10,
+                    0
+                  ],
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "ZiLR5",
+                      "name": "spShowAllIcon",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevrons-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "$fg/muted"
+                    },
+                    {
+                      "type": "text",
+                      "id": "9ldt6",
+                      "name": "spShowAllText",
+                      "fill": "$fg/muted",
+                      "content": "すべて表示",
+                      "fontFamily": "Inter",
+                      "fontSize": "$fontSize/xs",
+                      "fontWeight": "500"
+                    }
+                  ]
                 }
               ]
             }
@@ -2457,7 +2621,7 @@
       "type": "frame",
       "id": "3iRDC",
       "x": 3085,
-      "y": 900,
+      "y": 1084,
       "name": "Dashboard/CreateRecruitmentSheet",
       "width": 390,
       "height": 500,

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -67,7 +67,13 @@ export class DashboardPage {
 
   async openShiftBoard() {
     await this.page.getByRole("button", { name: "シフトを編集する" }).click();
-    await this.page.waitForURL(/\/shiftboard\//);
+    const warningDialog = this.page.getByRole("alertdialog", { name: "シフト希望がまだ変わるかも" });
+    const navigated = this.page.waitForURL(/\/shiftboard\//);
+    const dialogAppeared = warningDialog.waitFor({ state: "visible" }).then(() => true);
+    if (await Promise.race([dialogAppeared, navigated.then(() => false)])) {
+      await warningDialog.getByRole("button", { name: "編集画面へ進む" }).click();
+      await navigated;
+    }
   }
 
   async expectStaffSectionVisible() {
@@ -107,6 +113,19 @@ export class DashboardPage {
 
   async expectStaffNotVisible(name: string) {
     await expect(this.page.getByText(name)).not.toBeVisible();
+  }
+
+  async openUserMenu() {
+    await this.page.getByRole("button", { name: "ユーザーメニュー" }).click();
+  }
+
+  async expectUserMenuInfo(name: string, email: string) {
+    await this.openUserMenu();
+    const menu = this.page.getByRole("menu");
+    await expect(menu.getByText(name)).toBeVisible();
+    await expect(menu.getByText(email)).toBeVisible();
+    // メニューを閉じる
+    await this.page.keyboard.press("Escape");
   }
 
   async expectRecruitmentCardVisible() {

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -48,7 +48,8 @@ export class DashboardPage {
     }
 
     await this.page.getByRole("dialog").getByRole("button", { name: "登録する" }).click();
-    await expect(this.page.getByText("スタッフを追加しました")).toBeVisible();
+    await expect(this.page.getByText("スタッフを追加しました").first()).toBeVisible();
+    await expect(this.page.getByText("スタッフを追加しました").first()).not.toBeVisible();
   }
 
   async createRecruitment(data: { periodStart: string; periodEnd: string; deadline: string }) {
@@ -62,7 +63,8 @@ export class DashboardPage {
     await dateInputs.nth(2).fill(data.deadline);
 
     await this.page.getByRole("dialog").getByRole("button", { name: "作成する" }).click();
-    await expect(this.page.getByText("シフトを作成しました")).toBeVisible();
+    await expect(this.page.getByText("シフトを作成しました").first()).toBeVisible();
+    await expect(this.page.getByText("シフトを作成しました").first()).not.toBeVisible();
   }
 
   async openShiftBoard() {
@@ -158,6 +160,42 @@ export class DashboardPage {
 
   async expectShopTimeRange(timeRange: string) {
     await expect(this.page.getByText(timeRange)).toBeVisible();
+  }
+
+  // ページネーション関連
+  async clickLoadMoreRecruitments() {
+    await this.page.getByRole("button", { name: "もっと見る" }).click();
+  }
+
+  async clickShowAllStaffs() {
+    await this.page.getByRole("button", { name: "すべて表示" }).click();
+  }
+
+  async expectRecruitmentCardCount(count: number) {
+    await expect(this.page.getByRole("button", { name: "シフトを編集する" })).toHaveCount(count);
+  }
+
+  async expectStaffRowCount(count: number) {
+    const staffSection = this.page
+      .getByRole("heading", { name: "スタッフ", exact: true })
+      .locator("xpath=ancestor::*[4]");
+    await expect(staffSection.getByRole("button", { name: "メニュー" })).toHaveCount(count);
+  }
+
+  async expectLoadMoreRecruitmentVisible() {
+    await expect(this.page.getByRole("button", { name: "もっと見る" })).toBeVisible();
+  }
+
+  async expectLoadMoreRecruitmentNotVisible() {
+    await expect(this.page.getByRole("button", { name: "もっと見る" })).not.toBeVisible();
+  }
+
+  async expectShowAllStaffsVisible() {
+    await expect(this.page.getByRole("button", { name: "すべて表示" })).toBeVisible();
+  }
+
+  async expectShowAllStaffsNotVisible() {
+    await expect(this.page.getByRole("button", { name: "すべて表示" })).not.toBeVisible();
   }
 
   private async openStaffMenu(staffName: string) {

--- a/e2e/scenarios/dashboard-pagination.test.ts
+++ b/e2e/scenarios/dashboard-pagination.test.ts
@@ -1,0 +1,60 @@
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { test } from "@playwright/test";
+import { convexRun } from "../helpers/convex";
+import { DashboardPage } from "../pages/DashboardPage";
+
+test.describe("ダッシュボードのページネーション", () => {
+  test.setTimeout(120_000);
+
+  let dashboard: DashboardPage;
+
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page });
+    dashboard = new DashboardPage(page);
+  });
+
+  test("もっと見る・すべて表示でデータが段階的に表示される", async () => {
+    await test.step("Step 0: データ準備", async () => {
+      convexRun("testing:clearAllTables");
+
+      // UI経由でshop + user作成（Clerkのsubjectと自動的に紐付く）
+      await dashboard.goto();
+      await dashboard.completeSetup({
+        shopName: "ページネーションテスト店舗",
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+        ownerName: "テスト管理者",
+        ownerEmail: "admin@example.com",
+      });
+      await dashboard.expectSetupComplete();
+
+      // DB直接投入: staffs 12人 + recruitments 8件
+      convexRun("testing:seedPaginationTestData");
+    });
+
+    await test.step("Step 1: シフトの「もっと見る」で3件ずつ追加表示される", async () => {
+      await dashboard.goto();
+
+      await dashboard.expectRecruitmentCardCount(3);
+      await dashboard.expectLoadMoreRecruitmentVisible();
+
+      await dashboard.clickLoadMoreRecruitments();
+      await dashboard.expectRecruitmentCardCount(6);
+      await dashboard.expectLoadMoreRecruitmentVisible();
+
+      await dashboard.clickLoadMoreRecruitments();
+      await dashboard.expectRecruitmentCardCount(8);
+      await dashboard.expectLoadMoreRecruitmentNotVisible();
+    });
+
+    await test.step("Step 2: スタッフの「すべて表示」で全員表示される", async () => {
+      // オーナー（completeSetupで作成）+ 12人 = 13人、初期表示10人
+      await dashboard.expectStaffRowCount(10);
+      await dashboard.expectShowAllStaffsVisible();
+
+      await dashboard.clickShowAllStaffs();
+      await dashboard.expectStaffRowCount(13);
+      await dashboard.expectShowAllStaffsNotVisible();
+    });
+  });
+});

--- a/e2e/scenarios/first-shift-delivery.test.ts
+++ b/e2e/scenarios/first-shift-delivery.test.ts
@@ -73,6 +73,14 @@ test.describe("田中さんの初めてのシフト確定", () => {
       await dashboard.expectStaffVisible("鈴木花子（編集済）");
     });
 
+    await test.step("Step 2.55: 自分のスタッフ情報を編集するとアバターに反映される", async () => {
+      await dashboard.editStaff("田中太郎", {
+        name: "田中太郎",
+        email: "tanaka-changed@example.com",
+      });
+      await dashboard.expectUserMenuInfo("田中太郎", "tanaka-changed@example.com");
+    });
+
     await test.step("Step 2.6: スタッフを削除する", async () => {
       await dashboard.addStaffs([{ name: "削除テスト", email: "delete-test@example.com" }]);
       await dashboard.expectStaffVisible("削除テスト");

--- a/index.html
+++ b/index.html
@@ -10,14 +10,20 @@
     />
     <link rel="canonical" href="https://shiftori.app" />
     <meta name="theme-color" content="#000000" />
-    <link rel="icon" href="/favicon.ico" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦜</text></svg>"
+    />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
 
     <!-- OGP -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="シフトリ" />
-    <meta property="og:title" content="シフトリ | 少人数のお店のシフト管理をもっとラクに" />
+    <meta
+      property="og:title"
+      content="シフトリ | 少人数のお店のシフト管理をもっとラクに"
+    />
     <meta
       property="og:description"
       content="少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール"
@@ -28,7 +34,10 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="シフトリ | 少人数のお店のシフト管理をもっとラクに" />
+    <meta
+      name="twitter:title"
+      content="シフトリ | 少人数のお店のシフト管理をもっとラクに"
+    />
     <meta
       name="twitter:description"
       content="少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール"

--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦜</text></svg>" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="シフトリ - スタッフシフト管理"
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦜</text></svg>"
     />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="シフトリ - スタッフシフト管理" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>シフトリ</title>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,55 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="icon"
-      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦜</text></svg>"
+    <title>シフトリ | 少人数のお店のシフト管理をもっとラクに</title>
+    <meta
+      name="description"
+      content="少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール"
     />
+    <link rel="canonical" href="https://shiftori.app" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="シフトリ - スタッフシフト管理" />
+    <link rel="icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>シフトリ</title>
+
+    <!-- OGP -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="シフトリ" />
+    <meta property="og:title" content="シフトリ | 少人数のお店のシフト管理をもっとラクに" />
+    <meta
+      property="og:description"
+      content="少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール"
+    />
+    <meta property="og:url" content="https://shiftori.app" />
+    <meta property="og:image" content="https://shiftori.app/og-image.png" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="シフトリ | 少人数のお店のシフト管理をもっとラクに" />
+    <meta
+      name="twitter:description"
+      content="少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール"
+    />
+    <meta name="twitter:image" content="https://shiftori.app/og-image.png" />
+
+    <!-- JSON-LD -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "シフトリ",
+        "description": "少人数のお店のシフト作成をもっとラクに リンクを送るだけで希望シフトを収集 スタッフのアカウント登録も不要 無料ではじめられるシフト管理ツール",
+        "url": "https://shiftori.app",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Web",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,9 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: "http://localhost:3000",
 
+    /* ローカルはサーバー起動済みで速いため短く（CIはPlaywrightデフォルト30sを使用） */
+    ...(process.env.CI ? {} : { timeout: 5_000 }),
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,6 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /dashboard
+Disallow: /shiftboard
+Allow: /
+
+Sitemap: https://shiftori.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://shiftori.app</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://shiftori.app/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://shiftori.app/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/src/components/features/Dashboard/DashboardContent/index.stories.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.stories.tsx
@@ -17,7 +17,11 @@ export const Normal: Story = {
   args: {
     shop: { name: "居酒屋たなか", shiftStartTime: "14:00", shiftEndTime: "25:00" },
     recruitments: mockRecruitments,
+    recruitmentStatus: "CanLoadMore",
+    loadMoreRecruitments: () => {},
     staffs: mockStaffs,
+    staffStatus: "CanLoadMore",
+    loadMoreStaffs: () => {},
   },
 };
 
@@ -25,7 +29,11 @@ export const Empty: Story = {
   args: {
     shop: { name: "居酒屋たなか", shiftStartTime: "14:00", shiftEndTime: "25:00" },
     recruitments: [],
+    recruitmentStatus: "Exhausted",
+    loadMoreRecruitments: () => {},
     staffs: [],
+    staffStatus: "Exhausted",
+    loadMoreStaffs: () => {},
   },
 };
 
@@ -33,6 +41,10 @@ export const Setup: Story = {
   args: {
     shop: null,
     recruitments: [],
+    recruitmentStatus: "Exhausted",
+    loadMoreRecruitments: () => {},
     staffs: [],
+    staffStatus: "Exhausted",
+    loadMoreStaffs: () => {},
   },
 };

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -18,15 +18,27 @@ import type { SetupData } from "../SetupModal";
 import { SetupModal } from "../SetupModal";
 import { ShopInfoBar } from "../ShopInfoBar";
 import { StaffSection } from "../StaffSection";
-import { getDisplayStatus, type Recruitment, type Staff } from "../types";
+import { getDisplayStatus, type PaginationStatus, type Recruitment, type Staff } from "../types";
 
 type Props = {
   shop: { name: string; shiftStartTime: string; shiftEndTime: string } | null;
   recruitments: Recruitment[];
+  recruitmentStatus: PaginationStatus;
+  loadMoreRecruitments: () => void;
   staffs: Staff[];
+  staffStatus: PaginationStatus;
+  loadMoreStaffs: () => void;
 };
 
-export const DashboardContent = ({ shop, recruitments, staffs }: Props) => {
+export const DashboardContent = ({
+  shop,
+  recruitments,
+  recruitmentStatus,
+  loadMoreRecruitments,
+  staffs,
+  staffStatus,
+  loadMoreStaffs,
+}: Props) => {
   const navigate = useNavigate();
   const recruitmentModal = useDialog();
   const staffModal = useDialog();
@@ -162,12 +174,16 @@ export const DashboardContent = ({ shop, recruitments, staffs }: Props) => {
           recruitments={recruitments}
           onCreateClick={recruitmentModal.open}
           onOpenShiftBoard={handleOpenShiftBoard}
+          status={recruitmentStatus}
+          onLoadMore={loadMoreRecruitments}
         />
         <StaffSection
           staffs={staffs}
           onAddClick={staffModal.open}
           onEdit={handleEditClick}
           onDelete={handleDeleteClick}
+          status={staffStatus}
+          onLoadMore={loadMoreStaffs}
         />
       </ContentWrapper>
 

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -1,4 +1,4 @@
-import { Text, useBreakpointValue } from "@chakra-ui/react";
+import { Stack, Text, useBreakpointValue } from "@chakra-ui/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useState } from "react";
@@ -18,7 +18,7 @@ import type { SetupData } from "../SetupModal";
 import { SetupModal } from "../SetupModal";
 import { ShopInfoBar } from "../ShopInfoBar";
 import { StaffSection } from "../StaffSection";
-import type { Recruitment, Staff } from "../types";
+import { getDisplayStatus, type Recruitment, type Staff } from "../types";
 
 type Props = {
   shop: { name: string; shiftStartTime: string; shiftEndTime: string } | null;
@@ -33,10 +33,12 @@ export const DashboardContent = ({ shop, recruitments, staffs }: Props) => {
   const editStaffModal = useDialog();
   const editShopModal = useDialog();
   const deleteStaffDialog = useDialog();
+  const shiftBoardWarning = useDialog();
   const isMobile = useBreakpointValue({ base: true, lg: false });
   const isSetupRequired = shop === null;
   const [editTarget, setEditTarget] = useState<Staff | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Staff | null>(null);
+  const [pendingRecruitmentId, setPendingRecruitmentId] = useState<string | null>(null);
 
   const setupShopAndOwner = useMutation(api.setup.mutations.setupShopAndOwner);
   const createRecruitment = useMutation(api.recruitment.mutations.createRecruitment);
@@ -47,8 +49,25 @@ export const DashboardContent = ({ shop, recruitments, staffs }: Props) => {
 
   const Modal = isMobile ? BottomSheet : Dialog;
 
-  const handleOpenShiftBoard = (recruitmentId: string) => {
+  const navigateToShiftBoard = (recruitmentId: string) => {
     navigate({ to: "/shiftboard/$recruitmentId", params: { recruitmentId } });
+  };
+
+  const handleOpenShiftBoard = (recruitmentId: string) => {
+    const recruitment = recruitments.find((r) => r._id === recruitmentId);
+    if (recruitment && getDisplayStatus(recruitment) === "collecting") {
+      setPendingRecruitmentId(recruitmentId);
+      shiftBoardWarning.open();
+      return;
+    }
+    navigateToShiftBoard(recruitmentId);
+  };
+
+  const handleConfirmNavigation = () => {
+    if (pendingRecruitmentId) {
+      navigateToShiftBoard(pendingRecruitmentId);
+    }
+    shiftBoardWarning.close();
   };
 
   const handleSetupComplete = async (data: SetupData) => {
@@ -221,6 +240,21 @@ export const DashboardContent = ({ shop, recruitments, staffs }: Props) => {
         <Text fontSize="sm" color="gray.600">
           この操作は取り消せません。
         </Text>
+      </Dialog>
+
+      <Dialog
+        title="シフト希望がまだ変わるかも"
+        isOpen={shiftBoardWarning.isOpen}
+        onOpenChange={shiftBoardWarning.onOpenChange}
+        onClose={shiftBoardWarning.close}
+        onSubmit={handleConfirmNavigation}
+        submitLabel="編集画面へ進む"
+        role="alertdialog"
+      >
+        <Stack gap={1}>
+          <Text>全員分の希望がそろっていません</Text>
+          <Text>編集中にも変更される場合があります</Text>
+        </Stack>
       </Dialog>
 
       {isSetupRequired && <SetupModal isOpen={true} onOpenChange={() => {}} onComplete={handleSetupComplete} />}

--- a/src/components/features/Dashboard/LoadMoreButton/index.tsx
+++ b/src/components/features/Dashboard/LoadMoreButton/index.tsx
@@ -1,0 +1,21 @@
+import { Button } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import type { PaginationStatus } from "../types";
+
+type Props = {
+  status: PaginationStatus;
+  onLoadMore: () => void;
+  icon: ReactNode;
+  label: string;
+};
+
+export function LoadMoreButton({ status, onLoadMore, icon, label }: Props) {
+  if (status === "Exhausted" || status === "LoadingFirstPage") return null;
+
+  return (
+    <Button variant="outline" size="sm" w="full" onClick={onLoadMore} loading={status === "LoadingMore"}>
+      {status === "CanLoadMore" && icon}
+      {label}
+    </Button>
+  );
+}

--- a/src/components/features/Dashboard/RecruitmentCard/index.stories.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.stories.tsx
@@ -17,14 +17,19 @@ type Story = StoryObj<typeof meta>;
 const AllVariants = () => (
   <Flex direction="column" gap={4} p={4}>
     <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
-      募集中
+      収集中（締切前）
     </Text>
     <RecruitmentCard recruitment={mockRecruitments[0]} onOpenShiftBoard={() => {}} />
 
     <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
-      完了
+      締切済み
     </Text>
     <RecruitmentCard recruitment={mockRecruitments[1]} onOpenShiftBoard={() => {}} />
+
+    <Text fontSize="xs" fontWeight="semibold" color="fg.muted" mt={2}>
+      確定済み
+    </Text>
+    <RecruitmentCard recruitment={mockRecruitments[2]} onOpenShiftBoard={() => {}} />
   </Flex>
 );
 

--- a/src/components/features/Dashboard/RecruitmentCard/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 const displayStatusConfig = {
   collecting: { label: "収集中", colorPalette: "teal" },
-  "past-deadline": { label: "締切済み（要調整）", colorPalette: "yellow" },
+  "past-deadline": { label: "締切済み", colorPalette: "yellow" },
   confirmed: { label: "確定済み", colorPalette: "gray" },
 } as const;
 

--- a/src/components/features/Dashboard/RecruitmentCard/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.tsx
@@ -1,6 +1,7 @@
-import { Badge, Box, Button, Flex, Stack, Text } from "@chakra-ui/react";
+import { Box, Button, Flex, Stack, Text } from "@chakra-ui/react";
 import { LuArrowRight } from "react-icons/lu";
 import { formatDateShort } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
+import { RecruitmentStatusBadge } from "../RecruitmentStatusBadge";
 import { getDisplayStatus, type Recruitment } from "../types";
 
 type Props = {
@@ -8,16 +9,9 @@ type Props = {
   onOpenShiftBoard: (recruitmentId: string) => void;
 };
 
-const displayStatusConfig = {
-  collecting: { label: "収集中", colorPalette: "teal" },
-  "past-deadline": { label: "締切済み", colorPalette: "yellow" },
-  confirmed: { label: "確定済み", colorPalette: "gray" },
-} as const;
-
-export const RecruitmentCard = ({ recruitment, onOpenShiftBoard }: Props) => {
+export function RecruitmentCard({ recruitment, onOpenShiftBoard }: Props) {
   const { _id, periodStart, periodEnd, deadline, responseCount, totalStaffCount } = recruitment;
   const displayStatus = getDisplayStatus(recruitment);
-  const { label, colorPalette } = displayStatusConfig[displayStatus];
 
   return (
     <Box border="1px solid" borderColor="gray.200" borderRadius="lg" p={{ base: 4, lg: 5 }}>
@@ -40,9 +34,7 @@ export const RecruitmentCard = ({ recruitment, onOpenShiftBoard }: Props) => {
             <Text color="gray.600" fontSize="sm" whiteSpace="nowrap">
               提出状況: {responseCount}/{totalStaffCount}人
             </Text>
-            <Badge colorPalette={colorPalette} variant="subtle" borderRadius="full" px={2.5} fontSize="xs">
-              {label}
-            </Badge>
+            <RecruitmentStatusBadge status={displayStatus} />
           </Flex>
           <Button
             variant="outline"
@@ -58,4 +50,4 @@ export const RecruitmentCard = ({ recruitment, onOpenShiftBoard }: Props) => {
       </Stack>
     </Box>
   );
-};
+}

--- a/src/components/features/Dashboard/RecruitmentCard/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.tsx
@@ -1,15 +1,23 @@
 import { Badge, Box, Button, Flex, Stack, Text } from "@chakra-ui/react";
 import { LuArrowRight } from "react-icons/lu";
 import { formatDateShort } from "@/src/components/features/Shift/ShiftForm/utils/dateUtils";
-import type { Recruitment } from "../types";
+import { getDisplayStatus, type Recruitment } from "../types";
 
 type Props = {
   recruitment: Recruitment;
   onOpenShiftBoard: (recruitmentId: string) => void;
 };
 
+const displayStatusConfig = {
+  collecting: { label: "収集中", colorPalette: "teal" },
+  "past-deadline": { label: "締切済み（要調整）", colorPalette: "yellow" },
+  confirmed: { label: "確定済み", colorPalette: "gray" },
+} as const;
+
 export const RecruitmentCard = ({ recruitment, onOpenShiftBoard }: Props) => {
-  const { _id, periodStart, periodEnd, deadline, status, responseCount, totalStaffCount } = recruitment;
+  const { _id, periodStart, periodEnd, deadline, responseCount, totalStaffCount } = recruitment;
+  const displayStatus = getDisplayStatus(recruitment);
+  const { label, colorPalette } = displayStatusConfig[displayStatus];
 
   return (
     <Box border="1px solid" borderColor="gray.200" borderRadius="lg" p={{ base: 4, lg: 5 }}>
@@ -32,14 +40,8 @@ export const RecruitmentCard = ({ recruitment, onOpenShiftBoard }: Props) => {
             <Text color="gray.600" fontSize="sm" whiteSpace="nowrap">
               提出状況: {responseCount}/{totalStaffCount}人
             </Text>
-            <Badge
-              colorPalette={status === "open" ? "teal" : "gray"}
-              variant="subtle"
-              borderRadius="full"
-              px={2.5}
-              fontSize="xs"
-            >
-              {status === "open" ? "収集・編集中" : "確定済み"}
+            <Badge colorPalette={colorPalette} variant="subtle" borderRadius="full" px={2.5} fontSize="xs">
+              {label}
             </Badge>
           </Flex>
           <Button

--- a/src/components/features/Dashboard/RecruitmentCard/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentCard/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export function RecruitmentCard({ recruitment, onOpenShiftBoard }: Props) {
-  const { _id, periodStart, periodEnd, deadline, responseCount, totalStaffCount } = recruitment;
+  const { _id, periodStart, periodEnd, deadline, responseCount } = recruitment;
   const displayStatus = getDisplayStatus(recruitment);
 
   return (
@@ -32,7 +32,7 @@ export function RecruitmentCard({ recruitment, onOpenShiftBoard }: Props) {
             width={{ base: "full", lg: "auto" }}
           >
             <Text color="gray.600" fontSize="sm" whiteSpace="nowrap">
-              提出状況: {responseCount}/{totalStaffCount}人
+              提出済み: {responseCount}人
             </Text>
             <RecruitmentStatusBadge status={displayStatus} />
           </Flex>

--- a/src/components/features/Dashboard/RecruitmentSection/index.stories.tsx
+++ b/src/components/features/Dashboard/RecruitmentSection/index.stories.tsx
@@ -16,8 +16,22 @@ type Story = StoryObj<typeof meta>;
 export const Normal: Story = {
   args: {
     recruitments: mockRecruitments,
+
     onCreateClick: () => {},
     onOpenShiftBoard: () => {},
+    status: "Exhausted",
+    onLoadMore: () => {},
+  },
+};
+
+export const CanLoadMore: Story = {
+  args: {
+    recruitments: mockRecruitments.slice(0, 3),
+
+    onCreateClick: () => {},
+    onOpenShiftBoard: () => {},
+    status: "CanLoadMore",
+    onLoadMore: () => {},
   },
 };
 
@@ -26,5 +40,7 @@ export const EmptyState: Story = {
     recruitments: [],
     onCreateClick: () => {},
     onOpenShiftBoard: () => {},
+    status: "Exhausted",
+    onLoadMore: () => {},
   },
 };

--- a/src/components/features/Dashboard/RecruitmentSection/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentSection/index.tsx
@@ -1,18 +1,21 @@
 import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
-import { LuArrowRight, LuCalendarPlus, LuClipboardList } from "react-icons/lu";
+import { LuArrowRight, LuCalendarPlus, LuChevronDown, LuClipboardList } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
 import { InfoGuide } from "@/src/components/ui/InfoGuide";
+import { LoadMoreButton } from "../LoadMoreButton";
 import { RecruitmentCard } from "../RecruitmentCard";
 import { RecruitmentStatusBadge } from "../RecruitmentStatusBadge";
-import type { Recruitment } from "../types";
+import type { PaginationStatus, Recruitment } from "../types";
 
 type Props = {
   recruitments: Recruitment[];
   onCreateClick: () => void;
   onOpenShiftBoard: (recruitmentId: string) => void;
+  status: PaginationStatus;
+  onLoadMore: () => void;
 };
 
-export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoard }: Props) {
+export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoard, status, onLoadMore }: Props) {
   return (
     <Stack gap={4}>
       <Flex justify="space-between" align="center">
@@ -103,6 +106,7 @@ export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoa
           {recruitments.map((recruitment) => (
             <RecruitmentCard key={recruitment._id} recruitment={recruitment} onOpenShiftBoard={onOpenShiftBoard} />
           ))}
+          <LoadMoreButton status={status} onLoadMore={onLoadMore} icon={<LuChevronDown />} label="もっと見る" />
         </Stack>
       )}
     </Stack>

--- a/src/components/features/Dashboard/RecruitmentSection/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentSection/index.tsx
@@ -55,9 +55,14 @@ export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoa
                   </Flex>
                   <Flex align="center" gap={2}>
                     <RecruitmentStatusBadge status="confirmed" />
-                    <Text fontSize="xs" color="fg.muted">
-                      シフトが確定した状態
-                    </Text>
+                    <Stack gap={0.5}>
+                      <Text fontSize="xs" color="fg.muted">
+                        シフトを確定し スタッフに通知済みの状態
+                      </Text>
+                      <Text fontSize="xs" color="fg.muted">
+                        確定後も編集やシフトの再送ができます
+                      </Text>
+                    </Stack>
                   </Flex>
                 </Stack>
               </Stack>,
@@ -71,6 +76,9 @@ export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoa
                 </Flex>
                 <Text fontSize="xs" color="fg.muted">
                   スタッフの希望を見ながらシフトを組める画面に移動します
+                </Text>
+                <Text fontSize="xs" color="fg.muted">
+                  確定したあとも編集や再通知ができます
                 </Text>
               </Stack>,
             ]}

--- a/src/components/features/Dashboard/RecruitmentSection/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentSection/index.tsx
@@ -1,7 +1,9 @@
-import { Box, Button, Flex, Heading, Stack } from "@chakra-ui/react";
-import { LuCalendarPlus, LuClipboardList } from "react-icons/lu";
+import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
+import { LuArrowRight, LuCalendarPlus, LuClipboardList } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
+import { InfoGuide } from "@/src/components/ui/InfoGuide";
 import { RecruitmentCard } from "../RecruitmentCard";
+import { RecruitmentStatusBadge } from "../RecruitmentStatusBadge";
 import type { Recruitment } from "../types";
 
 type Props = {
@@ -10,11 +12,70 @@ type Props = {
   onOpenShiftBoard: (recruitmentId: string) => void;
 };
 
-export const RecruitmentSection = ({ recruitments, onCreateClick, onOpenShiftBoard }: Props) => {
+export function RecruitmentSection({ recruitments, onCreateClick, onOpenShiftBoard }: Props) {
   return (
     <Stack gap={4}>
       <Flex justify="space-between" align="center">
-        <Heading size={{ base: "md", lg: "lg" }}>シフト</Heading>
+        <Flex align="center" gap={0.5}>
+          <Heading size={{ base: "md", lg: "lg" }}>シフト</Heading>
+          <InfoGuide
+            title="シフトについて"
+            pages={[
+              <Stack key="1" gap={3}>
+                <Text fontSize="sm">期間を決めてスタッフにシフト希望を集められます</Text>
+                <Flex align="center" gap={2}>
+                  <Button size="sm" colorPalette="teal" pointerEvents="none">
+                    <LuCalendarPlus />
+                    シフト希望を集める
+                  </Button>
+                </Flex>
+                <Stack gap={0.5}>
+                  <Text fontSize="xs" color="fg.muted">
+                    このボタンを押すと 対象期間と締切を設定できます
+                  </Text>
+                  <Text fontSize="xs" color="fg.muted">
+                    作成するとスタッフにメールで通知が届きます
+                  </Text>
+                </Stack>
+              </Stack>,
+              <Stack key="2" gap={3}>
+                <Text fontSize="sm">カードのステータスで進み具合がわかります</Text>
+                <Stack gap={2}>
+                  <Flex align="center" gap={2}>
+                    <RecruitmentStatusBadge status="collecting" />
+                    <Text fontSize="xs" color="fg.muted">
+                      スタッフからの希望を受付中
+                    </Text>
+                  </Flex>
+                  <Flex align="center" gap={2}>
+                    <RecruitmentStatusBadge status="past-deadline" />
+                    <Text fontSize="xs" color="fg.muted">
+                      シフトを調整して 確定させましょう
+                    </Text>
+                  </Flex>
+                  <Flex align="center" gap={2}>
+                    <RecruitmentStatusBadge status="confirmed" />
+                    <Text fontSize="xs" color="fg.muted">
+                      シフトが確定した状態
+                    </Text>
+                  </Flex>
+                </Stack>
+              </Stack>,
+              <Stack key="3" gap={3}>
+                <Text fontSize="sm">シフトを編集するにはカードのボタンを押します</Text>
+                <Flex align="center" gap={2}>
+                  <Button variant="outline" size="sm" gap={1.5} pointerEvents="none">
+                    シフトを編集する
+                    <LuArrowRight />
+                  </Button>
+                </Flex>
+                <Text fontSize="xs" color="fg.muted">
+                  スタッフの希望を見ながらシフトを組める画面に移動します
+                </Text>
+              </Stack>,
+            ]}
+          />
+        </Flex>
         <Button size="sm" colorPalette="teal" onClick={onCreateClick}>
           <LuCalendarPlus />
           シフト希望を集める
@@ -38,4 +99,4 @@ export const RecruitmentSection = ({ recruitments, onCreateClick, onOpenShiftBoa
       )}
     </Stack>
   );
-};
+}

--- a/src/components/features/Dashboard/RecruitmentStatusBadge/index.stories.tsx
+++ b/src/components/features/Dashboard/RecruitmentStatusBadge/index.stories.tsx
@@ -1,0 +1,25 @@
+import { HStack } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RecruitmentStatusBadge } from "./index";
+
+const meta = {
+  title: "Dashboard/RecruitmentStatusBadge",
+  component: RecruitmentStatusBadge,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof RecruitmentStatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof RecruitmentStatusBadge>;
+
+// 全バリアント
+export const Variants: Story = {
+  render: () => (
+    <HStack gap={3}>
+      <RecruitmentStatusBadge status="collecting" />
+      <RecruitmentStatusBadge status="past-deadline" />
+      <RecruitmentStatusBadge status="confirmed" />
+    </HStack>
+  ),
+};

--- a/src/components/features/Dashboard/RecruitmentStatusBadge/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentStatusBadge/index.tsx
@@ -1,0 +1,21 @@
+import { Badge } from "@chakra-ui/react";
+import type { RecruitmentDisplayStatus } from "../types";
+
+const displayStatusConfig = {
+  collecting: { label: "収集中", colorPalette: "teal" },
+  "past-deadline": { label: "締切済み", colorPalette: "yellow" },
+  confirmed: { label: "確定済み", colorPalette: "gray" },
+} as const;
+
+type Props = {
+  status: RecruitmentDisplayStatus;
+};
+
+export function RecruitmentStatusBadge({ status }: Props) {
+  const { label, colorPalette } = displayStatusConfig[status];
+  return (
+    <Badge colorPalette={colorPalette} variant="subtle" borderRadius="full" px={2.5} fontSize="xs">
+      {label}
+    </Badge>
+  );
+}

--- a/src/components/features/Dashboard/StaffListItem/index.tsx
+++ b/src/components/features/Dashboard/StaffListItem/index.tsx
@@ -20,7 +20,15 @@ export const StaffListItem = ({ staff, onEdit, onDelete }: Props) => {
       _notLast={{ borderBottom: "1px solid", borderColor: "gray.200" }}
     >
       <Flex align="center" gap={4}>
-        <Text fontWeight="500" fontSize="sm">
+        <Text
+          fontWeight="500"
+          fontSize="sm"
+          w="160px"
+          flexShrink={0}
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+        >
           {staff.name}
         </Text>
         <Text color="gray.500" fontSize="sm" display={{ base: "none", lg: "block" }}>

--- a/src/components/features/Dashboard/StaffListItem/index.tsx
+++ b/src/components/features/Dashboard/StaffListItem/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, IconButton, Menu, Portal, Text } from "@chakra-ui/react";
+import { Badge, Flex, IconButton, Menu, Portal, Text } from "@chakra-ui/react";
 import { LuEllipsisVertical, LuPencil, LuTrash2 } from "react-icons/lu";
 import type { Staff } from "../types";
 
@@ -36,36 +36,43 @@ export const StaffListItem = ({ staff, onEdit, onDelete }: Props) => {
         </Text>
       </Flex>
 
-      <Menu.Root positioning={MENU_POSITIONING}>
-        <Menu.Trigger asChild>
-          <IconButton aria-label="メニュー" variant="ghost" size="xs" color="fg.muted">
-            <LuEllipsisVertical />
-          </IconButton>
-        </Menu.Trigger>
-        <Portal>
-          <Menu.Positioner>
-            <Menu.Content minW="140px">
-              <Menu.Item value="edit" cursor="pointer" onClick={() => onEdit(staff)}>
-                <LuPencil />
-                編集
-              </Menu.Item>
-              <Menu.Item
-                value="delete"
-                color={staff.isOwner ? "fg.muted" : "fg.error"}
-                cursor={staff.isOwner ? "not-allowed" : "pointer"}
-                disabled={staff.isOwner}
-                // Chakra v3 Menu.Item は disabled でも onClick が発火するためガード
-                onClick={() => {
-                  if (!staff.isOwner) onDelete(staff);
-                }}
-              >
-                <LuTrash2 />
-                削除
-              </Menu.Item>
-            </Menu.Content>
-          </Menu.Positioner>
-        </Portal>
-      </Menu.Root>
+      <Flex align="center" gap={2}>
+        {staff.isOwner && (
+          <Badge colorPalette="teal" variant="subtle" borderRadius="full" fontSize="xs" px={2.5}>
+            オーナー
+          </Badge>
+        )}
+        <Menu.Root positioning={MENU_POSITIONING}>
+          <Menu.Trigger asChild>
+            <IconButton aria-label="メニュー" variant="ghost" size="xs" color="fg.muted">
+              <LuEllipsisVertical />
+            </IconButton>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content minW="140px">
+                <Menu.Item value="edit" cursor="pointer" onClick={() => onEdit(staff)}>
+                  <LuPencil />
+                  編集
+                </Menu.Item>
+                <Menu.Item
+                  value="delete"
+                  color={staff.isOwner ? "fg.muted" : "fg.error"}
+                  cursor={staff.isOwner ? "not-allowed" : "pointer"}
+                  disabled={staff.isOwner}
+                  // Chakra v3 Menu.Item は disabled でも onClick が発火するためガード
+                  onClick={() => {
+                    if (!staff.isOwner) onDelete(staff);
+                  }}
+                >
+                  <LuTrash2 />
+                  削除
+                </Menu.Item>
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
+      </Flex>
     </Flex>
   );
 };

--- a/src/components/features/Dashboard/StaffSection/index.stories.tsx
+++ b/src/components/features/Dashboard/StaffSection/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { mockStaffs } from "../storyMocks";
+import { mockStaffs, mockStaffsMany } from "../storyMocks";
 import { StaffSection } from "./index";
 
 const meta = {
@@ -19,6 +19,19 @@ export const Normal: Story = {
     onAddClick: () => {},
     onEdit: () => {},
     onDelete: () => {},
+    status: "Exhausted",
+    onLoadMore: () => {},
+  },
+};
+
+export const CanLoadMore: Story = {
+  args: {
+    staffs: mockStaffsMany,
+    onAddClick: () => {},
+    onEdit: () => {},
+    onDelete: () => {},
+    status: "CanLoadMore",
+    onLoadMore: () => {},
   },
 };
 
@@ -28,5 +41,7 @@ export const EmptyState: Story = {
     onAddClick: () => {},
     onEdit: () => {},
     onDelete: () => {},
+    status: "Exhausted",
+    onLoadMore: () => {},
   },
 };

--- a/src/components/features/Dashboard/StaffSection/index.tsx
+++ b/src/components/features/Dashboard/StaffSection/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Flex, Heading, Stack } from "@chakra-ui/react";
-import { LuUserPlus, LuUsers } from "react-icons/lu";
+import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
+import { LuEllipsisVertical, LuUserPlus, LuUsers } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
+import { InfoGuide } from "@/src/components/ui/InfoGuide";
 import { StaffListItem } from "../StaffListItem";
 import type { Staff } from "../types";
 
@@ -11,11 +12,42 @@ type Props = {
   onDelete: (staff: Staff) => void;
 };
 
-export const StaffSection = ({ staffs, onAddClick, onEdit, onDelete }: Props) => {
+export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
   return (
     <Stack gap={4}>
       <Flex justify="space-between" align="center">
-        <Heading size={{ base: "md", lg: "lg" }}>スタッフ</Heading>
+        <Flex align="center" gap={0.5}>
+          <Heading size={{ base: "md", lg: "lg" }}>スタッフ</Heading>
+          <InfoGuide
+            title="スタッフについて"
+            pages={[
+              <Stack key="1" gap={3}>
+                <Text fontSize="sm">シフト希望を出してもらうメンバーを管理します</Text>
+                <Flex align="center" gap={2}>
+                  <Button size="sm" colorPalette="teal" pointerEvents="none">
+                    <LuUserPlus />
+                    スタッフを追加
+                  </Button>
+                </Flex>
+                <Stack gap={0.5}>
+                  <Text fontSize="xs" color="fg.muted">
+                    スタッフ側のアカウント登録は不要です
+                  </Text>
+                  <Text fontSize="xs" color="fg.muted">
+                    このメールアドレスにシフト希望の依頼が届きます
+                  </Text>
+                </Stack>
+              </Stack>,
+              <Stack key="2" gap={3}>
+                <Text fontSize="sm">登録したスタッフの編集・削除ができます</Text>
+                <Flex align="center" gap={2} color="fg.muted">
+                  <LuEllipsisVertical />
+                  <Text fontSize="xs">← このメニューから操作できます</Text>
+                </Flex>
+              </Stack>,
+            ]}
+          />
+        </Flex>
         <Button size="sm" colorPalette="teal" onClick={onAddClick}>
           <LuUserPlus />
           スタッフを追加
@@ -39,4 +71,4 @@ export const StaffSection = ({ staffs, onAddClick, onEdit, onDelete }: Props) =>
       )}
     </Stack>
   );
-};
+}

--- a/src/components/features/Dashboard/StaffSection/index.tsx
+++ b/src/components/features/Dashboard/StaffSection/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
-import { useMemo } from "react";
 import { LuEllipsisVertical, LuUserPlus, LuUsers } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
 import { InfoGuide } from "@/src/components/ui/InfoGuide";
@@ -14,7 +13,7 @@ type Props = {
 };
 
 export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
-  const sortedStaffs = useMemo(() => [...staffs].sort((a, b) => Number(b.isOwner) - Number(a.isOwner)), [staffs]);
+  const sortedStaffs = [...staffs].sort((a, b) => Number(b.isOwner) - Number(a.isOwner));
 
   return (
     <Stack gap={4}>
@@ -56,7 +55,7 @@ export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
           スタッフを追加
         </Button>
       </Flex>
-      {staffs.length === 0 ? (
+      {sortedStaffs.length === 0 ? (
         <Box border="1px solid" borderColor="gray.200" borderRadius="lg">
           <Empty
             icon={LuUsers}

--- a/src/components/features/Dashboard/StaffSection/index.tsx
+++ b/src/components/features/Dashboard/StaffSection/index.tsx
@@ -1,18 +1,21 @@
 import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
-import { LuEllipsisVertical, LuUserPlus, LuUsers } from "react-icons/lu";
+import { LuChevronsDown, LuEllipsisVertical, LuUserPlus, LuUsers } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
 import { InfoGuide } from "@/src/components/ui/InfoGuide";
+import { LoadMoreButton } from "../LoadMoreButton";
 import { StaffListItem } from "../StaffListItem";
-import type { Staff } from "../types";
+import type { PaginationStatus, Staff } from "../types";
 
 type Props = {
   staffs: Staff[];
   onAddClick: () => void;
   onEdit: (staff: Staff) => void;
   onDelete: (staff: Staff) => void;
+  status: PaginationStatus;
+  onLoadMore: () => void;
 };
 
-export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
+export function StaffSection({ staffs, onAddClick, onEdit, onDelete, status, onLoadMore }: Props) {
   const sortedStaffs = [...staffs].sort((a, b) => Number(b.isOwner) - Number(a.isOwner));
 
   return (
@@ -65,11 +68,14 @@ export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
           />
         </Box>
       ) : (
-        <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
-          {sortedStaffs.map((staff) => (
-            <StaffListItem key={staff._id} staff={staff} onEdit={onEdit} onDelete={onDelete} />
-          ))}
-        </Box>
+        <Stack gap={3}>
+          <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
+            {sortedStaffs.map((staff) => (
+              <StaffListItem key={staff._id} staff={staff} onEdit={onEdit} onDelete={onDelete} />
+            ))}
+          </Box>
+          <LoadMoreButton status={status} onLoadMore={onLoadMore} icon={<LuChevronsDown />} label="すべて表示" />
+        </Stack>
       )}
     </Stack>
   );

--- a/src/components/features/Dashboard/StaffSection/index.tsx
+++ b/src/components/features/Dashboard/StaffSection/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, Heading, Stack, Text } from "@chakra-ui/react";
+import { useMemo } from "react";
 import { LuEllipsisVertical, LuUserPlus, LuUsers } from "react-icons/lu";
 import { Empty } from "@/src/components/ui/Empty";
 import { InfoGuide } from "@/src/components/ui/InfoGuide";
@@ -13,6 +14,8 @@ type Props = {
 };
 
 export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
+  const sortedStaffs = useMemo(() => [...staffs].sort((a, b) => Number(b.isOwner) - Number(a.isOwner)), [staffs]);
+
   return (
     <Stack gap={4}>
       <Flex justify="space-between" align="center">
@@ -64,7 +67,7 @@ export function StaffSection({ staffs, onAddClick, onEdit, onDelete }: Props) {
         </Box>
       ) : (
         <Box border="1px solid" borderColor="gray.200" borderRadius="lg" overflow="hidden">
-          {staffs.map((staff) => (
+          {sortedStaffs.map((staff) => (
             <StaffListItem key={staff._id} staff={staff} onEdit={onEdit} onDelete={onDelete} />
           ))}
         </Box>

--- a/src/components/features/Dashboard/storyMocks.ts
+++ b/src/components/features/Dashboard/storyMocks.ts
@@ -4,15 +4,24 @@ import type { Recruitment, Staff } from "./types";
 export const mockRecruitments = [
   {
     _id: "rec-1",
-    periodStart: "2026-03-31",
-    periodEnd: "2026-04-06",
-    deadline: "2026-03-28",
+    periodStart: "2026-04-20",
+    periodEnd: "2026-04-26",
+    deadline: "2026-04-18",
     status: "open",
     responseCount: 8,
     totalStaffCount: 10,
   },
   {
     _id: "rec-2",
+    periodStart: "2026-03-31",
+    periodEnd: "2026-04-06",
+    deadline: "2026-03-28",
+    status: "open",
+    responseCount: 10,
+    totalStaffCount: 10,
+  },
+  {
+    _id: "rec-3",
     periodStart: "2026-03-24",
     periodEnd: "2026-03-30",
     deadline: "2026-03-21",

--- a/src/components/features/Dashboard/storyMocks.ts
+++ b/src/components/features/Dashboard/storyMocks.ts
@@ -9,7 +9,6 @@ export const mockRecruitments = [
     deadline: "2026-04-18",
     status: "open",
     responseCount: 8,
-    totalStaffCount: 10,
   },
   {
     _id: "rec-2",
@@ -18,7 +17,6 @@ export const mockRecruitments = [
     deadline: "2026-03-28",
     status: "open",
     responseCount: 10,
-    totalStaffCount: 10,
   },
   {
     _id: "rec-3",
@@ -27,7 +25,6 @@ export const mockRecruitments = [
     deadline: "2026-03-21",
     status: "confirmed",
     responseCount: 10,
-    totalStaffCount: 10,
   },
 ] as unknown as Recruitment[];
 
@@ -35,4 +32,17 @@ export const mockStaffs = [
   { _id: "s1", name: "田中太郎", email: "tanaka@example.com", isOwner: true },
   { _id: "s2", name: "佐藤花子", email: "sato@example.com", isOwner: false },
   { _id: "s3", name: "鈴木一郎", email: "suzuki@example.com", isOwner: false },
+] as unknown as Staff[];
+
+export const mockStaffsMany = [
+  { _id: "s1", name: "田中太郎", email: "tanaka@example.com", isOwner: true },
+  { _id: "s2", name: "佐藤花子", email: "sato@example.com", isOwner: false },
+  { _id: "s3", name: "鈴木一郎", email: "suzuki@example.com", isOwner: false },
+  { _id: "s4", name: "山田美咲", email: "yamada@example.com", isOwner: false },
+  { _id: "s5", name: "高橋健太", email: "takahashi@example.com", isOwner: false },
+  { _id: "s6", name: "伊藤麻衣", email: "ito@example.com", isOwner: false },
+  { _id: "s7", name: "渡辺翔太", email: "watanabe@example.com", isOwner: false },
+  { _id: "s8", name: "中村由美", email: "nakamura@example.com", isOwner: false },
+  { _id: "s9", name: "小林大輔", email: "kobayashi@example.com", isOwner: false },
+  { _id: "s10", name: "加藤彩", email: "kato@example.com", isOwner: false },
 ] as unknown as Staff[];

--- a/src/components/features/Dashboard/types.ts
+++ b/src/components/features/Dashboard/types.ts
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import type { Id } from "@/convex/_generated/dataModel";
 
 export type Recruitment = {
@@ -9,6 +10,14 @@ export type Recruitment = {
   responseCount: number;
   totalStaffCount: number;
 };
+
+export type RecruitmentDisplayStatus = "collecting" | "past-deadline" | "confirmed";
+
+export function getDisplayStatus(recruitment: Pick<Recruitment, "status" | "deadline">): RecruitmentDisplayStatus {
+  if (recruitment.status === "confirmed") return "confirmed";
+  const today = dayjs().format("YYYY-MM-DD");
+  return recruitment.deadline < today ? "past-deadline" : "collecting";
+}
 
 export type Staff = {
   _id: Id<"staffs">;

--- a/src/components/features/Dashboard/types.ts
+++ b/src/components/features/Dashboard/types.ts
@@ -8,7 +8,6 @@ export type Recruitment = {
   deadline: string;
   status: "open" | "confirmed";
   responseCount: number;
-  totalStaffCount: number;
 };
 
 export type RecruitmentDisplayStatus = "collecting" | "past-deadline" | "confirmed";
@@ -25,3 +24,5 @@ export type Staff = {
   email: string;
   isOwner: boolean;
 };
+
+export type { PaginationStatus } from "convex/browser";

--- a/src/components/templates/Header/UserMenu/index.stories.tsx
+++ b/src/components/templates/Header/UserMenu/index.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { createStore, Provider } from "jotai";
+import { userAtom } from "@/src/stores/user";
+import { UserMenu } from "./index";
+
+const createStoreWithUser = (name: string, email: string) => {
+  const store = createStore();
+  store.set(userAtom, { authId: "test", name, email });
+  return store;
+};
+
+const meta = {
+  title: "Templates/Header/UserMenu",
+  component: UserMenu,
+  parameters: {
+    layout: "centered",
+    backgrounds: { default: "teal", values: [{ name: "teal", value: "#0d9488" }] },
+  },
+  decorators: [
+    (Story) => (
+      <Provider store={createStoreWithUser("田中太郎", "tanaka@example.com")}>
+        <Story />
+      </Provider>
+    ),
+  ],
+} satisfies Meta<typeof UserMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** デフォルト表示 */
+export const Default: Story = {};

--- a/src/components/templates/Header/UserMenu/index.tsx
+++ b/src/components/templates/Header/UserMenu/index.tsx
@@ -1,0 +1,47 @@
+import { Box, Icon, Menu, Portal, Text } from "@chakra-ui/react";
+import { SignOutButton } from "@clerk/clerk-react";
+import { useAtomValue } from "jotai";
+import { LuLogOut, LuUserRound } from "react-icons/lu";
+import { userAtom } from "@/src/stores/user";
+
+export const UserMenu = () => {
+  const user = useAtomValue(userAtom);
+
+  return (
+    <Menu.Root positioning={{ placement: "bottom-end" }}>
+      <Menu.Trigger asChild>
+        <Box
+          as="button"
+          aria-label="ユーザーメニュー"
+          cursor="pointer"
+          _hover={{ opacity: 0.8 }}
+          transition="opacity 0.15s"
+          display="flex"
+        >
+          <Icon as={LuUserRound} boxSize={7} color="white" />
+        </Box>
+      </Menu.Trigger>
+      <Portal>
+        <Menu.Positioner>
+          <Menu.Content minW="200px">
+            <Box px={3} py={2}>
+              <Text fontWeight="semibold" fontSize="sm">
+                {user.name}
+              </Text>
+              <Text fontSize="xs" color="fg.muted">
+                {user.email}
+              </Text>
+            </Box>
+            <Menu.Separator />
+            <SignOutButton>
+              <Menu.Item value="logout" cursor="pointer" color="red.500">
+                <LuLogOut />
+                ログアウト
+              </Menu.Item>
+            </SignOutButton>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Portal>
+    </Menu.Root>
+  );
+};

--- a/src/components/templates/Header/index.tsx
+++ b/src/components/templates/Header/index.tsx
@@ -1,7 +1,6 @@
-import { Box, Button, Flex, Text } from "@chakra-ui/react";
-import { SignOutButton } from "@clerk/clerk-react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 import { Link } from "@tanstack/react-router";
-import { LuLogOut } from "react-icons/lu";
+import { UserMenu } from "./UserMenu";
 
 export const Header = () => {
   return (
@@ -13,12 +12,7 @@ export const Header = () => {
           </Text>
         </Link>
 
-        <SignOutButton>
-          <Button variant="ghost" size="sm" color="white" _hover={{ bg: "teal.500" }}>
-            <LuLogOut />
-            ログアウト
-          </Button>
-        </SignOutButton>
+        <UserMenu />
       </Flex>
     </Box>
   );

--- a/src/components/ui/InfoGuide/index.stories.tsx
+++ b/src/components/ui/InfoGuide/index.stories.tsx
@@ -1,0 +1,40 @@
+import { Text } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoGuide } from "./index";
+
+const meta = {
+  title: "UI/InfoGuide",
+  component: InfoGuide,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof InfoGuide>;
+
+export default meta;
+type Story = StoryObj<typeof InfoGuide>;
+
+// 単一ページ
+export const SinglePage: Story = {
+  args: {
+    title: "シフト申請について",
+    pages: [
+      <Text key="1">スタッフがシフトの希望を提出できる機能です。提出された希望をもとにシフトを作成します。</Text>,
+    ],
+  },
+};
+
+// 複数ページ（ページ送り）— ダイアログを開いた状態でキャプチャ
+export const MultiPage: Story = {
+  args: {
+    title: "使い方ガイド",
+    pages: [
+      <Text key="1">ステップ1: まず店舗情報を登録します。店舗名と営業時間を入力してください。</Text>,
+      <Text key="2">ステップ2: スタッフを追加します。名前とメールアドレスを入力すると招待が送られます。</Text>,
+      <Text key="3">ステップ3: シフト募集を開始すると、スタッフに通知が届きます。</Text>,
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const button = canvasElement.querySelector("button");
+    button?.click();
+  },
+};

--- a/src/components/ui/InfoGuide/index.tsx
+++ b/src/components/ui/InfoGuide/index.tsx
@@ -1,0 +1,76 @@
+import { Box, Button, Dialog as ChakraDialog, Circle, CloseButton, HStack, IconButton, Portal } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { useCallback, useState } from "react";
+import { LuInfo } from "react-icons/lu";
+import { useDialog } from "@/src/components/ui/Dialog";
+
+type InfoGuideProps = {
+  title: string;
+  pages: ReactNode[];
+  size?: "xs" | "sm";
+};
+
+export function InfoGuide({ title, pages, size = "xs" }: InfoGuideProps) {
+  const dialog = useDialog();
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const totalPages = pages.length;
+  const isMultiPage = totalPages > 1;
+  const isFirstPage = currentPage === 0;
+  const isLastPage = currentPage === totalPages - 1;
+
+  const handleOpen = useCallback(() => {
+    setCurrentPage(0);
+    dialog.open();
+  }, [dialog]);
+
+  return (
+    <>
+      <IconButton aria-label={title} variant="ghost" size={size} color="fg.muted" onClick={handleOpen}>
+        <LuInfo />
+      </IconButton>
+
+      <ChakraDialog.Root open={dialog.isOpen} onOpenChange={dialog.onOpenChange} placement="center">
+        <Portal>
+          <ChakraDialog.Backdrop />
+          <ChakraDialog.Positioner>
+            <ChakraDialog.Content>
+              <ChakraDialog.Header>
+                <ChakraDialog.Title>{title}</ChakraDialog.Title>
+              </ChakraDialog.Header>
+              <ChakraDialog.Body>
+                <Box minH="4rem">{pages[currentPage]}</Box>
+              </ChakraDialog.Body>
+              {isMultiPage && (
+                <HStack justify="center" gap={1.5} pb={2}>
+                  {pages.map((_, i) => (
+                    <Circle key={i} size="2" bg={i === currentPage ? "teal.500" : "gray.300"} />
+                  ))}
+                </HStack>
+              )}
+              <ChakraDialog.Footer>
+                {isMultiPage && !isFirstPage && (
+                  <Button variant="outline" size="sm" onClick={() => setCurrentPage((p) => p - 1)}>
+                    戻る
+                  </Button>
+                )}
+                {isMultiPage && !isLastPage ? (
+                  <Button colorPalette="teal" size="sm" onClick={() => setCurrentPage((p) => p + 1)}>
+                    次へ
+                  </Button>
+                ) : (
+                  <Button colorPalette="teal" size="sm" onClick={dialog.close}>
+                    閉じる
+                  </Button>
+                )}
+              </ChakraDialog.Footer>
+              <ChakraDialog.CloseTrigger asChild position="absolute" top="2" insetEnd="2">
+                <CloseButton size="sm" />
+              </ChakraDialog.CloseTrigger>
+            </ChakraDialog.Content>
+          </ChakraDialog.Positioner>
+        </Portal>
+      </ChakraDialog.Root>
+    </>
+  );
+}

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -7,3 +7,5 @@ export const CONVEX_URL = import.meta.env.VITE_CONVEX_URL ?? "";
 if (!CONVEX_URL) {
   throw new Error("Add your Convex URL to the .env file");
 }
+
+export const GTM_ID = import.meta.env.VITE_GTM_ID ?? "";

--- a/src/helpers/gtm/index.test.ts
+++ b/src/helpers/gtm/index.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { initGTM, resetGTM, sendEvent, sendPageView } from ".";
+
+describe("GTM ヘルパー", () => {
+  beforeEach(() => {
+    resetGTM();
+    window.dataLayer = [];
+    for (const el of document.head.querySelectorAll('script[src*="googletagmanager"]')) el.remove();
+    for (const el of document.body.querySelectorAll("noscript")) el.remove();
+  });
+
+  describe("initGTM", () => {
+    it("GTM IDが空の場合は何もしない", () => {
+      initGTM("");
+      expect(document.head.querySelector('script[src*="googletagmanager"]')).toBeNull();
+    });
+
+    it("スクリプトタグがDOMに挿入される", () => {
+      initGTM("GTM-TEST123");
+      const script = document.head.querySelector('script[src*="googletagmanager"]');
+      expect(script).not.toBeNull();
+      expect(script?.getAttribute("src")).toBe("https://www.googletagmanager.com/gtm.js?id=GTM-TEST123");
+    });
+
+    it("noscriptフォールバックがbodyに挿入される", () => {
+      initGTM("GTM-TEST123");
+      const noscript = document.body.querySelector("noscript");
+      expect(noscript).not.toBeNull();
+      const iframe = noscript?.querySelector("iframe");
+      expect(iframe?.getAttribute("src")).toBe("https://www.googletagmanager.com/ns.html?id=GTM-TEST123");
+    });
+
+    it("dataLayerにgtm.startイベントがpushされる", () => {
+      initGTM("GTM-TEST123");
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "gtm.js", "gtm.start": expect.any(Number) })]),
+      );
+    });
+
+    it("二重初期化を防止する", () => {
+      initGTM("GTM-TEST123");
+      initGTM("GTM-TEST123");
+      const scripts = document.head.querySelectorAll('script[src*="googletagmanager"]');
+      expect(scripts.length).toBe(1);
+    });
+  });
+
+  describe("sendPageView", () => {
+    it("初期化済みならpage_viewイベントがpushされる", () => {
+      initGTM("GTM-TEST123");
+      sendPageView("/dashboard");
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "page_view", page_path: "/dashboard" })]),
+      );
+    });
+
+    it("未初期化ならpushされない", () => {
+      window.dataLayer = [];
+      sendPageView("/dashboard");
+      expect(window.dataLayer).toEqual([]);
+    });
+  });
+
+  describe("sendEvent", () => {
+    it("カスタムイベントがpushされる", () => {
+      initGTM("GTM-TEST123");
+      sendEvent("click_button", { button_name: "submit" });
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "click_button", button_name: "submit" })]),
+      );
+    });
+
+    it("paramsなしでもpushできる", () => {
+      initGTM("GTM-TEST123");
+      sendEvent("scroll_to_bottom");
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "scroll_to_bottom" })]),
+      );
+    });
+
+    it("未初期化ならpushされない", () => {
+      window.dataLayer = [];
+      sendEvent("click_button");
+      expect(window.dataLayer).toEqual([]);
+    });
+  });
+});

--- a/src/helpers/gtm/index.ts
+++ b/src/helpers/gtm/index.ts
@@ -1,0 +1,44 @@
+declare global {
+  interface Window {
+    dataLayer: Record<string, unknown>[];
+  }
+}
+
+let initialized = false;
+
+export const initGTM = (gtmId: string): void => {
+  if (!gtmId || initialized) return;
+  initialized = true;
+
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({ "gtm.start": Date.now(), event: "gtm.js" });
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtm.js?id=${gtmId}`;
+  document.head.appendChild(script);
+
+  const noscript = document.createElement("noscript");
+  const iframe = document.createElement("iframe");
+  iframe.src = `https://www.googletagmanager.com/ns.html?id=${gtmId}`;
+  iframe.height = "0";
+  iframe.width = "0";
+  iframe.style.display = "none";
+  iframe.style.visibility = "hidden";
+  noscript.appendChild(iframe);
+  document.body.insertBefore(noscript, document.body.firstChild);
+};
+
+export const sendPageView = (path: string): void => {
+  if (!initialized) return;
+  window.dataLayer?.push({ event: "page_view", page_path: path });
+};
+
+export const sendEvent = (event: string, params?: Record<string, unknown>): void => {
+  if (!initialized) return;
+  window.dataLayer?.push({ event, ...params });
+};
+
+export const resetGTM = (): void => {
+  initialized = false;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,9 +7,12 @@ import z from "zod";
 import { ChakraProvider } from "@/src/components/config/ChakraProvider.tsx";
 import { ConvexClientProvider } from "@/src/components/config/ConvexProvider.tsx";
 import { customErrorMap } from "@/src/configs/zod/zop-setup.ts";
-import { CLERK_PUBLISHABLE_KEY, CONVEX_URL } from "@/src/constants/env";
+import { CLERK_PUBLISHABLE_KEY, CONVEX_URL, GTM_ID } from "@/src/constants/env";
+import { initGTM } from "@/src/helpers/gtm";
 import reportWebVitals from "./reportWebVitals.ts";
 import { routeTree } from "./routeTree.gen.ts";
+
+initGTM(GTM_ID);
 
 // Create a new router instance
 const router = createRouter({

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,22 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet, useRouterState } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { Toaster } from "@/src/components/ui/toaster";
+import { sendPageView } from "@/src/helpers/gtm";
+
+const PageViewTracker = () => {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  useEffect(() => {
+    sendPageView(pathname);
+  }, [pathname]);
+
+  return null;
+};
 
 export const Route = createRootRoute({
   component: () => (
     <>
+      <PageViewTracker />
       <Outlet />
       <Toaster />
     </>

--- a/src/routes/_auth/dashboard.tsx
+++ b/src/routes/_auth/dashboard.tsx
@@ -1,6 +1,6 @@
 import { Flex, Spinner } from "@chakra-ui/react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { usePaginatedQuery, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { DashboardContent } from "@/src/components/features/Dashboard/DashboardContent";
 import { Animation } from "@/src/components/templates/Animation";
@@ -10,10 +10,20 @@ export const Route = createFileRoute("/_auth/dashboard")({
   component: DashboardPage,
 });
 
-function DashboardPage() {
-  const data = useQuery(api.dashboard.queries.getDashboardData);
+const RECRUITMENT_PAGE_SIZE = 3;
+const STAFF_PAGE_SIZE = 10;
 
-  if (data === undefined) {
+function DashboardPage() {
+  const shop = useQuery(api.dashboard.queries.getDashboardShop);
+  const skipPagination = shop === undefined || shop === null;
+  const recruitments = usePaginatedQuery(api.dashboard.queries.getDashboardRecruitments, skipPagination ? "skip" : {}, {
+    initialNumItems: RECRUITMENT_PAGE_SIZE,
+  });
+  const staffs = usePaginatedQuery(api.dashboard.queries.getDashboardStaffs, skipPagination ? "skip" : {}, {
+    initialNumItems: STAFF_PAGE_SIZE,
+  });
+
+  if (shop === undefined) {
     return (
       <RootContentWrapper>
         <Flex justify="center" align="center" minH="200px">
@@ -23,12 +33,18 @@ function DashboardPage() {
     );
   }
 
-  if (data === null) return null;
-
   return (
     <RootContentWrapper>
       <Animation>
-        <DashboardContent shop={data.shop} recruitments={data.recruitments} staffs={data.staffs} />
+        <DashboardContent
+          shop={shop}
+          recruitments={recruitments.results}
+          recruitmentStatus={recruitments.status}
+          loadMoreRecruitments={() => recruitments.loadMore(RECRUITMENT_PAGE_SIZE)}
+          staffs={staffs.results}
+          staffStatus={staffs.status}
+          loadMoreStaffs={() => staffs.loadMore(STAFF_PAGE_SIZE)}
+        />
       </Animation>
     </RootContentWrapper>
   );


### PR DESCRIPTION
## Summary
ダッシュボードのページネーション対応を中心に、SEO/計測基盤の整備、InfoGuide・UserMenu・RecruitmentStatusBadge などのUI改善をまとめて反映。

## Changes

### ダッシュボード
- シフト・スタッフ一覧にページネーション（`LoadMoreButton`）を追加
- クエリをページネーション対応に分割（`convex/dashboard/queries.ts`）
- 見出しに `InfoGuide` を追加し、各ステータスの意味を説明
- 募集ステータスを3状態化、収集中には警告モーダルを表示
- バッジ文言を「収集中」に統一
- `RecruitmentStatusBadge` を独立コンポーネントに切り出し

### UI / テンプレート
- `InfoGuide` コンポーネント新規作成（情報アイコン付きガイドダイアログ）
- ヘッダーのログアウトボタンを `UserMenu` 化
- スタッフ一覧: オーナーバッジ + オーナー先頭ソート
- スタッフリストの名前列を固定幅化しメールアドレス位置を揃える
- シフトInfoGuide/ステータスラベル文言の調整
- favicon を絵文字SVGに変更

### SEO / 計測
- ランディングページのメタタグ・OGP を整備
- `robots.txt` / `sitemap.xml` を追加・更新
- GTM + GA4 の自前ヘルパー実装（`src/helpers/gtm/`）

### テスト / その他
- ダッシュボードページネーションのE2Eシナリオを追加
- E2Eのローカル実行時タイムアウトを5秒に短縮
- `convex` を v1.35.1 に更新
- レビュー手順を `CLAUDE.md` に追加