### PR TITLE
Add detailed logging to requestReissue mutation and email actions

### DIFF
--- a/convex/email/actions.ts
+++ b/convex/email/actions.ts
@@ -137,11 +137,29 @@ export const sendReissueEmail = internalAction({
     recruitmentId: v.id("recruitments"),
   },
   handler: async (ctx, { staffId, recruitmentId }) => {
+    const base = { staffId, recruitmentId };
+    const log = (event: string, extra: Record<string, unknown> = {}) =>
+      console.log(`[sendReissueEmail] ${event}`, { ...base, ...extra });
+    const logWarn = (event: string, extra: Record<string, unknown> = {}) =>
+      console.warn(`[sendReissueEmail] ${event}`, { ...base, ...extra });
+    const logError = (event: string, e: unknown, extra: Record<string, unknown> = {}) =>
+      console.error(`[sendReissueEmail] ${event}`, { ...base, ...extra, error: errorMessage(e) });
+
     const data = await ctx.runQuery(internal.email.queries.getReissueEmailData, { staffId, recruitmentId });
-    if (!data) return;
+    if (!data) {
+      logWarn("data_not_found");
+      return;
+    }
 
     const quota = await ctx.runQuery(internal.line.queries.getQuotaStatusInternal, {});
     const channel = selectChannel({ lineUserId: data.lineUserId, lineFollowing: data.lineFollowing }, quota);
+    log("channel_selected", {
+      channel,
+      hasLineUserId: Boolean(data.lineUserId),
+      lineFollowing: Boolean(data.lineFollowing),
+      hasEmail: Boolean(data.staffEmail),
+      quotaStatus: quota?.status ?? null,
+    });
 
     const { token } = await ctx.runMutation(internal.email.mutations.createMagicLink, {
       staffId,
@@ -161,26 +179,42 @@ export const sendReissueEmail = internalAction({
             magicLinkUrl,
           }),
         );
+        log("line_sent");
         return;
       } catch (e) {
-        console.error("LINE push failed; falling back to email", e);
+        logError("line_push_failed; falling back to email", e);
       }
     }
 
-    if (!data.staffEmail) return;
-    const resend = getResendClient();
-    await resend.emails.send({
-      from: `${data.shopName} <${RESEND_FROM}>`,
-      to: data.staffEmail,
-      subject: `【${data.shopName}】${data.periodLabel} シフト閲覧リンク`,
-      html: buildReissueEmailHtml({
-        staffName: data.staffName,
-        periodLabel: data.periodLabel,
-        magicLinkUrl,
-      }),
-    });
+    if (!data.staffEmail) {
+      log("no_email_no_line_skip");
+      return;
+    }
+
+    try {
+      const resend = getResendClient();
+      await resend.emails.send({
+        from: `${data.shopName} <${RESEND_FROM}>`,
+        to: data.staffEmail,
+        subject: `【${data.shopName}】${data.periodLabel} シフト閲覧リンク`,
+        html: buildReissueEmailHtml({
+          staffName: data.staffName,
+          periodLabel: data.periodLabel,
+          magicLinkUrl,
+        }),
+      });
+      log("email_sent");
+    } catch (e) {
+      // Resend API のエラー（API key 無効 / domain 未認証 / 4xx / 5xx）が action 全体を
+      // 落とすとフロントには成功扱いで返ってしまうため、ここで握ってログだけ残す。
+      logError("email_send_failed", e);
+    }
   },
 });
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
 
 /**
  * 募集開始通知の配信（LINE 振り分け対応）

--- a/convex/email/actions.ts
+++ b/convex/email/actions.ts
@@ -137,28 +137,20 @@ export const sendReissueEmail = internalAction({
     recruitmentId: v.id("recruitments"),
   },
   handler: async (ctx, { staffId, recruitmentId }) => {
-    const base = { staffId, recruitmentId };
-    const log = (event: string, extra: Record<string, unknown> = {}) =>
-      console.log(`[sendReissueEmail] ${event}`, { ...base, ...extra });
-    const logWarn = (event: string, extra: Record<string, unknown> = {}) =>
-      console.warn(`[sendReissueEmail] ${event}`, { ...base, ...extra });
-    const logError = (event: string, e: unknown, extra: Record<string, unknown> = {}) =>
-      console.error(`[sendReissueEmail] ${event}`, { ...base, ...extra, error: errorMessage(e) });
+    const log = (level: "log" | "warn" | "error", event: string, extra: Record<string, unknown> = {}) =>
+      console[level](`[sendReissueEmail] ${event}`, { staffId, recruitmentId, ...extra });
 
     const data = await ctx.runQuery(internal.email.queries.getReissueEmailData, { staffId, recruitmentId });
-    if (!data) {
-      logWarn("data_not_found");
-      return;
-    }
+    if (!data) return log("warn", "data_not_found");
 
     const quota = await ctx.runQuery(internal.line.queries.getQuotaStatusInternal, {});
     const channel = selectChannel({ lineUserId: data.lineUserId, lineFollowing: data.lineFollowing }, quota);
-    log("channel_selected", {
+    log("log", "channel_selected", {
       channel,
       hasLineUserId: Boolean(data.lineUserId),
       lineFollowing: Boolean(data.lineFollowing),
       hasEmail: Boolean(data.staffEmail),
-      quotaStatus: quota?.status ?? null,
+      quotaStatus: quota?.status,
     });
 
     const { token } = await ctx.runMutation(internal.email.mutations.createMagicLink, {
@@ -179,17 +171,13 @@ export const sendReissueEmail = internalAction({
             magicLinkUrl,
           }),
         );
-        log("line_sent");
-        return;
+        return log("log", "line_sent");
       } catch (e) {
-        logError("line_push_failed; falling back to email", e);
+        log("error", "line_push_failed; falling back to email", { error: errorMessage(e) });
       }
     }
 
-    if (!data.staffEmail) {
-      log("no_email_no_line_skip");
-      return;
-    }
+    if (!data.staffEmail) return log("log", "no_email_no_line_skip");
 
     try {
       const resend = getResendClient();
@@ -203,11 +191,11 @@ export const sendReissueEmail = internalAction({
           magicLinkUrl,
         }),
       });
-      log("email_sent");
+      log("log", "email_sent");
     } catch (e) {
       // Resend API のエラー（API key 無効 / domain 未認証 / 4xx / 5xx）が action 全体を
       // 落とすとフロントには成功扱いで返ってしまうため、ここで握ってログだけ残す。
-      logError("email_send_failed", e);
+      log("error", "email_send_failed", { error: errorMessage(e) });
     }
   },
 });

--- a/convex/staffAuth/mutations.test.ts
+++ b/convex/staffAuth/mutations.test.ts
@@ -206,100 +206,62 @@ describe("staffAuth/mutations", () => {
     beforeEach(() => vi.useFakeTimers());
     afterEach(() => vi.useRealTimers());
 
-    it("未登録メールでもエラーを投げない", async () => {
+    /**
+     * 早期リターンの全分岐で void が返ることを確認するテーブルドリブンテスト。
+     * setup フックで DB の状態をいじり、mutation がエラーを投げないことのみを検証する。
+     * （個別ログ出力は実装側のレビューで担保し、テストは「void 維持」契約だけを守る）
+     */
+    type Setup = (t: TestConvex<typeof schema>, ids: Awaited<ReturnType<typeof setupTestData>>) => Promise<void>;
+
+    const noop: Setup = async () => {};
+
+    it.each<{ name: string; email: string; setup: Setup }>([
+      { name: "未登録メールでも void", email: "unknown@example.com", setup: noop },
+      { name: "正常系（有効なメール+recruitment）", email: "suzuki@example.com", setup: noop },
+      {
+        name: "recruitment.status が confirmed 以外でも void",
+        email: "suzuki@example.com",
+        setup: async (t, { recruitmentId }) => {
+          await t.run(async (ctx) => ctx.db.patch(recruitmentId, { status: "open" }));
+        },
+      },
+      {
+        name: "staff.shopId と recruitment.shopId 不一致でも void",
+        email: "suzuki@example.com",
+        setup: async (t, { staffId }) => {
+          await t.run(async (ctx) => {
+            const otherShopId = await ctx.db.insert("shops", {
+              name: "別店舗",
+              shiftStartTime: "09:00",
+              shiftEndTime: "22:00",
+              ownerId: "user_other_owner",
+              isDeleted: false,
+            });
+            await ctx.db.patch(staffId, { shopId: otherShopId });
+          });
+        },
+      },
+      {
+        name: "staff が論理削除済みでも void",
+        email: "suzuki@example.com",
+        setup: async (t, { staffId }) => {
+          await t.run(async (ctx) => ctx.db.patch(staffId, { isDeleted: true }));
+        },
+      },
+      {
+        name: "recruitment が論理削除済みでも void",
+        email: "suzuki@example.com",
+        setup: async (t, { recruitmentId }) => {
+          await t.run(async (ctx) => ctx.db.patch(recruitmentId, { isDeleted: true }));
+        },
+      },
+    ])("$name", async ({ email, setup }) => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const ids = await setupTestData(t);
+      await setup(t, ids);
 
       await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "unknown@example.com",
-          recruitmentId,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("有効なメール+recruitmentでエラーを投げない", async () => {
-      const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
-
-      await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "suzuki@example.com",
-          recruitmentId,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("recruitment.status が confirmed 以外でも void を返す（エラーにならない）", async () => {
-      const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
-
-      // setupTestData の recruitment を open に変更（confirmed 以外）
-      await t.run(async (ctx) => {
-        await ctx.db.patch(recruitmentId, { status: "open" });
-      });
-
-      await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "suzuki@example.com",
-          recruitmentId,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("staff.shopId と recruitment.shopId が不一致でも void を返す", async () => {
-      const t = convexTest(schema, modules);
-      const { recruitmentId, staffId } = await setupTestData(t);
-
-      // 別店舗を作って staff の shopId を移す
-      await t.run(async (ctx) => {
-        const otherShopId = await ctx.db.insert("shops", {
-          name: "別店舗",
-          shiftStartTime: "09:00",
-          shiftEndTime: "22:00",
-          ownerId: "user_other_owner",
-          isDeleted: false,
-        });
-        await ctx.db.patch(staffId, { shopId: otherShopId });
-      });
-
-      await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "suzuki@example.com",
-          recruitmentId,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("staff が論理削除済みでも void を返す", async () => {
-      const t = convexTest(schema, modules);
-      const { recruitmentId, staffId } = await setupTestData(t);
-
-      await t.run(async (ctx) => {
-        await ctx.db.patch(staffId, { isDeleted: true });
-      });
-
-      await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "suzuki@example.com",
-          recruitmentId,
-        }),
-      ).resolves.not.toThrow();
-    });
-
-    it("recruitment が論理削除済みでも void を返す", async () => {
-      const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
-
-      await t.run(async (ctx) => {
-        await ctx.db.patch(recruitmentId, { isDeleted: true });
-      });
-
-      await expect(
-        t.mutation(api.staffAuth.mutations.requestReissue, {
-          email: "suzuki@example.com",
-          recruitmentId,
-        }),
+        t.mutation(api.staffAuth.mutations.requestReissue, { email, recruitmentId: ids.recruitmentId }),
       ).resolves.not.toThrow();
     });
   });

--- a/convex/staffAuth/mutations.test.ts
+++ b/convex/staffAuth/mutations.test.ts
@@ -229,6 +229,79 @@ describe("staffAuth/mutations", () => {
         }),
       ).resolves.not.toThrow();
     });
