### PR TITLE
Add network error handling to staff session verification

### DIFF
--- a/src/components/features/StaffView/NetworkErrorView/index.stories.tsx
+++ b/src/components/features/StaffView/NetworkErrorView/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { NetworkErrorView } from "./index";
+
+const meta = {
+  title: "Features/StaffView/NetworkErrorView",
+  component: NetworkErrorView,
+} satisfies Meta<typeof NetworkErrorView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onRetry: () => {},
+  },
+};

--- a/src/components/features/StaffView/NetworkErrorView/index.tsx
+++ b/src/components/features/StaffView/NetworkErrorView/index.tsx
@@ -1,0 +1,26 @@
+import { Button, Flex, Icon, Text, VStack } from "@chakra-ui/react";
+import { LuWifiOff } from "react-icons/lu";
+
+type Props = {
+  onRetry: () => void;
+};
+
+export const NetworkErrorView = ({ onRetry }: Props) => {
+  return (
+    <Flex flex={1} align="center" justify="center" px={8}>
+      <VStack gap={4}>
+        <Icon as={LuWifiOff} boxSize={12} color="orange.500" />
+        <Text fontSize="lg" fontWeight="semibold" textAlign="center">
+          うまく開けませんでした
+        </Text>
+        <Text fontSize="sm" color="fg.muted" textAlign="center">
+          通信がうまくつながりませんでした。{"\n"}
+          再試行するか、ブラウザ（Safari/Chrome）{"\n"}で開き直してください。
+        </Text>
+        <Button colorPalette="teal" size="md" borderRadius="lg" px={6} onClick={onRetry}>
+          再試行する
+        </Button>
+      </VStack>
+    </Flex>
+  );
+};

