### PR TITLE
fix(line): quota未取得時もLINE送信を試みる

### DIFF
--- a/convex/_lib/notification.test.ts
+++ b/convex/_lib/notification.test.ts
@@ -10,8 +10,8 @@ describe("selectChannel", () => {
     expect(selectChannel({ lineUserId: "U123", lineFollowing: true }, { status: "exceeded" })).toBe("email");
   });
 
-  it("quota が null（cron 未実行）なら安全側で email", () => {
-    expect(selectChannel({ lineUserId: "U123", lineFollowing: true }, null)).toBe("email");
+  it("quota が null（cron 未実行）でも LINE を試みる（失敗時は呼び出し側でフォールバック）", () => {
+    expect(selectChannel({ lineUserId: "U123", lineFollowing: true }, null)).toBe("line");
   });
 
   it("未連携なら email", () => {

--- a/convex/_lib/notification.ts
+++ b/convex/_lib/notification.ts
@@ -2,10 +2,12 @@
  * 通知チャネル振り分け（純粋関数 / DB アクセスなし）
  *
  * 仕様:
- * - LINE 連携済み（lineUserId あり）かつ友達追加中（lineFollowing=true）かつ Quota 残量あり → "line"
+ * - Quota 既知かつ exceeded → "email"
+ * - LINE 連携済み（lineUserId あり）かつ友達追加中（lineFollowing=true） → "line"
  * - それ以外 → "email"
  *
- * Quota が未取得（cron 未実行）の場合は安全側に倒して "email" を返す
+ * Quota が未取得（cron 未実行）の場合は LINE 送信を試みる。
+ * 実際に LINE Push が失敗した場合は呼び出し側で email にフォールバックする。
  */
 export type LineNotificationStaff = {
   lineUserId?: string;
@@ -17,7 +19,7 @@ export type LineNotificationQuota = {
 };
 
 export function selectChannel(staff: LineNotificationStaff, quota: LineNotificationQuota | null): "line" | "email" {
-  if (!quota || quota.status === "exceeded") return "email";
+  if (quota?.status === "exceeded") return "email";
   if (staff.lineUserId && staff.lineFollowing) return "line";
   return "email";
 }


### PR DESCRIPTION
新規デプロイ環境ではcron初回発火（JST 02:00）まで`lineQuotaStatus`が空のため、
LINE連携済みでも強制的にemailになっていた。呼び出し側に既存のtry/catchフォール
バックがあるので、null時はlineを返すよう変更しても安全。

https://claude.ai/code/session_0123zdnV4LUrHPZzQozGQJDr