+
+    it("recruitment.status が confirmed 以外でも void を返す（エラーにならない）", async () => {
+      const t = convexTest(schema, modules);
+      const { recruitmentId } = await setupTestData(t);
+
+      // setupTestData の recruitment を open に変更（confirmed 以外）
+      await t.run(async (ctx) => {
+        await ctx.db.patch(recruitmentId, { status: "open" });
+      });
+
+      await expect(
+        t.mutation(api.staffAuth.mutations.requestReissue, {
+          email: "suzuki@example.com",
+          recruitmentId,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("staff.shopId と recruitment.shopId が不一致でも void を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { recruitmentId, staffId } = await setupTestData(t);
+
+      // 別店舗を作って staff の shopId を移す
+      await t.run(async (ctx) => {
+        const otherShopId = await ctx.db.insert("shops", {
+          name: "別店舗",
+          shiftStartTime: "09:00",
+          shiftEndTime: "22:00",
+          ownerId: "user_other_owner",
+          isDeleted: false,
+        });
+        await ctx.db.patch(staffId, { shopId: otherShopId });
+      });
+
+      await expect(
+        t.mutation(api.staffAuth.mutations.requestReissue, {
+          email: "suzuki@example.com",
+          recruitmentId,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("staff が論理削除済みでも void を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { recruitmentId, staffId } = await setupTestData(t);
+
+      await t.run(async (ctx) => {
+        await ctx.db.patch(staffId, { isDeleted: true });
+      });
+
+      await expect(
+        t.mutation(api.staffAuth.mutations.requestReissue, {
+          email: "suzuki@example.com",
+          recruitmentId,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("recruitment が論理削除済みでも void を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { recruitmentId } = await setupTestData(t);
+
+      await t.run(async (ctx) => {
+        await ctx.db.patch(recruitmentId, { isDeleted: true });
+      });
+
+      await expect(
+        t.mutation(api.staffAuth.mutations.requestReissue, {
+          email: "suzuki@example.com",
+          recruitmentId,
+        }),
+      ).resolves.not.toThrow();
+    });
   });
 
   describe("requestReissue レートリミット", () => {

--- a/convex/staffAuth/mutations.ts
+++ b/convex/staffAuth/mutations.ts
@@ -90,21 +90,17 @@ export const requestReissue = mutation({
     recruitmentId: v.id("recruitments"),
   },
   handler: async (ctx, { email, recruitmentId }) => {
-    const emailDomain = email.split("@")[1] ?? null;
-    const logSkip = (reason: string, extra: Record<string, unknown> = {}) => {
+    const emailDomain = email.split("@")[1];
+    const logSkip = (reason: string, extra: Record<string, unknown> = {}) =>
       console.warn("[requestReissue] skip", { reason, recruitmentId, ...extra });
-    };
 
     // レートリミットチェック（email+recruitmentId をキーに）
+    // メアド列挙攻撃防止: レートリミットでも成功時と同じレスポンス（void）を返す
     const { ok } = await rateLimit(ctx, {
       name: "requestReissue",
       key: `${email}:${recruitmentId}`,
     });
-    if (!ok) {
-      // メアド列挙攻撃防止: レートリミットでも成功時と同じレスポンス（void）を返す
-      logSkip("rate_limited", { emailDomain });
-      return;
-    }
+    if (!ok) return logSkip("rate_limited", { emailDomain });
 
     const staff = await ctx.db
       .query("staffs")
@@ -114,23 +110,21 @@ export const requestReissue = mutation({
     if (staff.isDeleted) return logSkip("staff_deleted", { staffId: staff._id });
 
     const recruitment = await ctx.db.get(recruitmentId);
-    if (!recruitment) return logSkip("recruitment_not_found", { staffId: staff._id });
-    if (recruitment.isDeleted) return logSkip("recruitment_deleted", { staffId: staff._id });
+    const staffId = staff._id;
+    if (!recruitment) return logSkip("recruitment_not_found", { staffId });
+    if (recruitment.isDeleted) return logSkip("recruitment_deleted", { staffId });
     if (recruitment.status !== "confirmed") {
-      return logSkip("recruitment_not_confirmed", { staffId: staff._id, status: recruitment.status });
+      return logSkip("recruitment_not_confirmed", { staffId, status: recruitment.status });
     }
     if (staff.shopId !== recruitment.shopId) {
       return logSkip("shop_mismatch", {
-        staffId: staff._id,
+        staffId,
         staffShopId: staff.shopId,
         recruitmentShopId: recruitment.shopId,
       });
     }
 
-    await ctx.scheduler.runAfter(0, internal.email.actions.sendReissueEmail, {
-      staffId: staff._id,
-      recruitmentId,
-    });
-    console.log("[requestReissue] scheduled", { staffId: staff._id, recruitmentId });
+    await ctx.scheduler.runAfter(0, internal.email.actions.sendReissueEmail, { staffId, recruitmentId });
+    console.log("[requestReissue] scheduled", { staffId, recruitmentId });
   },
 });

--- a/convex/staffAuth/mutations.ts
+++ b/convex/staffAuth/mutations.ts
@@ -79,6 +79,10 @@ export const verifyToken = mutation({
 /**
  * リンク再発行リクエスト
  * セキュリティ: 結果に関わらず一律voidを返す（メアド列挙攻撃防止）
+ *
+ * 内部ロギング: 早期リターンの理由をサーバーログに残し、配信不達の原因特定を可能にする。
+ * フロントへのレスポンスはどの分岐でも void を維持する。
+ * メールアドレスは生で残さず domain 部分のみログに含める（Dashboard 共有時の漏洩防止）。
  */
 export const requestReissue = mutation({
   args: {
@@ -86,6 +90,11 @@ export const requestReissue = mutation({
     recruitmentId: v.id("recruitments"),
   },
   handler: async (ctx, { email, recruitmentId }) => {
+    const emailDomain = email.split("@")[1] ?? null;
+    const logSkip = (reason: string, extra: Record<string, unknown> = {}) => {
+      console.warn("[requestReissue] skip", { reason, recruitmentId, ...extra });
+    };
+
     // レートリミットチェック（email+recruitmentId をキーに）
     const { ok } = await rateLimit(ctx, {
       name: "requestReissue",
@@ -93,6 +102,7 @@ export const requestReissue = mutation({
     });
     if (!ok) {
       // メアド列挙攻撃防止: レートリミットでも成功時と同じレスポンス（void）を返す
+      logSkip("rate_limited", { emailDomain });
       return;
     }
 
@@ -100,23 +110,27 @@ export const requestReissue = mutation({
       .query("staffs")
       .withIndex("by_email", (q) => q.eq("email", email))
       .first();
+    if (!staff) return logSkip("staff_not_found", { emailDomain });
+    if (staff.isDeleted) return logSkip("staff_deleted", { staffId: staff._id });
 
     const recruitment = await ctx.db.get(recruitmentId);
-
-    if (
-      !staff ||
-      staff.isDeleted ||
-      !recruitment ||
-      recruitment.isDeleted ||
-      recruitment.status !== "confirmed" ||
-      staff.shopId !== recruitment.shopId
-    ) {
-      return;
+    if (!recruitment) return logSkip("recruitment_not_found", { staffId: staff._id });
+    if (recruitment.isDeleted) return logSkip("recruitment_deleted", { staffId: staff._id });
+    if (recruitment.status !== "confirmed") {
+      return logSkip("recruitment_not_confirmed", { staffId: staff._id, status: recruitment.status });
+    }
+    if (staff.shopId !== recruitment.shopId) {
+      return logSkip("shop_mismatch", {
+        staffId: staff._id,
+        staffShopId: staff.shopId,
+        recruitmentShopId: recruitment.shopId,
+      });
     }
 
     await ctx.scheduler.runAfter(0, internal.email.actions.sendReissueEmail, {
       staffId: staff._id,
       recruitmentId,
     });
+    console.log("[requestReissue] scheduled", { staffId: staff._id, recruitmentId });
   },
 });


### PR DESCRIPTION
## Summary
Enhanced observability for the magic link reissue flow by adding structured logging at early return points in the `requestReissue` mutation and `sendReissueEmail` action. This enables better debugging of delivery failures while maintaining security by avoiding email enumeration attacks.

## Key Changes

- **requestReissue mutation**: Added granular logging for each early return condition (rate limited, staff not found, deleted records, status mismatch, shop mismatch). Logs include staffId and recruitment context but mask email addresses to only domain portion for security.

- **sendReissueEmail action**: Added structured logging for channel selection, LINE push attempts, email send attempts, and error cases. Implemented error handling for Resend API failures to prevent action-level failures from masking success responses to the frontend.

- **Test refactoring**: Converted individual test cases into a table-driven test using `it.each()` to comprehensively verify that all early return branches maintain the void contract. Added test cases for:
  - Unregistered email
  - Valid email with recruitment
  - Non-confirmed recruitment status
  - Shop ID mismatch
  - Soft-deleted staff
  - Soft-deleted recruitment

## Implementation Details

- Email domain extraction (`email.split("@")[1]`) prevents sensitive email data from appearing in logs while preserving domain information for debugging
- Consistent log format with `[functionName]` prefix for easy filtering in centralized logging
- Error messages extracted via `errorMessage()` helper to safely handle unknown error types
- Resend API errors are caught and logged rather than propagated, ensuring frontend always receives success response (void) regardless of delivery outcome

https://claude.ai/code/session_013yJiqjbcLhbwvQVbfndJGK