--- a/src/hooks/useStaffSession.test.ts
+++ b/src/hooks/useStaffSession.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const verifyTokenMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useMutation: () => verifyTokenMock,
+}));
+
+vi.mock("@/convex/_generated/api", () => ({
+  api: { staffAuth: { mutations: { verifyToken: "verifyToken" } } },
+}));
+
+import { useStaffSession } from "./useStaffSession";
+
+beforeEach(() => {
+  localStorage.clear();
+  verifyTokenMock.mockReset();
+});
+
+describe("useStaffSession", () => {
+  it("verifyTokenが reject したとき networkError になる（expired ではない）", async () => {
+    verifyTokenMock.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useStaffSession("token-123"));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("networkError");
+    });
+    if (result.current.status !== "networkError") throw new Error("type guard");
+    expect(typeof result.current.retry).toBe("function");
+  });
+
+  it("retry() を呼ぶと verifyToken が再度呼ばれて成功すれば authenticated になる", async () => {
+    verifyTokenMock
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({ status: "ok", sessionToken: "sess-1", recruitmentId: "rec-1" });
+
+    const { result } = renderHook(() => useStaffSession("token-abc"));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("networkError");
+    });
+
+    const errorState = result.current;
+    if (errorState.status !== "networkError") throw new Error("type guard");
+    act(() => {
+      errorState.retry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("authenticated");
+    });
+    expect(verifyTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("server が status: 'expired' を返したときは networkError にならず expired のまま", async () => {
+    verifyTokenMock.mockResolvedValueOnce({ status: "expired", recruitmentId: "rec-9" });
+
+    const { result } = renderHook(() => useStaffSession("token-xyz"));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("expired");
+    });
+    if (result.current.status !== "expired") throw new Error("type guard");
+    expect(result.current.recruitmentId).toBe("rec-9");
+  });
+
+  it("server が status: 'rate_limited' を返したとき rateLimited になる", async () => {
+    verifyTokenMock.mockResolvedValueOnce({
+      status: "rate_limited",
+      retryAfter: Date.now() + 60_000,
+      recruitmentId: null,
+    });
+
+    const { result } = renderHook(() => useStaffSession("token-rl"));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("rateLimited");
+    });
+  });
+
+  it("token が無く localStorage にもセッションが無いとき expired を返す", () => {
+    const { result } = renderHook(() => useStaffSession(undefined));
+    expect(result.current.status).toBe("expired");
+    if (result.current.status !== "expired") throw new Error("type guard");
+    expect(result.current.recruitmentId).toBeNull();
+    expect(verifyTokenMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useStaffSession.ts
+++ b/src/hooks/useStaffSession.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "convex/react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/convex/_generated/api";
 import { clearSession, getStoredSession, type SessionInfo, storeSession } from "@/src/utils/staffSession";
 
@@ -7,6 +7,7 @@ type StaffSessionState =
   | { status: "loading" }
   | { status: "rateLimited" }
   | { status: "expired"; recruitmentId: string | null }
+  | { status: "networkError"; retry: () => void }
   | { status: "authenticated"; session: SessionInfo; clearSession: () => void };
 
 export function useStaffSession(token: string | undefined): StaffSessionState {
@@ -18,10 +19,11 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
     !token && !initialSession ? { recruitmentId: null } : null,
   );
   const [rateLimited, setRateLimited] = useState(false);
+  const [networkError, setNetworkError] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const verifyingRef = useRef(false);
 
-  useEffect(() => {
+  const verify = useCallback(() => {
     if (!token || session || verifyingRef.current) return;
 
     verifyingRef.current = true;
@@ -39,7 +41,7 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
         }
       })
       .catch(() => {
-        setExpired({ recruitmentId: null });
+        setNetworkError(true);
       })
       .finally(() => {
         verifyingRef.current = false;
@@ -47,7 +49,17 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
       });
   }, [token, session, verifyToken]);
 
+  useEffect(() => {
+    verify();
+  }, [verify]);
+
+  const retry = useCallback(() => {
+    setNetworkError(false);
+    verify();
+  }, [verify]);
+
   if (rateLimited) return { status: "rateLimited" };
+  if (networkError) return { status: "networkError", retry };
   if (expired) return { status: "expired", recruitmentId: expired.recruitmentId };
   if (!session || verifying) return { status: "loading" };
 

--- a/src/hooks/useStaffSession.ts
+++ b/src/hooks/useStaffSession.ts
@@ -20,14 +20,12 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
   );
   const [rateLimited, setRateLimited] = useState(false);
   const [networkError, setNetworkError] = useState(false);
-  const [verifying, setVerifying] = useState(false);
   const verifyingRef = useRef(false);
 
   const verify = useCallback(() => {
     if (!token || session || verifyingRef.current) return;
 
     verifyingRef.current = true;
-    setVerifying(true);
 
     verifyToken({ token })
       .then((result) => {
@@ -45,7 +43,6 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
       })
       .finally(() => {
         verifyingRef.current = false;
-        setVerifying(false);
       });
   }, [token, session, verifyToken]);
 
@@ -61,7 +58,7 @@ export function useStaffSession(token: string | undefined): StaffSessionState {
   if (rateLimited) return { status: "rateLimited" };
   if (networkError) return { status: "networkError", retry };
   if (expired) return { status: "expired", recruitmentId: expired.recruitmentId };
-  if (!session || verifying) return { status: "loading" };
+  if (!session) return { status: "loading" };
 
   return {
     status: "authenticated",

--- a/src/routes/_unregistered/shifts.submit.tsx
+++ b/src/routes/_unregistered/shifts.submit.tsx
@@ -5,7 +5,9 @@ import type { Id } from "@/convex/_generated/dataModel";
 import type { DayEntry } from "@/src/components/features/StaffSubmit/DayCard";
 import { ExpiredSubmitView } from "@/src/components/features/StaffSubmit/ExpiredSubmitView";
 import { ShiftSubmitPage } from "@/src/components/features/StaffSubmit/ShiftSubmitPage";
+import { NetworkErrorView } from "@/src/components/features/StaffView/NetworkErrorView";
 import { RateLimitedView } from "@/src/components/features/StaffView/RateLimitedView";
+import { StaffLayout } from "@/src/components/templates/StaffLayout";
 import { ErrorBoundary } from "@/src/components/ui/ErrorBoundary";
 import { FullPageSpinner } from "@/src/components/ui/FullPageSpinner";
 import { buildMeta } from "@/src/helpers/seo";
@@ -27,6 +29,13 @@ function ShiftSubmitRoute() {
 
   if (state.status === "loading") return <FullPageSpinner />;
   if (state.status === "rateLimited") return <RateLimitedView title="シフト提出" />;
+  if (state.status === "networkError") {
+    return (
+      <StaffLayout shopName="シフト提出">
+        <NetworkErrorView onRetry={state.retry} />
+      </StaffLayout>
+    );
+  }
   if (state.status === "expired") return <ExpiredSubmitView shopName="シフト提出" />;
 
   return (

--- a/src/routes/_unregistered/shifts.view.tsx
+++ b/src/routes/_unregistered/shifts.view.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { ExpiredView } from "@/src/components/features/StaffView/ExpiredView";
+import { NetworkErrorView } from "@/src/components/features/StaffView/NetworkErrorView";
 import { RateLimitedView } from "@/src/components/features/StaffView/RateLimitedView";
 import { ShiftViewPage } from "@/src/components/features/StaffView/ShiftViewPage";
 import { StaffLayout } from "@/src/components/templates/StaffLayout";
@@ -27,6 +28,13 @@ function ShiftViewRoute() {
 
   if (state.status === "loading") return <FullPageSpinner />;
   if (state.status === "rateLimited") return <RateLimitedView title="シフト閲覧" />;
+  if (state.status === "networkError") {
+    return (
+      <StaffLayout shopName="シフト閲覧">
+        <NetworkErrorView onRetry={state.retry} />
+      </StaffLayout>
+    );
+  }
   if (state.status === "expired") {
     return (
       <StaffLayout shopName="シフト閲覧">


### PR DESCRIPTION
## Summary
This PR adds proper network error handling to the staff session verification flow. Previously, network errors during token verification were treated as expired sessions. Now they are handled as a distinct state with a retry mechanism.

## Key Changes
- **Enhanced `useStaffSession` hook**: 
  - Added `networkError` state to distinguish network failures from expired tokens
  - Implemented `retry()` callback to allow users to retry failed verification attempts
  - Changed error handling to set network error state instead of marking session as expired
  - Refactored verification logic into a `verify` callback for reusability

- **New `NetworkErrorView` component**:
  - Created UI component to display network error state with WiFi icon
  - Includes user-friendly Japanese messaging and retry button
  - Integrated with Chakra UI for consistent styling

- **Updated route handlers**:
  - Modified `shifts.view.tsx` and `shifts.submit.tsx` to handle and display network errors
  - Added proper layout wrapping for network error views

- **Comprehensive test coverage**:
  - Added `useStaffSession.test.ts` with 5 test cases covering:
    - Network error detection and retry functionality
    - Successful retry after network failure
    - Proper handling of server-side expired/rate-limited responses
    - Fallback behavior when no token is available

## Implementation Details
- Network errors (promise rejections) are now caught separately from server responses
- The retry mechanism resets the network error state and re-triggers verification
- Rate-limited and expired states are still handled by server responses, not network errors
- All existing session management utilities remain unchanged

https://claude.ai/code/session_011t7GrXYCP7vYqHCAQvkEYW