### PR TITLE
fix(layout): 固定ヘッダー配下でコンテンツが小さくてもスクロールする不具合を修正

### DIFF
--- a/src/components/templates/StaffLayout/index.tsx
+++ b/src/components/templates/StaffLayout/index.tsx
@@ -11,9 +11,9 @@ type Props = {
 
 export function StaffLayout({ shopName, children }: Props) {
   return (
-    <Flex direction="column" minH="100vh">
+    <Flex direction="column">
       <StaffHeader shopName={shopName} />
-      <Box pt={HEADER_PT} flex={1} display="flex" flexDirection="column">
+      <Box pt={HEADER_PT} flex={1} display="flex" flexDirection="column" minH="100dvh">
         {children}
       </Box>
     </Flex>

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -17,9 +17,9 @@ function RouteComponent() {
 
 function AuthenticatedLayout() {
   return (
-    <Box w="100%" minH="100vh">
+    <Box w="100%">
       <Header />
-      <Box pt="56px">
+      <Box pt="56px" minH="100dvh">
         <Outlet />
       </Box>
     </Box>


### PR DESCRIPTION
外側ラッパーの minH="100vh" と内側の padding-top (ヘッダー高さ分) が重なり、
子要素に h=100% 等があると合計が viewport を超えてスクロールが発生していた。
また 100vh はモバイルブラウザの URL バー分を含むため、見えているビューポート
より大きくなり小さなコンテンツでもスクロールが出ていた。

minH="100dvh" を padding-top と同じ要素に付け替え、border-box により
パディングを内包する形に変更。

https://claude.ai/code/session_014ar8NXdaon1mFrQHcfSaN7