### PR TITLE
スタッフ向け法務同意ページと通知文面を整備

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
           TZ: Asia/Tokyo
           VITE_CONVEX_URL: ${{ steps.preview.outputs.PREVIEW_URL }}
           CONVEX_PREVIEW_NAME: ${{ env.CONVEX_PREVIEW_NAME }}
-          E2E_CLERK_USER: ${{ vars.E2E_CLERK_USER }}
+          E2E_CLERK_USERS: ${{ vars.E2E_CLERK_USERS }}
           E2E_CLERK_PASSWORD: ${{ vars.E2E_CLERK_PASSWORD }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           VITE_CLERK_PUBLISHABLE_KEY: ${{ secrets.VITE_CLERK_PUBLISHABLE_KEY }}

--- a/.github/workflows/sync-release-version-to-develop.yml
+++ b/.github/workflows/sync-release-version-to-develop.yml
@@ -1,0 +1,117 @@
+name: Sync Release Version to Develop
+
+on:
+  workflow_run:
+    workflows: ["Release to Production"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate sync token
+        env:
+          RELEASE_SYNC_TOKEN: ${{ secrets.RELEASE_SYNC_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_SYNC_TOKEN" ]; then
+            echo "::error title=RELEASE_SYNC_TOKEN is not configured::Create a fine-grained PAT or GitHub App token with contents:write and pull_requests:write so the sync branch push triggers normal CI."
+            exit 1
+          fi
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync package version from main
+        id: sync
+        env:
+          RELEASE_SYNC_TOKEN: ${{ secrets.RELEASE_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SYNC_BRANCH="ci/sync-release-version-to-develop"
+          git remote set-url origin "https://x-access-token:${RELEASE_SYNC_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin main develop --prune
+
+          MAIN_VERSION="$(git show origin/main:package.json | node -e "let input = ''; process.stdin.on('data', (chunk) => input += chunk); process.stdin.on('end', () => console.log(JSON.parse(input).version));")"
+          DEVELOP_VERSION="$(node -e "const fs = require('fs'); console.log(JSON.parse(fs.readFileSync('package.json', 'utf8')).version);")"
+
+          echo "branch=${SYNC_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "version=${MAIN_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "from_version=${DEVELOP_VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ "$MAIN_VERSION" = "$DEVELOP_VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "develop already has package version ${MAIN_VERSION}."
+            exit 0
+          fi
+
+          git switch -C "$SYNC_BRANCH" origin/develop
+          node -e 'const fs = require("fs"); const version = process.argv[1]; const path = "package.json"; const pkg = JSON.parse(fs.readFileSync(path, "utf8")); pkg.version = version; fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);' "$MAIN_VERSION"
+
+          if git diff --quiet -- package.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No package.json diff to sync."
+            exit 0
+          fi
+
+          git add package.json
+          git commit -m "chore: sync release version ${MAIN_VERSION} to develop"
+          git push --force-with-lease origin "$SYNC_BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update pull request
+        if: steps.sync.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_SYNC_TOKEN }}
+          SYNC_BRANCH: ${{ steps.sync.outputs.branch }}
+          RELEASE_VERSION: ${{ steps.sync.outputs.version }}
+          DEVELOP_VERSION: ${{ steps.sync.outputs.from_version }}
+        run: |
+          set -euo pipefail
+
+          TITLE="chore: sync release version ${RELEASE_VERSION} to develop"
+          BODY="$(cat <<EOF
+          main のリリース処理で更新された package version を develop に取り込みます。
+
+          - develop: ${DEVELOP_VERSION}
+          - main: ${RELEASE_VERSION}
+
+          このPRは \`package.json\` の version 同期だけを対象にします。
+          EOF
+          )"
+
+          PR_NUMBER="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$SYNC_BRANCH" \
+            --base develop \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')"
+
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr edit "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body "$BODY"
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base develop \
+              --head "$SYNC_BRANCH" \
+              --title "$TITLE" \
+              --body "$BODY"
+          fi

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -23,6 +23,7 @@ import type * as _lib_resend from "../_lib/resend.js";
 import type * as _lib_time from "../_lib/time.js";
 import type * as _lib_uuid from "../_lib/uuid.js";
 import type * as _lib_validation from "../_lib/validation.js";
+import type * as _test_scenarioBuilders from "../_test/scenarioBuilders.js";
 import type * as _test_seed from "../_test/seed.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
@@ -89,6 +90,7 @@ declare const fullApi: ApiFromModules<{
   "_lib/time": typeof _lib_time;
   "_lib/uuid": typeof _lib_uuid;
   "_lib/validation": typeof _lib_validation;
+  "_test/scenarioBuilders": typeof _test_scenarioBuilders;
   "_test/seed": typeof _test_seed;
   constants: typeof constants;
   crons: typeof crons;

--- a/convex/_lib/notificationDelivery.test.ts
+++ b/convex/_lib/notificationDelivery.test.ts
@@ -40,10 +40,10 @@ describe("isDryRunOwnerEmail", () => {
   });
 
   it("matches NOTIFICATION_DRY_RUN_USER_EMAILS entries as case-insensitive substrings after trimming", () => {
-    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "testtest, Test2@example.com ");
+    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "e2e-user-1@test.com, Test2@example.com ");
 
-    expect(isDryRunOwnerEmail(" testtest ")).toBe(true);
-    expect(isDryRunOwnerEmail(" testtest@example.com ")).toBe(true);
+    expect(isDryRunOwnerEmail(" e2e-user-1@test.com ")).toBe(true);
+    expect(isDryRunOwnerEmail(" preview-e2e-user-1@test.com ")).toBe(true);
     expect(isDryRunOwnerEmail(" TEST2@example.com ")).toBe(true);
   });
 
@@ -60,7 +60,7 @@ describe("isDryRunOwnerEmail", () => {
   });
 
   it("does not match owner emails outside NOTIFICATION_DRY_RUN_USER_EMAILS", () => {
-    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "testtest,test2");
+    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "e2e-user-1@test.com,test2");
 
     expect(isDryRunOwnerEmail("manager@example.com")).toBe(false);
   });
@@ -89,7 +89,7 @@ describe("isNotificationDeliverySuppressedForShop", () => {
   });
 
   it("returns false when the shop owner's users.email is not configured for dry-run", async () => {
-    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "testtest,test2");
+    vi.stubEnv("NOTIFICATION_DRY_RUN_USER_EMAILS", "e2e-user-1@test.com,test2");
     const t = convexTest(schema, modules);
     const shopId = await t.run(async (ctx) => {
       const seeded = await seedManagerShop(ctx, {
@@ -116,7 +116,7 @@ describe("E2E owner seed email", () => {
     const t = convexTest(schema, modules);
     const result = await t.mutation(internal.testing.seedLineLinkScenario, {
       ownerAuthTokenIdentifier: "owner_e2e",
-      ownerEmail: "testtest",
+      ownerEmail: "e2e-user-1@test.com",
     });
 
     const stored = await t.run(async (ctx) => {
@@ -128,6 +128,6 @@ describe("E2E owner seed email", () => {
       return { ownerEmail: owner?.email, staffEmail: staff?.email };
     });
 
-    expect(stored).toEqual({ ownerEmail: "testtest", staffEmail: "tanaka@example.com" });
+    expect(stored).toEqual({ ownerEmail: "e2e-user-1@test.com", staffEmail: "tanaka@example.com" });
   });
 });

--- a/convex/legal/actions.ts
+++ b/convex/legal/actions.ts
@@ -30,7 +30,7 @@ export const sendStaffConsentEmail = internalAction({
     await resend.emails.send({
       from: formatResendFrom(data.shopName, RESEND_FROM_EMAIL),
       to: data.staffEmail,
-      subject: formatResendSubject(data.shopName, "シフト管理サービスの利用規約・プライバシーポリシー確認のお願い"),
+      subject: formatResendSubject(data.shopName, "シフトリの使い方と利用規約・プライバシーポリシーの確認"),
       html: buildStaffLegalConsentEmailHtml({
         staffName: data.staffName,
         shopName: data.shopName,

--- a/convex/notification/templates.ts
+++ b/convex/notification/templates.ts
@@ -398,20 +398,19 @@ export function buildStaffLegalConsentEmailHtml(params: StaffLegalConsentEmailPa
         <tr><td style="padding:32px 24px;">
           <p style="margin:0 0 20px;font-size:15px;color:#1a202c;">${params.staffName}さん</p>
           <p style="margin:0 0 16px;font-size:15px;color:#1a202c;">
-            ${params.shopName} が利用しているシフト管理SaaS「シフトリ」からのお知らせです。<br/>
-            シフトリではメール・LINEからシフト希望の提出・確定の通知の受け取りが可能です。
+            ${params.shopName} で利用するシフト管理サービス「シフトリ」のご案内です。<br/>
+            シフトリでは、メール・LINEで届くリンクからシフト希望の提出や確定シフトの確認ができます。
           </p>
-          <p style="margin:0 0 24px;font-size:15px;color:#1a202c;">サービス利用のため、利用規約とプライバシーポリシーへの同意をお願いします。</p>
+          <p style="margin:0 0 24px;font-size:15px;color:#1a202c;">下のリンクから、シフトリの使い方と利用規約・プライバシーポリシーをご確認ください。</p>
 
           <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
             <tr><td align="center">
-              <a href="${params.consentUrl}" style="display:inline-block;padding:12px 32px;background-color:#319795;color:#ffffff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;" rel="noreferrer">規約を確認して同意する</a>
+              <a href="${params.consentUrl}" style="display:inline-block;padding:12px 32px;background-color:#319795;color:#ffffff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;" rel="noreferrer">シフトリの案内と規約を確認する</a>
             </td></tr>
           </table>
 
           <p style="margin:0 0 8px;font-size:13px;color:#718096;">このリンクは ${expiresAtLabel} まで有効です。</p>
-          <p style="margin:0 0 8px;font-size:13px;color:#718096;">期限が切れた場合でも、LINE連携時の案内やシフト提出時に同意できます。</p>
-          <p style="margin:0 0 24px;font-size:13px;color:#718096;">未同意でも、シフト募集・催促・確定シフトなどのお知らせは引き続き受け取れます。</p>
+          <p style="margin:0 0 24px;font-size:13px;color:#718096;">利用規約・プライバシーポリシーの同意が間に合わなくても、シフト募集・催促・確定シフトなどのお知らせは引き続き受け取れます。</p>
 
           <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;" />
           <p style="margin:0;font-size:12px;color:#a0aec0;">※ このメールに返信しても届きません。</p>
@@ -432,10 +431,12 @@ export function buildStaffLegalConsentLineText(params: {
   return [
     `${params.staffName}さん`,
     "",
-    `${params.shopName} が利用しているシフト管理SaaS「シフトリ」からのお知らせです。`,
-    "スタッフ向け利用規約とプライバシーポリシーをご確認ください。",
+    `${params.shopName} で利用するシフト管理サービス「シフトリ」のご案内です。`,
+    "シフトリでは、メール・LINEで届くリンクからシフト希望の提出や確定シフトの確認ができます。",
     "",
-    "確認と同意はこちら",
+    "シフトリの使い方と、利用規約・プライバシーポリシーを確認できます。",
+    "",
+    "確認はこちら",
     params.consentUrl,
     "",
     `リンク有効期限: ${formatDateTimeJa(params.expiresAt)}`,

--- a/convex/testing.ts
+++ b/convex/testing.ts
@@ -13,6 +13,15 @@ import schema from "./schema";
 
 const TABLE_NAMES = Object.keys(schema.tables) as (keyof typeof schema.tables)[];
 const magicLinkPurposeValidator = v.union(v.literal("submit"), v.literal("view"));
+const staffEmailScopeArgs = {
+  shopId: v.optional(v.id("shops")),
+  staffEmail: v.string(),
+};
+const magicLinkLookupArgs = {
+  recruitmentId: v.optional(v.id("recruitments")),
+  ...staffEmailScopeArgs,
+  purpose: magicLinkPurposeValidator,
+};
 const scenarioDatesValidator = v.object({
   periodStart: v.string(),
   periodEnd: v.string(),
@@ -47,13 +56,44 @@ function assertE2EHelpersEnabled() {
   }
 }
 
-async function findActiveStaffByEmail(ctx: TestCtx, staffEmail: string) {
+async function findActiveStaffByEmail(ctx: TestCtx, staffEmail: string, shopId?: Id<"shops">) {
+  if (shopId) {
+    return await ctx.db
+      .query("staffs")
+      .withIndex("by_shopId_email_isDeleted", (q) =>
+        q.eq("shopId", shopId).eq("email", staffEmail).eq("isDeleted", false),
+      )
+      .first();
+  }
+
   const staffs = await ctx.db
     .query("staffs")
     .withIndex("by_email", (q) => q.eq("email", staffEmail))
     .order("desc")
     .take(10);
   return staffs.find((staff) => !staff.isDeleted) ?? null;
+}
+
+async function findOwnerShopByAuthTokenIdentifier(ctx: TestCtx, ownerAuthTokenIdentifier: string) {
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_authTokenIdentifier", (q) => q.eq("authTokenIdentifier", ownerAuthTokenIdentifier))
+    .order("desc")
+    .first();
+  if (!user || user.isDeleted) return null;
+
+  const memberships = await ctx.db
+    .query("shopMembers")
+    .withIndex("by_userId_and_isDeleted", (q) => q.eq("userId", user._id).eq("isDeleted", false))
+    .order("desc")
+    .take(10);
+
+  for (const membership of memberships) {
+    const shop = await ctx.db.get(membership.shopId);
+    if (shop && !shop.isDeleted) return shop;
+  }
+
+  return null;
 }
 
 function matchesPurpose(status: "open" | "confirmed", purpose: MagicLinkPurpose) {
@@ -216,7 +256,7 @@ async function deleteShopGraph(ctx: MutationCtx, shopId: Id<"shops">) {
   await ctx.db.delete(shopId);
 }
 
-async function resetOwnerScenarioData(ctx: MutationCtx, ownerAuthTokenIdentifier: string) {
+async function resetOwnerScenarioDataForAuth(ctx: MutationCtx, ownerAuthTokenIdentifier: string) {
   const users = await ctx.db
     .query("users")
     .withIndex("by_authTokenIdentifier", (q) => q.eq("authTokenIdentifier", ownerAuthTokenIdentifier))
@@ -240,6 +280,18 @@ async function resetOwnerScenarioData(ctx: MutationCtx, ownerAuthTokenIdentifier
   }
 }
 
+export const resetOwnerScenarioData = internalMutation({
+  args: {
+    ownerAuthTokenIdentifier: v.string(),
+  },
+  handler: async (ctx, args) => {
+    assertE2EHelpersEnabled();
+    if (!args.ownerAuthTokenIdentifier) throw new Error("ownerAuthTokenIdentifier is required");
+    await resetOwnerScenarioDataForAuth(ctx, args.ownerAuthTokenIdentifier);
+    return { reset: true };
+  },
+});
+
 async function createOwnerScenario(
   ctx: MutationCtx,
   args: {
@@ -252,7 +304,7 @@ async function createOwnerScenario(
 ) {
   assertE2EHelpersEnabled();
   if (!args.ownerAuthTokenIdentifier) throw new Error("ownerAuthTokenIdentifier is required");
-  await resetOwnerScenarioData(ctx, args.ownerAuthTokenIdentifier);
+  await resetOwnerScenarioDataForAuth(ctx, args.ownerAuthTokenIdentifier);
 
   const userId = await ctx.db.insert("users", {
     authTokenIdentifier: args.ownerAuthTokenIdentifier,
@@ -431,6 +483,7 @@ export const clearAllTables = internalMutation(async ({ db }) => {
  */
 export const seedShiftData = internalMutation({
   args: {
+    ownerAuthTokenIdentifier: v.optional(v.string()),
     staffAssignments: v.array(
       v.object({
         staffName: v.string(),
@@ -448,8 +501,9 @@ export const seedShiftData = internalMutation({
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const shops = await ctx.db.query("shops").order("desc").take(1);
-    const shop = shops[0];
+    const shop = args.ownerAuthTokenIdentifier
+      ? await findOwnerShopByAuthTokenIdentifier(ctx, args.ownerAuthTokenIdentifier)
+      : await ctx.db.query("shops").order("desc").first();
     if (!shop) throw new Error("No shop found");
 
     const staffs = await ctx.db
@@ -760,7 +814,7 @@ export const seedSubmitTestData = internalMutation({
     });
 
     // magic link token
-    const token = `test-token-${Date.now()}`;
+    const token = generateUUID();
     await ctx.db.insert("magicLinks", {
       token,
       staffId,
@@ -1048,15 +1102,11 @@ export const seedLineLinkScenario = internalMutation({
 });
 
 export const getLatestMagicLinkToken = internalQuery({
-  args: {
-    recruitmentId: v.optional(v.id("recruitments")),
-    staffEmail: v.string(),
-    purpose: magicLinkPurposeValidator,
-  },
+  args: magicLinkLookupArgs,
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const staff = await findActiveStaffByEmail(ctx, args.staffEmail);
+    const staff = await findActiveStaffByEmail(ctx, args.staffEmail, args.shopId);
     if (!staff) return { token: null };
 
     const links = await ctx.db
@@ -1083,15 +1133,11 @@ export const getLatestMagicLinkToken = internalQuery({
 });
 
 export const createMagicLinkTokenForLatestRecruitment = internalMutation({
-  args: {
-    recruitmentId: v.optional(v.id("recruitments")),
-    staffEmail: v.string(),
-    purpose: magicLinkPurposeValidator,
-  },
+  args: magicLinkLookupArgs,
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const staff = await findActiveStaffByEmail(ctx, args.staffEmail);
+    const staff = await findActiveStaffByEmail(ctx, args.staffEmail, args.shopId);
     if (!staff) throw new Error(`Staff not found: ${args.staffEmail}`);
 
     const recruitment = await findRecruitmentForPurpose(ctx, staff, args.purpose, args.recruitmentId);
@@ -1111,13 +1157,11 @@ export const createMagicLinkTokenForLatestRecruitment = internalMutation({
 });
 
 export const getLatestLineLinkToken = internalQuery({
-  args: {
-    staffEmail: v.string(),
-  },
+  args: staffEmailScopeArgs,
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const staff = await findActiveStaffByEmail(ctx, args.staffEmail);
+    const staff = await findActiveStaffByEmail(ctx, args.staffEmail, args.shopId);
     if (!staff) return { token: null };
 
     const links = await ctx.db
@@ -1146,13 +1190,11 @@ export const getLatestLineLinkToken = internalQuery({
 });
 
 export const createLineLinkTokenForStaff = internalMutation({
-  args: {
-    staffEmail: v.string(),
-  },
+  args: staffEmailScopeArgs,
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const staff = await findActiveStaffByEmail(ctx, args.staffEmail);
+    const staff = await findActiveStaffByEmail(ctx, args.staffEmail, args.shopId);
     if (!staff) throw new Error(`Staff not found: ${args.staffEmail}`);
 
     const token = await createLineLinkToken(ctx, { staffId: staff._id, shopId: staff.shopId });
@@ -1162,13 +1204,11 @@ export const createLineLinkTokenForStaff = internalMutation({
 });
 
 export const simulateLineFollowForStaff = internalMutation({
-  args: {
-    staffEmail: v.string(),
-  },
+  args: staffEmailScopeArgs,
   handler: async (ctx, args) => {
     assertE2EHelpersEnabled();
 
-    const staff = await findActiveStaffByEmail(ctx, args.staffEmail);
+    const staff = await findActiveStaffByEmail(ctx, args.staffEmail, args.shopId);
     if (!staff) throw new Error(`Staff not found: ${args.staffEmail}`);
 
     const account = await getStaffLineAccount(ctx, staff._id);

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -44,8 +44,9 @@ e2e/
 
 ## 認証
 
-- `fixtures/auth.setup.ts` で `@clerk/testing` の `setupClerkTestingToken` を利用
-- CIでは環境変数 `E2E_CLERK_USER` / `E2E_CLERK_PASSWORD` を使用
+- `fixtures/auth.setup.ts` で `@clerk/testing` の `clerk.signIn` を利用し、3ユーザー分の storageState を作成
+- CIでは環境変数 `E2E_CLERK_USERS`（カンマ区切り3件） / `E2E_CLERK_PASSWORD` を使用
+- scenario は `fixtures/e2eTest.ts` の `test` を import し、workerごとに別ユーザーの storageState を使う
 
 ## データ
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -44,8 +44,9 @@ e2e/
 
 ## 認証
 
-- `fixtures/auth.setup.ts` で `@clerk/testing` の `setupClerkTestingToken` を利用
-- CIでは環境変数 `E2E_CLERK_USER` / `E2E_CLERK_PASSWORD` を使用
+- `fixtures/auth.setup.ts` で `@clerk/testing` の `clerk.signIn` を利用し、3ユーザー分の storageState を作成
+- CIでは環境変数 `E2E_CLERK_USERS`（カンマ区切り3件） / `E2E_CLERK_PASSWORD` を使用
+- scenario は `fixtures/e2eTest.ts` の `test` を import し、workerごとに別ユーザーの storageState を使う
 
 ## データ
 

--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -1,25 +1,37 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { clerk, clerkSetup } from "@clerk/testing/playwright";
 import { test as setup } from "@playwright/test";
+import { getE2EClerkUsers } from "../helpers/e2eUsers";
 
-const STORAGE_STATE_PATH = "e2e/.clerk/user.json";
+const E2E_CLERK_USERS = getE2EClerkUsers();
 
-setup("prepare Clerk testing token and sign in", async ({ page }) => {
-  await clerkSetup();
+setup.describe.configure({ mode: "parallel" });
 
-  // Clerk の認証画面そのものはE2E対象外。ここでは以降の manager 画面検証に必要な storageState だけ作る。
-  await page.goto("/");
-  await clerk.signIn({
-    page,
-    signInParams: {
-      strategy: "password",
-      identifier: process.env.E2E_CLERK_USER ?? "",
-      password: process.env.E2E_CLERK_PASSWORD ?? "",
-    },
+for (const user of E2E_CLERK_USERS) {
+  setup(`prepare Clerk testing token and sign in: user-${user.index + 1}`, async ({ page }) => {
+    await clerkSetup();
+
+    // Clerk の認証画面そのものはE2E対象外。以降の manager 画面検証に必要な storageState だけ作る。
+    await page.goto("/");
+    await clerk.signIn({
+      page,
+      signInParams: {
+        strategy: "password",
+        identifier: user.email,
+        password: process.env.E2E_CLERK_PASSWORD ?? "",
+      },
+    });
+
+    // dashboard 到達まで確認してから保存し、後続 scenario が初回ロード競合を踏まないようにする。
+    await page.goto("/dashboard");
+    await page.waitForURL(/dashboard/, { timeout: 15000 });
+
+    mkdirSync(dirname(user.storageStatePath), { recursive: true });
+    await page.context().storageState({ path: user.storageStatePath });
+    writeFileSync(
+      user.metaPath,
+      `${JSON.stringify({ email: user.email, index: user.index, storageStatePath: user.storageStatePath }, null, 2)}\n`,
+    );
   });
-
-  // dashboard 到達まで確認してから保存し、後続 scenario が初回ロード競合を踏まないようにする。
-  await page.goto("/dashboard");
-  await page.waitForURL(/dashboard/, { timeout: 15000 });
-
-  await page.context().storageState({ path: STORAGE_STATE_PATH });
-});
+}

--- a/e2e/fixtures/e2eTest.ts
+++ b/e2e/fixtures/e2eTest.ts
@@ -1,0 +1,38 @@
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { test as base, expect } from "@playwright/test";
+import { type E2EClerkUser, getE2EClerkUserForIndex, setCurrentE2EClerkUserIndex } from "../helpers/e2eUsers";
+
+type E2ETestFixtures = {
+  e2eClerkUser: string;
+};
+
+type E2EWorkerFixtures = {
+  e2eWorkerUser: E2EClerkUser;
+};
+
+export const test = base.extend<E2ETestFixtures, E2EWorkerFixtures>({
+  e2eWorkerUser: [
+    // biome-ignore lint/correctness/noEmptyPattern: Playwright requires fixture destructuring even when unused.
+    async ({}, use, workerInfo) => {
+      const user = getE2EClerkUserForIndex(workerInfo.parallelIndex);
+      setCurrentE2EClerkUserIndex(user.index);
+      await use(user);
+    },
+    { scope: "worker", auto: true },
+  ],
+
+  storageState: async ({ e2eWorkerUser }, use) => {
+    await use(e2eWorkerUser.storageStatePath);
+  },
+
+  e2eClerkUser: async ({ e2eWorkerUser }, use) => {
+    await use(e2eWorkerUser.email);
+  },
+
+  page: async ({ page }, use) => {
+    await setupClerkTestingToken({ page });
+    await use(page);
+  },
+});
+
+export { expect };

--- a/e2e/helpers/e2eUsers.ts
+++ b/e2e/helpers/e2eUsers.ts
@@ -1,0 +1,82 @@
+import { join } from "node:path";
+
+const DEFAULT_E2E_CLERK_USER_EMAILS = ["e2e-user-1@test.com", "e2e-user-2@test.com", "e2e-user-3@test.com"];
+const EXPECTED_E2E_USER_COUNT = 3;
+const CURRENT_E2E_USER_INDEX_ENV = "E2E_CURRENT_USER_INDEX";
+
+export type E2EClerkUser = {
+  index: number;
+  email: string;
+  storageStatePath: string;
+  metaPath: string;
+};
+
+export function parseE2EClerkUserEmails(raw = process.env.E2E_CLERK_USERS) {
+  const trimmed = raw?.trim();
+  const emails = (trimmed ? trimmed.split(",") : DEFAULT_E2E_CLERK_USER_EMAILS)
+    .map((email) => email.trim())
+    .filter(Boolean);
+
+  if (emails.length !== EXPECTED_E2E_USER_COUNT) {
+    throw new Error(`E2E_CLERK_USERS must contain exactly ${EXPECTED_E2E_USER_COUNT} comma-separated users.`);
+  }
+  if (new Set(emails).size !== emails.length) {
+    throw new Error("E2E_CLERK_USERS must not contain duplicate users.");
+  }
+  if (emails.some((email) => email.toLowerCase().includes("testtest"))) {
+    throw new Error("E2E_CLERK_USERS must not include the retired testtest user.");
+  }
+
+  return emails;
+}
+
+export function getE2EClerkUsers(): E2EClerkUser[] {
+  return parseE2EClerkUserEmails().map((email, index) => ({
+    index,
+    email,
+    storageStatePath: getE2EStorageStatePath(index),
+    metaPath: getE2EStorageStateMetaPath(index),
+  }));
+}
+
+export function getE2EWorkerCount() {
+  return getE2EClerkUsers().length;
+}
+
+export function getE2EStorageStatePath(index: number) {
+  return join("e2e", ".clerk", `user-${index}.json`);
+}
+
+export function getE2EStorageStateMetaPath(index: number) {
+  return join("e2e", ".clerk", `user-${index}.meta.json`);
+}
+
+export function getE2EClerkUserForIndex(index: number): E2EClerkUser {
+  const users = getE2EClerkUsers();
+  const normalizedIndex = normalizeE2EUserIndex(index, users.length);
+  return users[normalizedIndex];
+}
+
+export function setCurrentE2EClerkUserIndex(index: number) {
+  process.env[CURRENT_E2E_USER_INDEX_ENV] = String(normalizeE2EUserIndex(index, getE2EWorkerCount()));
+}
+
+export function getCurrentE2EClerkUserIndex() {
+  const raw = process.env[CURRENT_E2E_USER_INDEX_ENV] ?? process.env.TEST_PARALLEL_INDEX ?? "0";
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`Invalid E2E user index: ${raw}`);
+  }
+  return normalizeE2EUserIndex(parsed, getE2EWorkerCount());
+}
+
+export function getCurrentE2EClerkUser() {
+  return getE2EClerkUserForIndex(getCurrentE2EClerkUserIndex());
+}
+
+function normalizeE2EUserIndex(index: number, userCount: number) {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`E2E user index must be a non-negative integer: ${index}`);
+  }
+  return index % userCount;
+}

--- a/e2e/helpers/notificationTokens.ts
+++ b/e2e/helpers/notificationTokens.ts
@@ -23,44 +23,54 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function pollConvexToken<T extends { token: string | null }>(
+  fn: string,
+  args: Record<string, unknown>,
+  attempts: number,
+): Promise<(T & { token: string }) | null> {
+  for (let i = 0; i < attempts; i++) {
+    const result = convexRunJson<T>(fn, args);
+    if (result.token) return result as T & { token: string };
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  return null;
+}
+
 export async function getOrCreateMagicLinkToken(args: {
   recruitmentId?: string;
+  shopId?: string;
   staffEmail: string;
   purpose: MagicLinkPurpose;
 }): Promise<CreatedMagicLinkResult> {
   // 通知 action は scheduler 経由で非同期実行される。
   // まず実際に発行された token を待ち、無ければテスト用 internal API で補助発行してシナリオを進める。
-  for (let i = 0; i < POLL_ATTEMPTS; i++) {
-    const result = convexRunJson<MagicLinkResult>("testing:getLatestMagicLinkToken", args);
-    if (result.token) return result as CreatedMagicLinkResult;
-    await sleep(POLL_INTERVAL_MS);
-  }
+  const existing = await pollConvexToken<MagicLinkResult>("testing:getLatestMagicLinkToken", args, POLL_ATTEMPTS);
+  if (existing) return existing;
 
   return convexRunJson<CreatedMagicLinkResult>("testing:createMagicLinkTokenForLatestRecruitment", args);
 }
 
 export async function waitForMagicLinkToken(args: {
   recruitmentId?: string;
+  shopId?: string;
   staffEmail: string;
   purpose: MagicLinkPurpose;
 }): Promise<CreatedMagicLinkResult> {
   // 追送・follow起点の通知は「発行されること」自体が検証対象なので、補助発行せず待ち切れなければ失敗にする。
-  for (let i = 0; i < POLL_ATTEMPTS * 2; i++) {
-    const result = convexRunJson<MagicLinkResult>("testing:getLatestMagicLinkToken", args);
-    if (result.token) return result as CreatedMagicLinkResult;
-    await sleep(POLL_INTERVAL_MS);
-  }
+  const issued = await pollConvexToken<MagicLinkResult>("testing:getLatestMagicLinkToken", args, POLL_ATTEMPTS * 2);
+  if (issued) return issued;
 
   throw new Error(`Magic link token was not issued for ${args.staffEmail}`);
 }
 
-export async function getOrCreateLineLinkToken(staffEmail: string): Promise<CreatedLineLinkResult> {
+export async function getOrCreateLineLinkToken(args: {
+  shopId?: string;
+  staffEmail: string;
+}): Promise<CreatedLineLinkResult> {
   // LINE Login の外部画面には遷移しない。E2Eではアプリ側で連携URLを発行できることだけ確認する。
-  for (let i = 0; i < POLL_ATTEMPTS; i++) {
-    const result = convexRunJson<LineLinkResult>("testing:getLatestLineLinkToken", { staffEmail });
-    if (result.token) return result as CreatedLineLinkResult;
-    await sleep(POLL_INTERVAL_MS);
-  }
+  const existing = await pollConvexToken<LineLinkResult>("testing:getLatestLineLinkToken", args, POLL_ATTEMPTS);
+  if (existing) return existing;
 
-  return convexRunJson<CreatedLineLinkResult>("testing:createLineLinkTokenForStaff", { staffEmail });
+  return convexRunJson<CreatedLineLinkResult>("testing:createLineLinkTokenForStaff", args);
 }

--- a/e2e/helpers/scenarioSeeds.ts
+++ b/e2e/helpers/scenarioSeeds.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { convexRunJson } from "./convex";
+import { getCurrentE2EClerkUser, getE2EStorageStatePath } from "./e2eUsers";
 
 type ClerkStorageState = {
   cookies: Array<{
@@ -15,17 +16,18 @@ type ClerkSessionPayload = {
   sub?: string;
 };
 
-let cachedOwnerAuthTokenIdentifier: string | null = null;
+const cachedOwnerAuthTokenIdentifiers = new Map<number, string>();
 
 function decodeBase64Url(value: string) {
   const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
   return Buffer.from(padded.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf-8");
 }
 
-export function getE2EOwnerAuthTokenIdentifier() {
-  if (cachedOwnerAuthTokenIdentifier) return cachedOwnerAuthTokenIdentifier;
+export function getE2EOwnerAuthTokenIdentifier(userIndex = getCurrentE2EClerkUser().index) {
+  const cached = cachedOwnerAuthTokenIdentifiers.get(userIndex);
+  if (cached) return cached;
 
-  const storagePath = join(process.cwd(), "e2e", ".clerk", "user.json");
+  const storagePath = join(process.cwd(), getE2EStorageStatePath(userIndex));
   const state = JSON.parse(readFileSync(storagePath, "utf-8")) as ClerkStorageState;
   // Clerk の cookie 名・domain はローカル/CIで揺れることがある。
   // Convex の認証キーは issuer|subject なので、保存済み storageState からJWTを読む。
@@ -47,15 +49,23 @@ export function getE2EOwnerAuthTokenIdentifier() {
     throw new Error("Clerk session JWT does not include iss/sub");
   }
 
-  cachedOwnerAuthTokenIdentifier = `${decoded.iss}|${decoded.sub}`;
-  return cachedOwnerAuthTokenIdentifier;
+  const authTokenIdentifier = `${decoded.iss}|${decoded.sub}`;
+  cachedOwnerAuthTokenIdentifiers.set(userIndex, authTokenIdentifier);
+  return authTokenIdentifier;
 }
 
 export function seedOwnerScenario<T>(fn: string, args: Record<string, unknown> = {}) {
+  const user = getCurrentE2EClerkUser();
   // dry-run 判定は ownerEmail 経由で行うため、seed でも本番コードと同じ owner 情報を渡す。
   return convexRunJson<T>(fn, {
-    ownerAuthTokenIdentifier: getE2EOwnerAuthTokenIdentifier(),
-    ownerEmail: process.env.E2E_CLERK_USER,
+    ownerAuthTokenIdentifier: getE2EOwnerAuthTokenIdentifier(user.index),
+    ownerEmail: user.email,
     ...args,
+  });
+}
+
+export function resetCurrentOwnerScenarioData() {
+  return convexRunJson("testing:resetOwnerScenarioData", {
+    ownerAuthTokenIdentifier: getE2EOwnerAuthTokenIdentifier(),
   });
 }

--- a/e2e/pages/StaffLegalConsentPage.ts
+++ b/e2e/pages/StaffLegalConsentPage.ts
@@ -8,7 +8,7 @@ export class StaffLegalConsentPage {
   }
 
   async expectConsentFormVisible() {
-    await expect(this.page.getByText("規約の確認")).toBeVisible();
+    await expect(this.page.getByRole("heading", { name: "利用規約・プライバシーポリシーの確認" })).toBeVisible();
     await expect(this.legalConsentCheckbox()).toBeVisible();
   }
 

--- a/e2e/scenarios/dashboard-pagination.test.ts
+++ b/e2e/scenarios/dashboard-pagination.test.ts
@@ -1,5 +1,4 @@
-import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";
 
@@ -9,7 +8,6 @@ test.describe("ダッシュボードのページネーション", () => {
   let dashboard: DashboardPage;
 
   test.beforeEach(async ({ page }) => {
-    await setupClerkTestingToken({ page });
     dashboard = new DashboardPage(page);
   });
 

--- a/e2e/scenarios/first-shift-delivery.test.ts
+++ b/e2e/scenarios/first-shift-delivery.test.ts
@@ -1,7 +1,7 @@
-import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures/e2eTest";
 import { convexRun } from "../helpers/convex";
 import { getNextWeekDates } from "../helpers/date";
+import { getE2EOwnerAuthTokenIdentifier, resetCurrentOwnerScenarioData } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";
 import { ShiftBoardPage } from "../pages/ShiftBoardPage";
 
@@ -28,13 +28,12 @@ test.describe("田中さんの初めてのシフト確定", () => {
   let shiftBoard: ShiftBoardPage;
 
   test.beforeEach(async ({ page }) => {
-    await setupClerkTestingToken({ page });
     dashboard = new DashboardPage(page);
     shiftBoard = new ShiftBoardPage(page);
   });
 
   test("初回セットアップからシフト確定まで", async ({ page }) => {
-    convexRun("testing:clearAllTables");
+    resetCurrentOwnerScenarioData();
 
     await test.step("Step 1: 初回セットアップを完了する", async () => {
       await dashboard.goto();
@@ -106,7 +105,11 @@ test.describe("田中さんの初めてのシフト確定", () => {
       await dashboard.expectRecruitmentCardVisible();
     });
 
-    convexRun("testing:seedShiftData", { staffAssignments: STAFF_ASSIGNMENTS, dates: dates.dates });
+    convexRun("testing:seedShiftData", {
+      ownerAuthTokenIdentifier: getE2EOwnerAuthTokenIdentifier(),
+      staffAssignments: STAFF_ASSIGNMENTS,
+      dates: dates.dates,
+    });
 
     await test.step("Step 4: シフトボードを開いて全体を確認する", async () => {
       await dashboard.openShiftBoard();

--- a/e2e/scenarios/legal-consent-flow.test.ts
+++ b/e2e/scenarios/legal-consent-flow.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { convexRunJson } from "../helpers/convex";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";
@@ -16,25 +16,15 @@ type StaffSubmitSeed = {
 test.describe("法務同意フロー", () => {
   test.setTimeout(45_000);
 
-  test("管理者は同意要求版が古い場合だけダッシュボード上で再同意できる", async ({ page }) => {
+  test("管理者はダッシュボード上で再同意できる", async ({ page }) => {
     const dashboard = new DashboardPage(page);
 
-    await test.step("文書版だけ古い場合は再同意バナーが出ない", async () => {
-      seedOwnerScenario("testing:seedLegalManagerConsentScenario", {
-        legalConsentState: "oldDocumentOnly",
-      });
-      await dashboard.goto();
-      await dashboard.expectLegalReconsentNotVisible();
+    seedOwnerScenario("testing:seedLegalManagerConsentScenario", {
+      legalConsentState: "oldRequired",
     });
-
-    await test.step("同意要求版が古い場合はバナーから再同意できる", async () => {
-      seedOwnerScenario("testing:seedLegalManagerConsentScenario", {
-        legalConsentState: "oldRequired",
-      });
-      await dashboard.goto();
-      await dashboard.expectLegalReconsentVisible();
-      await dashboard.acceptLegalReconsent();
-    });
+    await dashboard.goto();
+    await dashboard.expectLegalReconsentVisible();
+    await dashboard.acceptLegalReconsent();
   });
 
   test("スタッフはマジックリンクの同意ページで同意できる", async ({ page }) => {
@@ -49,49 +39,12 @@ test.describe("法務同意フロー", () => {
     await consentPage.expectAcceptedVisible();
   });
 
-  test("スタッフ希望シフトでは未同意または同意要求版が古い場合だけ提出時に同意する", async ({ page }) => {
+  test("未同意スタッフは提出時に同意してシフト希望を提出できる", async ({ page }) => {
     const submitPage = new StaffSubmitPage(page);
-
-    await test.step("同意済みならチェックボックスなしで提出できる", async () => {
-      const seed = convexRunJson<StaffSubmitSeed>("testing:seedLegalStaffSubmitScenario", {
-        legalConsentState: "current",
-      });
-      await submitPage.goto(seed.token);
-      await submitPage.expectFormVisible();
-      await submitPage.expectLegalConsentNotVisible();
-      await submitPage.toggleDay("4/7(火)");
-      await submitPage.submit();
-      await submitPage.expectCompletionVisible();
-    });
-
-    await test.step("文書版だけ古い場合もチェックボックスなしで提出できる", async () => {
-      const seed = convexRunJson<StaffSubmitSeed>("testing:seedLegalStaffSubmitScenario", {
-        legalConsentState: "oldDocumentOnly",
-      });
-      await submitPage.goto(seed.token);
-      await submitPage.expectFormVisible();
-      await submitPage.expectLegalConsentNotVisible();
-      await submitPage.toggleDay("4/7(火)");
-      await submitPage.submit();
-      await submitPage.expectCompletionVisible();
-    });
 
     await test.step("未同意ならチェックして提出できる", async () => {
       const seed = convexRunJson<StaffSubmitSeed>("testing:seedLegalStaffSubmitScenario", {
         legalConsentState: "missing",
-      });
-      await submitPage.goto(seed.token);
-      await submitPage.expectFormVisible();
-      await submitPage.expectLegalConsentVisible();
-      await submitPage.toggleDay("4/7(火)");
-      await submitPage.acceptLegalConsent();
-      await submitPage.submit();
-      await submitPage.expectCompletionVisible();
-    });
-
-    await test.step("同意要求版が古い場合もチェックして提出できる", async () => {
-      const seed = convexRunJson<StaffSubmitSeed>("testing:seedLegalStaffSubmitScenario", {
-        legalConsentState: "oldRequired",
       });
       await submitPage.goto(seed.token);
       await submitPage.expectFormVisible();

--- a/e2e/scenarios/line-link-token-flow.test.ts
+++ b/e2e/scenarios/line-link-token-flow.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures/e2eTest";
 import { getOrCreateLineLinkToken } from "../helpers/notificationTokens";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";
@@ -8,17 +8,21 @@ const MANAGER = {
   email: "tanaka@example.com",
 };
 
+type LineLinkSeed = {
+  shopId: string;
+};
+
 test.describe("LINE連携URL発行", () => {
   test.setTimeout(30_000);
 
   test("店長操作でLINE連携トークンが発行される", async ({ page }) => {
-    seedOwnerScenario("testing:seedLineLinkScenario");
+    const seed = seedOwnerScenario<LineLinkSeed>("testing:seedLineLinkScenario");
     const dashboard = new DashboardPage(page);
 
     await test.step("Step 1: LINE連携QR/URLを発行する", async () => {
       await dashboard.goto();
       await dashboard.openLineQr(MANAGER.name);
-      const lineToken = await getOrCreateLineLinkToken(MANAGER.email);
+      const lineToken = await getOrCreateLineLinkToken({ staffEmail: MANAGER.email, shopId: seed.shopId });
       expect(lineToken.token).toMatch(/^[0-9a-f-]{36}$/);
     });
   });

--- a/e2e/scenarios/notification-confirmation-view-flow.test.ts
+++ b/e2e/scenarios/notification-confirmation-view-flow.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { convexRunJson } from "../helpers/convex";
 import { getNextWeekDates } from "../helpers/date";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
@@ -10,6 +10,7 @@ const MANAGER = {
 };
 
 type ConfirmationScenarioSeed = {
+  shopId: string;
   recruitmentId: string;
   viewToken: string;
 };
@@ -49,6 +50,7 @@ test.describe("通知URL起点の確定シフト閲覧", () => {
 
         const reissuedToken = convexRunJson<MagicLinkSeed>("testing:createMagicLinkTokenForLatestRecruitment", {
           recruitmentId: seed.recruitmentId,
+          shopId: seed.shopId,
           staffEmail: MANAGER.email,
           purpose: "view",
         });

--- a/e2e/scenarios/notification-reminder-flow.test.ts
+++ b/e2e/scenarios/notification-reminder-flow.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { formatDateWithWeekday, getNextWeekDates } from "../helpers/date";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";

--- a/e2e/scenarios/notification-submit-flow.test.ts
+++ b/e2e/scenarios/notification-submit-flow.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { formatDateWithWeekday, getNextWeekDates } from "../helpers/date";
 import { seedOwnerScenario } from "../helpers/scenarioSeeds";
 import { DashboardPage } from "../pages/DashboardPage";

--- a/e2e/scenarios/open-recruitment-added-staff-notification.test.ts
+++ b/e2e/scenarios/open-recruitment-added-staff-notification.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "../fixtures/e2eTest";
 import { convexRunJson } from "../helpers/convex";
 import { formatDateWithWeekday, getNextWeekDates } from "../helpers/date";
 import { waitForMagicLinkToken } from "../helpers/notificationTokens";
@@ -16,12 +16,17 @@ const MANAGER = {
   email: "tanaka@example.com",
 };
 
+type OpenRecruitmentSeed = {
+  shopId: string;
+  recruitmentId: string;
+};
+
 test.describe("募集中の追加スタッフ通知", () => {
   test.setTimeout(45_000);
 
   test("募集中にスタッフを追加すると、そのスタッフの希望提出リンクが発行される", async ({ page }) => {
     const dates = getNextWeekDates();
-    seedOwnerScenario("testing:seedOpenRecruitmentNotificationScenario", { dates });
+    const seed = seedOwnerScenario<OpenRecruitmentSeed>("testing:seedOpenRecruitmentNotificationScenario", { dates });
     const dashboard = new DashboardPage(page);
     const submitPage = new StaffSubmitPage(page);
 
@@ -32,7 +37,12 @@ test.describe("募集中の追加スタッフ通知", () => {
     });
 
     await test.step("Step 2: 追加スタッフ向けの希望提出リンクから提出できる", async () => {
-      const token = await waitForMagicLinkToken({ staffEmail: ADDED_STAFF.email, purpose: "submit" });
+      const token = await waitForMagicLinkToken({
+        recruitmentId: seed.recruitmentId,
+        shopId: seed.shopId,
+        staffEmail: ADDED_STAFF.email,
+        purpose: "submit",
+      });
       await submitPage.goto(token.token);
       await submitPage.expectFormVisible();
       await submitPage.expectUnsubmittedBadge();
@@ -45,18 +55,24 @@ test.describe("募集中の追加スタッフ通知", () => {
 
   test("LINE follow時に募集中シフトの希望提出リンクが発行される", async ({ page }) => {
     const dates = getNextWeekDates();
-    seedOwnerScenario("testing:seedOpenRecruitmentNotificationScenario", { dates });
+    const seed = seedOwnerScenario<OpenRecruitmentSeed>("testing:seedOpenRecruitmentNotificationScenario", { dates });
     const submitPage = new StaffSubmitPage(page);
 
     await test.step("Step 1: LINE follow相当の状態更新を行う", async () => {
       const result = convexRunJson<{ scheduled: boolean }>("testing:simulateLineFollowForStaff", {
+        shopId: seed.shopId,
         staffEmail: MANAGER.email,
       });
       expect(result.scheduled).toBe(true);
     });
 
     await test.step("Step 2: LINE通知で発行された希望提出リンクから提出できる", async () => {
-      const token = await waitForMagicLinkToken({ staffEmail: MANAGER.email, purpose: "submit" });
+      const token = await waitForMagicLinkToken({
+        recruitmentId: seed.recruitmentId,
+        shopId: seed.shopId,
+        staffEmail: MANAGER.email,
+        purpose: "submit",
+      });
       await submitPage.goto(token.token);
       await submitPage.expectFormVisible();
       await submitPage.expectUnsubmittedBadge();

--- a/e2e/scenarios/staff-shift-submission.test.ts
+++ b/e2e/scenarios/staff-shift-submission.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test } from "../fixtures/e2eTest";
 import { convexRunJson } from "../helpers/convex";
 import { StaffSubmitPage } from "../pages/StaffSubmitPage";
 
@@ -55,21 +55,6 @@ test.describe("スタッフのシフト希望提出", () => {
 
       await submitPage.submit();
       await submitPage.expectCompletionVisible();
-    });
-  });
-
-  test("締切後の表示確認", async () => {
-    await test.step("提出済み＋締切後は閲覧のみ", async () => {
-      const token = seedAndGetToken({ deadlinePassed: true, hasExistingSubmission: true });
-      await submitPage.goto(token);
-      await submitPage.expectReadOnlyVisible();
-      await submitPage.expectSubmitButtonNotVisible();
-    });
-
-    await test.step("未提出＋締切後は締切超過メッセージ", async () => {
-      const token = seedAndGetToken({ deadlinePassed: true });
-      await submitPage.goto(token);
-      await submitPage.expectExpiredVisible();
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yps-crispy-carnival",
-  "version": "0.0.15",
+  "version": "0.0.14",
   "private": true,
   "packageManager": "pnpm@10.33.3",
   "type": "module",
@@ -34,6 +34,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build  --stats-json",
     "convex:dev": "npx convex dev",
+    "convex:configure": "npx convex dev --configure",
     "convex:clear": "npx convex run testing:clearAllTables",
     "convex:restore": "tsx convex-seeds/scripts/import.ts",
     "convex:save": "tsx convex-seeds/scripts/export.ts",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "convex:dev": "npx convex dev",
     "convex:configure": "npx convex dev --configure",
     "convex:clear": "npx convex run testing:clearAllTables",
+    "cconvex:clearAllTables:dev": "npx convex run testing:clearAllTables --deployment dev",
+    "cconvex:clearAllTables:prod": "npx convex run testing:clearAllTables --prod",
     "convex:restore": "tsx convex-seeds/scripts/import.ts",
     "convex:save": "tsx convex-seeds/scripts/export.ts",
     "convex:env-setup": "tsx scripts/setupEnv.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
+import { getE2EWorkerCount } from "./e2e/helpers/e2eUsers";
 
 dotenv.config({ debug: false, quiet: true });
 
@@ -7,19 +8,11 @@ dotenv.config({ debug: false, quiet: true });
  * E2Eテスト実行順序と依存関係:
  *
  * 1. setup
- *    ├── 全ユーザーのログイン認証を実行
+ *    ├── E2E_CLERK_USERS の3ユーザーでログイン認証を実行
  *    └── 認証状態をファイルに保存
  *
- * 2. 認証済みテスト (User A / 管理者)
- *    ├── auth/login.test.ts - 認証確認
- *    ├── shop/register.test.ts - 店舗登録
- *    ├── shop/list.test.ts - 店舗一覧
- *    ├── shop/detail.test.ts - 店舗詳細
- *    ├── shop/edit.test.ts - 店舗編集
- *    └── staff/list.test.ts - スタッフ一覧（StaffTab操作）
- *
- * 3. 認証済みテストB (User B / 新規店長)
- *    └── userB/new-owner.test.ts - 新規店長の初回ログイン〜店舗登録
+ * 2. 認証済みテスト
+ *    └── workerごとに別ユーザーの storageState を使い、owner単位のseedで並列実行
  *
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -31,8 +24,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 1 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: 1,
+  /* E2E_CLERK_USERS のユーザー数に合わせて、別ユーザーで並列実行する。 */
+  workers: getE2EWorkerCount(),
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [["list"], ["html"], ["json", { outputFile: "test-results.json" }]],
   /* expect() の待機上限。エラー発生時に即座に失敗を返すため短めに設定 */
@@ -70,7 +63,6 @@ export default defineConfig({
       testMatch: /scenarios\/(?!userB\/).*\.test\.ts/,
       use: {
         ...devices["Desktop Chrome"],
-        storageState: "e2e/.clerk/user.json",
       },
       dependencies: ["setup"],
     },

--- a/src/components/devtools/EmailPreview/index.stories.tsx
+++ b/src/components/devtools/EmailPreview/index.stories.tsx
@@ -5,6 +5,7 @@ import {
   buildRecruitmentEmailHtml,
   buildReissueEmailHtml,
   buildReminderEmailHtml,
+  buildStaffLegalConsentEmailHtml,
 } from "@/convex/notification/templates";
 import { EmailPreview } from ".";
 
@@ -26,6 +27,7 @@ const fixtures = {
   deadline: "4/25(金)",
   magicLinkUrl: "https://example.com/shifts/view?token=preview-token",
   reissueUrl: "https://example.com/shifts/reissue?staff=preview",
+  consentUrl: "https://example.com/legal/staff/consent?token=preview-token",
   shifts: [
     { date: "5/1(金)", startTime: "09:00", endTime: "13:00" },
     { date: "5/2(土)", startTime: "17:00", endTime: "22:00" },
@@ -38,6 +40,25 @@ const fixtures = {
     { date: "5/3(日)", startTime: null, endTime: null },
   ],
 };
+
+const legalDocuments = {
+  terms: {
+    audience: "staff",
+    kind: "terms",
+    title: "スタッフ向け利用規約",
+    documentVersion: "staff-terms-doc-2026-05-09",
+    path: "/terms/staff",
+    requiredConsentVersion: "staff-terms-consent-2026-05-09",
+  },
+  privacy: {
+    audience: "staff",
+    kind: "privacy",
+    title: "スタッフ向けプライバシーポリシー",
+    documentVersion: "staff-privacy-doc-2026-05-09",
+    path: "/privacy/staff",
+    requiredConsentVersion: "staff-privacy-consent-2026-05-09",
+  },
+} as const;
 
 const Section = ({ label, html }: { label: string; html: string }) => (
   <Flex direction="column" gap={2}>
@@ -135,6 +156,23 @@ export const Reissue: StoryObj<typeof meta> = {
           staffName: fixtures.staffName,
           periodLabel: fixtures.periodLabel,
           magicLinkUrl: fixtures.magicLinkUrl,
+        })}
+      />
+    </VariantsContainer>
+  ),
+};
+
+export const StaffLegalConsent: StoryObj<typeof meta> = {
+  render: () => (
+    <VariantsContainer>
+      <Section
+        label="スタッフ向け案内・規約確認"
+        html={buildStaffLegalConsentEmailHtml({
+          staffName: fixtures.staffName,
+          shopName: "居酒屋さくら",
+          consentUrl: fixtures.consentUrl,
+          expiresAt: new Date("2026-05-31T12:00:00+09:00").getTime(),
+          documents: legalDocuments,
         })}
       />
     </VariantsContainer>

--- a/src/components/features/Dashboard/AddStaffForm/index.tsx
+++ b/src/components/features/Dashboard/AddStaffForm/index.tsx
@@ -36,8 +36,8 @@ export const AddStaffForm = ({ onSubmit }: Props) => {
   return (
     <form id="add-staff-form" noValidate onSubmit={handleSubmit(onSubmit)}>
       <Stack gap={4}>
-        <Text fontSize="sm" color="fg.muted" lineHeight="tall">
-          現在募集中のシフトがある場合、追加したスタッフにも希望提出リンクをメールで送ります。
+        <Text fontSize="xs" color="fg.muted" lineHeight="tall">
+          追加時にシフトリの使い方、LINE連携案内、募集中の希望シフト提出リンクをメールでお送りします。
         </Text>
 
         {rootError && (

--- a/src/components/features/Dashboard/LegalReconsentBanner/index.tsx
+++ b/src/components/features/Dashboard/LegalReconsentBanner/index.tsx
@@ -1,5 +1,6 @@
-import { Box, Checkbox, Flex, Link, Text } from "@chakra-ui/react";
+import { Box, Checkbox, Flex, Text } from "@chakra-ui/react";
 import { useState } from "react";
+import { LegalDocumentLink } from "@/src/components/features/LegalDocumentLink";
 import { Button } from "@/src/components/ui/Button";
 
 export type LegalReconsentDocumentLinks = {
@@ -48,13 +49,8 @@ export function LegalReconsentBanner({ documents, isSubmitting = false, onAccept
               <Checkbox.HiddenInput />
               <Checkbox.Control />
               <Checkbox.Label fontSize="sm" lineHeight={1.7} color="teal.950">
-                <Link href={documents.terms.path} target="_blank" rel="noopener noreferrer" color="teal.700">
-                  利用規約
-                </Link>
-                と
-                <Link href={documents.privacy.path} target="_blank" rel="noopener noreferrer" color="teal.700">
-                  プライバシーポリシー
-                </Link>
+                <LegalDocumentLink href={documents.terms.path}>利用規約</LegalDocumentLink>と
+                <LegalDocumentLink href={documents.privacy.path}>プライバシーポリシー</LegalDocumentLink>
                 に同意します
               </Checkbox.Label>
             </Checkbox.Root>

--- a/src/components/features/Dashboard/SetupModal/SetupStep2/index.tsx
+++ b/src/components/features/Dashboard/SetupModal/SetupStep2/index.tsx
@@ -1,6 +1,7 @@
-import { Checkbox, Field, Input, Link, Stack, Text } from "@chakra-ui/react";
+import { Checkbox, Field, Input, Stack, Text } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import { LegalDocumentLink } from "@/src/components/features/LegalDocumentLink";
 import { type Step2Data, step2Schema } from "./index";
 
 type Props = {
@@ -54,13 +55,8 @@ export const SetupStep2 = ({ onSubmit, defaultValues, formId = "setup-step2" }: 
             <Checkbox.HiddenInput />
             <Checkbox.Control />
             <Checkbox.Label fontSize="sm" lineHeight={1.7}>
-              <Link href="/terms/manager" target="_blank" rel="noopener noreferrer" color="teal.700">
-                利用規約
-              </Link>
-              と
-              <Link href="/privacy/manager" target="_blank" rel="noopener noreferrer" color="teal.700">
-                プライバシーポリシー
-              </Link>
+              <LegalDocumentLink href="/terms/manager">利用規約</LegalDocumentLink>と
+              <LegalDocumentLink href="/privacy/manager">プライバシーポリシー</LegalDocumentLink>
               に同意します
             </Checkbox.Label>
           </Checkbox.Root>

--- a/src/components/features/LegalDocumentLink/index.stories.tsx
+++ b/src/components/features/LegalDocumentLink/index.stories.tsx
@@ -1,0 +1,40 @@
+import { Box, Stack, Text } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LegalDocumentLink } from "./index";
+
+const meta = {
+  title: "Features/LegalDocumentLink",
+  component: LegalDocumentLink,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    href: "/terms/manager",
+    children: "利用規約",
+  },
+} satisfies Meta<typeof LegalDocumentLink>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  render: () => (
+    <Stack gap={5} maxW="560px">
+      <Box>
+        <Text mb={2} fontSize="xs" fontWeight="semibold" color="fg.muted">
+          Standalone
+        </Text>
+        <LegalDocumentLink href="/terms/manager">利用規約</LegalDocumentLink>
+      </Box>
+      <Box>
+        <Text mb={2} fontSize="xs" fontWeight="semibold" color="fg.muted">
+          Inline consent text
+        </Text>
+        <Text fontSize="sm" lineHeight={1.7}>
+          <LegalDocumentLink href="/terms/manager">利用規約</LegalDocumentLink>と
+          <LegalDocumentLink href="/privacy/manager">プライバシーポリシー</LegalDocumentLink>に同意します
+        </Text>
+      </Box>
+    </Stack>
+  ),
+};

--- a/src/components/features/LegalDocumentLink/index.tsx
+++ b/src/components/features/LegalDocumentLink/index.tsx
@@ -1,0 +1,32 @@
+import { Link } from "@chakra-ui/react";
+import type { ComponentProps, ReactNode } from "react";
+import { LuExternalLink } from "react-icons/lu";
+
+type Props = Omit<ComponentProps<typeof Link>, "children" | "href" | "target" | "rel"> & {
+  href: string;
+  children: ReactNode;
+};
+
+export const LegalDocumentLink = ({ href, children, color = "teal.700", ...props }: Props) => {
+  const { "aria-label": ariaLabel, ...linkProps } = props;
+  const computedAriaLabel = ariaLabel ?? (typeof children === "string" ? `${children}（別タブで開きます）` : undefined);
+
+  return (
+    <Link
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      color={color}
+      display="inline-flex"
+      alignItems="center"
+      gap={1}
+      me={0.5}
+      verticalAlign="-0.125em"
+      aria-label={computedAriaLabel}
+      {...linkProps}
+    >
+      {children}
+      <LuExternalLink aria-hidden="true" focusable="false" size={12} />
+    </Link>
+  );
+};

--- a/src/components/features/StaffLegalConsent/ConsentPage/LegalConsentPanel.stories.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/LegalConsentPanel.stories.tsx
@@ -1,0 +1,119 @@
+import { Box, Stack } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import type { StaffLegalConsentPageData } from "./index";
+import { LegalConsentPanel } from "./LegalConsentPanel";
+
+const documents = {
+  terms: {
+    title: "スタッフ向け利用規約",
+    documentVersion: "staff-terms-doc-2026-05-09",
+    requiredConsentVersion: "staff-terms-consent-2026-05-09",
+    path: "/terms/staff",
+  },
+  privacy: {
+    title: "スタッフ向けプライバシーポリシー",
+    documentVersion: "staff-privacy-doc-2026-05-09",
+    requiredConsentVersion: "staff-privacy-consent-2026-05-09",
+    path: "/privacy/staff",
+  },
+};
+
+const okData: StaffLegalConsentPageData = {
+  status: "ok",
+  staffName: "田中 太郎",
+  shopName: "居酒屋さくら",
+  expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  documents,
+};
+
+const acceptedData: StaffLegalConsentPageData = {
+  status: "accepted",
+  staffName: "田中 太郎",
+  shopName: "居酒屋さくら",
+  documents,
+};
+
+const expiredData: StaffLegalConsentPageData = {
+  status: "expired",
+  documents,
+};
+
+const meta = {
+  title: "features/StaffLegalConsent/LegalConsentPanel",
+  component: LegalConsentPanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    data: okData,
+    checked: false,
+    error: null,
+    isSubmitting: false,
+    onCheckedChange: () => {},
+    onAccept: async () => {},
+  },
+  decorators: [
+    (Story) => (
+      <Box bg="teal.50" minH="100dvh" px={{ base: 4, md: 8 }} py={{ base: 5, md: 8 }}>
+        <Box maxW="760px" mx="auto">
+          <Story />
+        </Box>
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof LegalConsentPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <InteractivePanel data={okData} />,
+};
+
+export const Variants: Story = {
+  render: () => (
+    <Stack gap={5}>
+      <InteractivePanel data={okData} />
+      <LegalConsentPanel
+        data={acceptedData}
+        checked={false}
+        error={null}
+        isSubmitting={false}
+        onCheckedChange={() => {}}
+        onAccept={async () => {}}
+      />
+      <LegalConsentPanel
+        data={expiredData}
+        checked={false}
+        error={null}
+        isSubmitting={false}
+        onCheckedChange={() => {}}
+        onAccept={async () => {}}
+      />
+    </Stack>
+  ),
+};
+
+function InteractivePanel({ data }: { data: StaffLegalConsentPageData }) {
+  const [checked, setChecked] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <LegalConsentPanel
+      data={data}
+      checked={checked}
+      error={error}
+      isSubmitting={false}
+      onCheckedChange={(nextChecked) => {
+        setChecked(nextChecked);
+        if (nextChecked) setError(null);
+      }}
+      onAccept={async () => {
+        if (!checked) {
+          setError("利用規約とプライバシーポリシーに同意してください");
+        }
+      }}
+    />
+  );
+}

--- a/src/components/features/StaffLegalConsent/ConsentPage/LegalConsentPanel.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/LegalConsentPanel.tsx
@@ -1,0 +1,135 @@
+import { Box, Checkbox, Circle, Flex, HStack, Text, VStack } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+import { LuCircleCheck, LuClock, LuFileCheck2 } from "react-icons/lu";
+import { LegalDocumentLink } from "@/src/components/features/LegalDocumentLink";
+import { Button } from "@/src/components/ui/Button";
+import type { StaffLegalConsentPageData } from "./index";
+
+type Props = {
+  data: StaffLegalConsentPageData;
+  checked: boolean;
+  error: string | null;
+  isSubmitting: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  onAccept: () => Promise<void>;
+};
+
+export function LegalConsentPanel({ data, checked, error, isSubmitting, onCheckedChange, onAccept }: Props) {
+  if (data.status === "expired") {
+    return (
+      <PanelFrame tone="neutral" icon={<LuClock />} title="リンクの有効期限が切れています">
+        <Text color="fg.muted" lineHeight={1.8}>
+          この同意リンクは現在利用できません。
+          <br />
+          同意していない場合でも、お店からの通知は届きます。
+          <br />
+          初回シフト提出時に同意欄がありますので、その際ご確認ください。
+        </Text>
+        <LegalDocumentLinks data={data} />
+      </PanelFrame>
+    );
+  }
+
+  if (data.status === "accepted") {
+    return (
+      <PanelFrame tone="success" icon={<LuCircleCheck />} title="同意済みです">
+        <Text color="fg.muted" lineHeight={1.8}>
+          利用規約・プライバシーポリシーへの同意は完了しています。
+        </Text>
+        <LegalDocumentLinks data={data} />
+      </PanelFrame>
+    );
+  }
+
+  return (
+    <PanelFrame tone="action" icon={<LuFileCheck2 />} title="利用規約・プライバシーポリシーの確認">
+      <VStack align="stretch" gap={4}>
+        <Text color="fg.muted" lineHeight={1.8}>
+          内容をご確認のうえ、同意をお願いします。
+        </Text>
+        <Box>
+          <Checkbox.Root
+            colorPalette="teal"
+            checked={checked}
+            onCheckedChange={(details) => onCheckedChange(details.checked === true)}
+          >
+            <Checkbox.HiddenInput />
+            <Checkbox.Control
+              bg="white"
+              borderColor="gray.300"
+              _checked={{ bg: "teal.500", borderColor: "teal.500" }}
+            />
+            <Checkbox.Label fontSize="sm" lineHeight={1.7}>
+              <LegalLink href={data.documents.terms.path}>利用規約</LegalLink>と
+              <LegalLink href={data.documents.privacy.path}>プライバシーポリシー</LegalLink>
+              に同意します
+            </Checkbox.Label>
+          </Checkbox.Root>
+          {error && (
+            <Text mt={2} color="red.600" fontSize="xs">
+              {error}
+            </Text>
+          )}
+        </Box>
+        <Button colorPalette="teal" h="48px" borderRadius="lg" loading={isSubmitting} onClick={onAccept}>
+          同意する
+        </Button>
+      </VStack>
+    </PanelFrame>
+  );
+}
+
+function PanelFrame({
+  tone,
+  icon,
+  title,
+  children,
+}: {
+  tone: "action" | "success" | "neutral";
+  icon: ReactNode;
+  title: string;
+  children: ReactNode;
+}) {
+  const styles = {
+    action: { bg: "teal.50", iconBg: "teal.500", iconColor: "white" },
+    success: { bg: "green.50", iconBg: "green.500", iconColor: "white" },
+    neutral: { bg: "gray.50", iconBg: "gray.500", iconColor: "white" },
+  }[tone];
+
+  return (
+    <Box bg={styles.bg} p={{ base: 5, md: 6 }}>
+      <VStack align="stretch" gap={4}>
+        <HStack gap={3} align="center">
+          <Circle size="36px" bg={styles.iconBg} color={styles.iconColor} flexShrink={0}>
+            {icon}
+          </Circle>
+          <Text as="h2" color="gray.900" fontSize={{ base: "lg", md: "xl" }} fontWeight="bold">
+            {title}
+          </Text>
+        </HStack>
+        {children}
+      </VStack>
+    </Box>
+  );
+}
+
+function LegalDocumentLinks({ data }: { data: StaffLegalConsentPageData }) {
+  return (
+    <Flex gap={3} wrap="wrap">
+      <LegalLink href={data.documents.terms.path}>{formatDocumentTitle(data.documents.terms.title)}</LegalLink>
+      <LegalLink href={data.documents.privacy.path}>{formatDocumentTitle(data.documents.privacy.title)}</LegalLink>
+    </Flex>
+  );
+}
+
+function formatDocumentTitle(title: string) {
+  return title.replace(/^スタッフ向け/, "");
+}
+
+function LegalLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <LegalDocumentLink href={href} fontWeight="semibold">
+      {children}
+    </LegalDocumentLink>
+  );
+}

--- a/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.stories.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.stories.tsx
@@ -1,0 +1,25 @@
+import { Box } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StaffGuideContent } from "./StaffGuideContent";
+
+const meta = {
+  title: "features/StaffLegalConsent/StaffGuideContent",
+  component: StaffGuideContent,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <Box bg="teal.50" minH="100dvh" px={{ base: 3, md: 6 }} py={{ base: 4, md: 8 }}>
+        <Box maxW="960px" mx="auto" bg="white" borderRadius={{ base: "2xl", md: "3xl" }} overflow="hidden">
+          <Story />
+        </Box>
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof StaffGuideContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.tsx
@@ -1,0 +1,203 @@
+import { Box, Circle, Flex, HStack, Icon, Image, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import type { IconType } from "react-icons";
+import { LuBell, LuCalendarCheck, LuLink, LuMail, LuSmartphone, LuStore, LuUserRoundX } from "react-icons/lu";
+import heroSpImage from "../../LandingPage/hero-sp.webp";
+
+type QuickPoint = {
+  icon: IconType;
+  label: string;
+};
+
+type GuideItem = {
+  icon: IconType;
+  title: string;
+  body: string;
+};
+
+const shiftreeDescription = "勤務先のお店がシフト希望の回収や確定シフトの共有に使うシフト管理サービスです。";
+
+const quickPoints: QuickPoint[] = [
+  { icon: LuUserRoundX, label: "アカウント登録不要" },
+  { icon: LuLink, label: "LINE、メールからシフト提出" },
+];
+
+const guideItems: GuideItem[] = [
+  {
+    icon: LuStore,
+    title: "シフトリとは",
+    body: shiftreeDescription,
+  },
+  {
+    icon: LuBell,
+    title: "お店から連絡が届きます",
+    body: "シフト希望の提出依頼、締切前のお知らせ、確定シフトなどが届きます。",
+  },
+  {
+    icon: LuMail,
+    title: "メールまたはLINEで届きます",
+    body: "勤務先からメールやLINEでシフトに関する案内が届きます。",
+  },
+  {
+    icon: LuSmartphone,
+    title: "登録なしで使えます",
+    body: "届いたリンクからシフト希望の提出や確定シフトの確認ができます。",
+  },
+];
+
+const flowItems = [
+  { icon: LuMail, labelLines: ["メール・LINEが届く"] },
+  { icon: LuLink, labelLines: ["添付のリンクを", "開く"] },
+  { icon: LuCalendarCheck, labelLines: ["希望シフトを提出"] },
+  { icon: LuBell, labelLines: ["確定シフトが届く"] },
+];
+
+export function StaffGuideContent() {
+  return (
+    <VStack align="stretch" gap={{ base: 5, md: 7 }}>
+      <HeroSection />
+      <GuideSection />
+      <UsageFlowSection />
+    </VStack>
+  );
+}
+
+function HeroSection() {
+  return (
+    <Box position="relative" overflow="hidden" bg="teal.50" w="100vw" mx="calc(50% - 50vw)">
+      <Flex
+        maxW="960px"
+        mx="auto"
+        px={{ base: 9, md: 8 }}
+        pt={{ base: 9, md: 10 }}
+        pb={{ base: 7, md: 9 }}
+        gap={{ base: 6, md: 10 }}
+        align={{ base: "stretch", md: "center" }}
+        justify={{ md: "space-between" }}
+        direction={{ base: "column", md: "row" }}
+      >
+        <VStack align="stretch" gap={5} flex={{ base: 1, md: "0 1 600px" }} maxW={{ md: "600px" }}>
+          <Box>
+            <Text as="h1" color="teal.900" fontSize={{ base: "3xl", md: "5xl" }} fontWeight="bold" lineHeight={1.25}>
+              シフトリのご案内
+            </Text>
+            <Text mt={4} color="gray.800" fontSize={{ base: "md", md: "lg" }} lineHeight={1.9}>
+              {shiftreeDescription}
+            </Text>
+          </Box>
+          <Box aria-hidden="true" display={{ base: "block", md: "none" }} alignSelf="center" w="150px">
+            <Image src={heroSpImage} alt="" w="full" h="auto" objectFit="contain" />
+          </Box>
+          <SimpleGrid columns={{ base: 1, sm: 2 }} gap={3}>
+            {quickPoints.map((item) => (
+              <QuickPointCard key={item.label} item={item} />
+            ))}
+          </SimpleGrid>
+        </VStack>
+
+        <Box
+          aria-hidden="true"
+          display={{ base: "none", md: "flex" }}
+          justifyContent="center"
+          flex={{ md: "0 0 240px" }}
+        >
+          <Image src={heroSpImage} alt="" w="180px" maxW="full" h="auto" objectFit="contain" />
+        </Box>
+      </Flex>
+    </Box>
+  );
+}
+
+function QuickPointCard({ item }: { item: QuickPoint }) {
+  return (
+    <HStack gap={3} align="center" bg="white" borderRadius="xl" px={4} py={3} boxShadow="sm" minH="72px">
+      <Icon as={item.icon} color="teal.500" boxSize={7} flexShrink={0} />
+      <Text color="gray.900" fontSize="sm" fontWeight="bold" lineHeight={1.5}>
+        {item.label}
+      </Text>
+    </HStack>
+  );
+}
+
+function GuideSection() {
+  return (
+    <Box px={{ base: 5, md: 8 }} py={6}>
+      <Text as="h2" color="teal.900" fontSize={{ base: "xl", md: "2xl" }} fontWeight="bold" textAlign="center">
+        シフトリとは？
+      </Text>
+      <VStack align="stretch" gap={0} mt={{ base: 4, md: 6 }}>
+        {guideItems.map((item, index) => (
+          <GuideRow key={item.title} index={index + 1} item={item} isLast={index === guideItems.length - 1} />
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+
+function GuideRow({ index, item, isLast }: { index: number; item: GuideItem; isLast: boolean }) {
+  return (
+    <Flex gap={{ base: 4, md: 6 }} py={{ base: 5, md: 6 }} borderBottomWidth={isLast ? 0 : 1} borderColor="gray.100">
+      <Circle size={{ base: "56px", md: "92px" }} bg="teal.50" flexShrink={0}>
+        <Icon as={item.icon} color="teal.600" boxSize={{ base: 7, md: 10 }} />
+      </Circle>
+      <Flex gap={{ base: 3, md: 4 }} align="flex-start" flex={1}>
+        <Circle size="32px" bg="teal.500" color="white" fontSize="sm" fontWeight="bold" flexShrink={0}>
+          {String(index).padStart(2, "0")}
+        </Circle>
+        <Box>
+          <Text color="teal.900" fontSize={{ base: "md", md: "xl" }} fontWeight="bold">
+            {item.title}
+          </Text>
+          <Text mt={2} color="gray.800" fontSize={{ base: "sm", md: "md" }} lineHeight={1.9}>
+            {item.body}
+          </Text>
+        </Box>
+      </Flex>
+    </Flex>
+  );
+}
+
+function UsageFlowSection() {
+  return (
+    <Box px={{ base: 5, md: 8 }} py={6}>
+      <Text as="h2" color="teal.900" fontSize={{ base: "xl", md: "2xl" }} fontWeight="bold" textAlign="center">
+        操作の流れ
+      </Text>
+      <SimpleGrid columns={{ base: 2, md: 4 }} gap={{ base: 3, md: 4 }} mt={{ base: 4, md: 6 }} alignItems="stretch">
+        {flowItems.map((item, index) => (
+          <FlowCard key={item.labelLines.join("-")} item={item} index={index + 1} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+
+function FlowCard({ item, index }: { item: (typeof flowItems)[number]; index: number }) {
+  return (
+    <Box h="full">
+      <VStack
+        gap={3}
+        justify="center"
+        minH={{ base: "132px", md: "148px" }}
+        h="full"
+        bg="white"
+        borderWidth={1}
+        borderColor="gray.200"
+        borderRadius="xl"
+        px={4}
+        py={4}
+      >
+        <Circle size="28px" bg="teal.500" color="white" fontSize="sm" fontWeight="bold" alignSelf="flex-start">
+          {index}
+        </Circle>
+        <Icon as={item.icon} color="teal.600" boxSize={8} />
+        <Text color="gray.900" fontSize="sm" fontWeight="bold" lineHeight={1.6} textAlign="center">
+          {item.labelLines.map((line) => (
+            <Text as="span" key={line} display="block">
+              {line}
+            </Text>
+          ))}
+        </Text>
+      </VStack>
+    </Box>
+  );
+}

--- a/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/StaffGuideContent.tsx
@@ -18,7 +18,7 @@ const shiftreeDescription = "勤務先のお店がシフト希望の回収や確
 
 const quickPoints: QuickPoint[] = [
   { icon: LuUserRoundX, label: "アカウント登録不要" },
-  { icon: LuLink, label: "LINE、メールからシフト提出" },
+  { icon: LuLink, label: "LINE・メールからシフト提出" },
 ];
 
 const guideItems: GuideItem[] = [

--- a/src/components/features/StaffLegalConsent/ConsentPage/index.tsx
+++ b/src/components/features/StaffLegalConsent/ConsentPage/index.tsx
@@ -1,7 +1,7 @@
-import { Box, Checkbox, Link, Text, VStack } from "@chakra-ui/react";
-import type { ReactNode } from "react";
+import { Box, VStack } from "@chakra-ui/react";
 import { useState } from "react";
-import { Button } from "@/src/components/ui/Button";
+import { LegalConsentPanel } from "./LegalConsentPanel";
+import { StaffGuideContent } from "./StaffGuideContent";
 
 export type StaffLegalDocumentLinks = {
   terms: { title: string; documentVersion: string; requiredConsentVersion: string; path: string };
@@ -37,26 +37,6 @@ export function StaffLegalConsentPage({ data, isSubmitting = false, onAccept }: 
   const [checked, setChecked] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  if (data.status === "expired") {
-    return (
-      <Frame title="リンクの有効期限が切れています">
-        <Text color="fg.muted" lineHeight={1.8}>
-          この同意リンクは利用できません。新しい案内が届いた場合はそちらから確認してください。シフト提出時にも同意できます。
-        </Text>
-      </Frame>
-    );
-  }
-
-  if (data.status === "accepted") {
-    return (
-      <Frame title="同意済みです">
-        <Text color="fg.muted" lineHeight={1.8}>
-          {data.shopName} のシフト管理サービス利用に必要な同意は完了しています。
-        </Text>
-      </Frame>
-    );
-  }
-
   const handleAccept = async () => {
     if (!checked) {
       setError("利用規約とプライバシーポリシーに同意してください");
@@ -67,59 +47,22 @@ export function StaffLegalConsentPage({ data, isSubmitting = false, onAccept }: 
   };
 
   return (
-    <Frame title="規約の確認">
-      <VStack align="stretch" gap={5}>
-        <Text color="fg.muted" lineHeight={1.8}>
-          {data.staffName}さん、{data.shopName}{" "}
-          が利用しているシフト管理SaaS「シフトリ」のスタッフ向け利用条件をご確認ください。
-        </Text>
-        <Box p={4} bg="gray.50" borderRadius="md" borderWidth={1} borderColor="border.default">
-          <Checkbox.Root
-            colorPalette="teal"
+    <Box minH="calc(100dvh - 48px)" px={{ base: 3, md: 0 }} pt={0} pb={{ base: 4, md: 8 }}>
+      <VStack align="stretch" gap={{ base: 4, md: 6 }} w="full" maxW="960px" mx="auto">
+        <StaffGuideContent />
+        <Box px={{ base: 4, md: 8 }} pb={{ base: 5, md: 8 }}>
+          <LegalConsentPanel
+            data={data}
             checked={checked}
-            onCheckedChange={(details) => {
-              setChecked(details.checked === true);
-              if (details.checked === true) setError(null);
+            error={error}
+            isSubmitting={isSubmitting}
+            onCheckedChange={(nextChecked) => {
+              setChecked(nextChecked);
+              if (nextChecked) setError(null);
             }}
-          >
-            <Checkbox.HiddenInput />
-            <Checkbox.Control />
-            <Checkbox.Label fontSize="sm" lineHeight={1.7}>
-              <Link href={data.documents.terms.path} target="_blank" rel="noopener noreferrer" color="teal.700">
-                利用規約
-              </Link>
-              と
-              <Link href={data.documents.privacy.path} target="_blank" rel="noopener noreferrer" color="teal.700">
-                プライバシーポリシー
-              </Link>
-              に同意します
-            </Checkbox.Label>
-          </Checkbox.Root>
-          {error && (
-            <Text mt={2} color="red.600" fontSize="xs">
-              {error}
-            </Text>
-          )}
+            onAccept={handleAccept}
+          />
         </Box>
-        <Button colorPalette="teal" h="48px" loading={isSubmitting} onClick={handleAccept}>
-          同意する
-        </Button>
-        <Text fontSize="xs" color="fg.subtle" lineHeight={1.7}>
-          未同意でもシフトのお知らせは引き続き受け取れます。シフト希望を提出するときには同意が必要です。
-        </Text>
-      </VStack>
-    </Frame>
-  );
-}
-
-function Frame({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <Box maxW="560px" mx="auto" px={4} py={8}>
-      <VStack align="stretch" gap={5} bg="white" borderWidth={1} borderColor="border.default" borderRadius="lg" p={5}>
-        <Text fontSize="xl" fontWeight="bold">
-          {title}
-        </Text>
-        {children}
       </VStack>
     </Box>
   );

--- a/src/components/features/StaffSubmit/SubmitFormView/index.tsx
+++ b/src/components/features/StaffSubmit/SubmitFormView/index.tsx
@@ -1,8 +1,9 @@
-import { Box, Checkbox, Flex, Icon, Link, Text, VStack } from "@chakra-ui/react";
+import { Box, Checkbox, Flex, Icon, Text, VStack } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { LuPointer } from "react-icons/lu";
+import { LegalDocumentLink } from "@/src/components/features/LegalDocumentLink";
 import { STAFF_CONTENT_MAX_W } from "@/src/components/templates/StaffHeader";
 import { Button } from "@/src/components/ui/Button";
 import { formatDateWithWeekday, getDateRange } from "@/src/domains/shift/date";
@@ -136,23 +137,8 @@ export const SubmitFormView = ({ data, onSubmit }: Props) => {
                 <Checkbox.HiddenInput />
                 <Checkbox.Control />
                 <Checkbox.Label fontSize="sm" lineHeight={1.7}>
-                  <Link
-                    href={data.legalDocuments.terms.path}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    color="teal.700"
-                  >
-                    利用規約
-                  </Link>
-                  と
-                  <Link
-                    href={data.legalDocuments.privacy.path}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    color="teal.700"
-                  >
-                    プライバシーポリシー
-                  </Link>
+                  <LegalDocumentLink href={data.legalDocuments.terms.path}>利用規約</LegalDocumentLink>と
+                  <LegalDocumentLink href={data.legalDocuments.privacy.path}>プライバシーポリシー</LegalDocumentLink>
                   に同意します
                 </Checkbox.Label>
               </Checkbox.Root>


### PR DESCRIPTION
## Summary
スタッフ向け法務同意ページを、規約確認だけでなくシフトリの案内として見えるように整えます。あわせて通知文面、法務リンク、E2E/運用補助の設定を更新します。

## Design

### スタッフ法務同意導線
```mermaid
sequenceDiagram
    Manager->>Convex: スタッフ追加/LINE連携
    Convex->>Staff: メール・LINEで案内リンク送信
    Staff->>ConsentPage: シフトリ案内と規約確認を表示
    Staff->>Convex: 利用規約・プライバシーポリシーに同意
```

## Changes
- **スタッフ向け案内UI**: ConsentPageをシフトリの説明、操作の流れ、利用規約/プライバシーポリシー確認に分割
- **通知文面**: メール/LINEを「シフトリの使い方と規約確認」案内に調整し、EmailPreviewを追加
- **法務リンク**: 別タブアイコン付きLegalDocumentLinkを追加し、関連UIで利用
- **E2E基盤**: 3ユーザー並列実行に対応し、法務同意フロー周辺のテストヘルパーを整理
- **運用補助**: release version同期PR作成とConvex全消し用スクリプト/生成API更新を追加

## Checks
- pnpm lint
- pnpm type-check