### PR TITLE
Renovateの自動マージCI設定を安定化

### DIFF
--- a/.github/workflows/test-logic.yml
+++ b/.github/workflows/test-logic.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   unit-test:
+    name: logic-test (${{ matrix.shard }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   unit-test:
+    name: ui-test (${{ matrix.shard }})
     runs-on: ubuntu-latest
     environment: Preview
     strategy:

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -53,11 +53,11 @@ import type * as shiftSubmission_mutations from "../shiftSubmission/mutations.js
 import type * as shiftSubmission_queries from "../shiftSubmission/queries.js";
 import type * as shiftSubmission_schemas from "../shiftSubmission/schemas.js";
 import type * as shop_mutations from "../shop/mutations.js";
+import type * as staff_mutations from "../staff/mutations.js";
+import type * as staff_schemas from "../staff/schemas.js";
 import type * as staffAuth_mutations from "../staffAuth/mutations.js";
 import type * as staffAuth_queries from "../staffAuth/queries.js";
 import type * as staffAuth_schemas from "../staffAuth/schemas.js";
-import type * as staff_mutations from "../staff/mutations.js";
-import type * as staff_schemas from "../staff/schemas.js";
 import type * as testing from "../testing.js";
 
 import type {
@@ -112,11 +112,11 @@ declare const fullApi: ApiFromModules<{
   "shiftSubmission/queries": typeof shiftSubmission_queries;
   "shiftSubmission/schemas": typeof shiftSubmission_schemas;
   "shop/mutations": typeof shop_mutations;
+  "staff/mutations": typeof staff_mutations;
+  "staff/schemas": typeof staff_schemas;
   "staffAuth/mutations": typeof staffAuth_mutations;
   "staffAuth/queries": typeof staffAuth_queries;
   "staffAuth/schemas": typeof staffAuth_schemas;
-  "staff/mutations": typeof staff_mutations;
-  "staff/schemas": typeof staff_schemas;
   testing: typeof testing;
 }>;
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   "@clerk/shared": false
   esbuild: true

--- a/renovate.json
+++ b/renovate.json
@@ -5,20 +5,32 @@
   "labels": ["renovate"],
   "baseBranchPatterns": ["develop"],
   "automerge": true,
+  "platformAutomerge": true,
+  "rebaseWhen": "conflicted",
   "minimumReleaseAge": "2 days",
   "schedule": ["* * * * 6"],
+  "prConcurrentLimit": 10,
+  "branchConcurrentLimit": 10,
+  "prHourlyLimit": 10,
+  "commitHourlyLimit": 10,
   "packageRules": [
     {
       "addLabels": ["react"],
-      "matchPackageNames": ["/react/"]
+      "groupName": "React packages",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     },
     {
       "addLabels": ["Storybook"],
-      "matchPackageNames": ["/@storybook/", "@chromatic-com/storybook"]
+      "groupName": "Storybook packages",
+      "matchPackageNames": ["/^@storybook\\//", "@chromatic-com/storybook"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     },
     {
       "addLabels": ["playwright"],
-      "matchPackageNames": ["/playwright/"]
+      "groupName": "Playwright packages",
+      "matchPackageNames": ["playwright", "/^@playwright\\//"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Renovateが同一内容のcommitを作り直してCIを再走させる問題を抑えるため、競合時のみrebaseする設定へ変更します。あわせてdevelopの必須CI rulesetと一致するよう、logic/ui testのチェック名を分離します。

## Changes
- **Renovate設定**: `rebaseWhen: conflicted`、`commitHourlyLimit`、10件並行運用、GitHub platform automergeを明示
- **CIチェック名**: logic testとUI testのmatrixチェック名を `logic-test (...)` / `ui-test (...)` に分離
- **pnpm workspace**: 単一パッケージとして `packages: ["."]` を明示し、pnpm実行エラーを回避

## Verification
- `jq . renovate.json`
- `pnpm lint`
- `pnpm type-check`
- `git diff --check`
- GitHub ruleset `Require CI Pass` がdevelop向けにactiveであることを確認済み