### PR TITLE
CIの外部公開処理を軽量化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-preview:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed' && !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     environment: Preview
     env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Deploy Report to GitHub Pages
         if: ${{ !cancelled() }}
         run: |
-          git clone https://x-access-token:${{ secrets.HOSTING_PAGES_TOKEN }}@github.com/yn1323/hosting-pages.git
+          git clone --depth 1 --single-branch https://x-access-token:${{ secrets.HOSTING_PAGES_TOKEN }}@github.com/yn1323/hosting-pages.git
           rm -rf hosting-pages/$REPORT_DIR/${{ github.event.pull_request.number }}
           mkdir -p hosting-pages/$REPORT_DIR/${{ github.event.pull_request.number }}
           cp -r playwright-report/* hosting-pages/$REPORT_DIR/${{ github.event.pull_request.number }}/


### PR DESCRIPTION
## Summary
E2EのPlaywrightレポート公開時に `hosting-pages` リポジトリの履歴全体を取得しており、CI時間が伸びていました。
あわせて、Renovateの依存更新PRではCloudflare PagesのPreview Deployを走らせないようにして、不要な外部デプロイを抑制します。

## Changes
- **E2Eレポート公開の軽量化**: `hosting-pages` のcloneに `--depth 1 --single-branch` を追加
- **Renovate PRのDeploy抑制**: `renovate/` で始まるPRブランチでは `deploy-preview` ジョブをスキップ
- **cleanupは維持**: PR close時のCloudflare Pages preview削除処理は既存previewの片付け用に残す

## Verification
- `pnpm lint`（ブランチ移動前に成功）
- `pnpm type-check`（ブランチ移動前に成功）
- `./node_modules/.bin/biome check`
- `./node_modules/.bin/tsc`
- `git diff --check`