### PR TITLE
Convex Scenarioテストのセキュリティ境界を強化

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/convex/AGENTS.md
+++ b/convex/AGENTS.md
@@ -337,6 +337,18 @@ convex/
 - 正常系と異常系をセットで書く
 - テストデータは internal mutation 経由でセットアップ
 
+### Convex Scenario Test
+
+`convex/_scenario/` の Scenario Test は、E2E の代わりに複数の Convex 関数を高速に通す業務フローテストとして扱う。
+
+- 繰り返し出るユーザー操作相当の API 呼び出しは `convex/_test/scenarioFixtures.ts` に寄せる
+- Scenario Fixture は public/internal Convex API を呼ぶ薄い operation wrapper にする
+- Fixture には検証パターン、期待値、`expect(...)` を入れない
+- DB 直 seed は前提状態作成だけに使い、通常のユーザー操作は Fixture 経由で表現する
+- 各 `it` は Scenario 向け AAA（Arrange / Act / Assert）が読み取れる順序で書く
+- 長い業務フローでは `Act` / `Assert` の小さなまとまりを複数置いてよい
+- 新しい Scenario Test を追加するときは、既存 Fixture に同じ操作がないか確認してから API 直呼びを追加する
+
 ### テスト不要
 
 - `_generated/`

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as _lib_time from "../_lib/time.js";
 import type * as _lib_uuid from "../_lib/uuid.js";
 import type * as _lib_validation from "../_lib/validation.js";
 import type * as _test_scenarioBuilders from "../_test/scenarioBuilders.js";
+import type * as _test_scenarioFixtures from "../_test/scenarioFixtures.js";
 import type * as _test_seed from "../_test/seed.js";
 import type * as constants from "../constants.js";
 import type * as crons from "../crons.js";
@@ -91,6 +92,7 @@ declare const fullApi: ApiFromModules<{
   "_lib/uuid": typeof _lib_uuid;
   "_lib/validation": typeof _lib_validation;
   "_test/scenarioBuilders": typeof _test_scenarioBuilders;
+  "_test/scenarioFixtures": typeof _test_scenarioFixtures;
   "_test/seed": typeof _test_seed;
   constants: typeof constants;
   crons: typeof crons;

--- a/convex/_scenario/legalConsent.test.ts
+++ b/convex/_scenario/legalConsent.test.ts
@@ -1,7 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import { MANAGER_SUBJECT, SCENARIO_NOW, scenarioDate, seedSession, seedStaff } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -14,6 +15,10 @@ describe("法務同意シナリオ", () => {
 
   it("スタッフ同意リンクは page data から同意済み状態へ遷移し、同意済み通知対象から外れる", async () => {
     const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    // Arrange: 法務同意が必要なスタッフと同意リンクを用意する。
     const { staffId, shopId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -29,18 +34,19 @@ describe("法務同意シナリオ", () => {
     });
     const { token } = await t.mutation(internal.legal.mutations.createStaffConsentToken, { staffId, shopId });
 
-    const pageBeforeAccept = await t.query(api.legal.queries.getStaffConsentPageData, { token });
+    // Assert: 同意前のページデータが表示できる。
+    const pageBeforeAccept = await staff.getStaffConsentPageData(token);
     expect(pageBeforeAccept).toMatchObject({
       status: "ok",
       staffName: "同意スタッフ",
       shopName: "法務店舗",
     });
 
-    await expect(
-      t.mutation(api.legal.mutations.acceptStaffLegalConsent, { token, acceptedLegal: true }),
-    ).resolves.toEqual({ status: "ok" });
+    // Act: スタッフが同意リンクから同意する。
+    await expect(staff.acceptStaffLegalConsent({ token, acceptedLegal: true })).resolves.toEqual({ status: "ok" });
 
-    const pageAfterAccept = await t.query(api.legal.queries.getStaffConsentPageData, { token });
+    // Assert: 同意後は通知対象から外れる。
+    const pageAfterAccept = await staff.getStaffConsentPageData(token);
     expect(pageAfterAccept).toMatchObject({
       status: "accepted",
       staffName: "同意スタッフ",
@@ -54,6 +60,10 @@ describe("法務同意シナリオ", () => {
 
   it("未同意スタッフはシフト提出時の同意で state/event が記録される", async () => {
     const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    // Arrange: 未同意スタッフが提出できる募集中シフトとセッションを用意する。
     const ids = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -84,13 +94,15 @@ describe("法務同意シナリオ", () => {
       return { staffId, recruitmentId };
     });
 
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    // Act: スタッフが提出時に法務同意する。
+    await staff.submitShiftRequests({
       sessionToken: "scenario-submit-legal-session",
       recruitmentId: ids.recruitmentId,
       acceptedLegal: true,
       requests: [{ date: scenarioDate(7), startTime: "10:00", endTime: "18:00" }],
     });
 
+    // Assert: 同意 state と event が提出由来として記録される。
     const legalState = await t.run(async (ctx) =>
       ctx.db
         .query("legalConsentStates")

--- a/convex/_scenario/lineNotification.test.ts
+++ b/convex/_scenario/lineNotification.test.ts
@@ -1,9 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import {
   countScheduledJobs,
-  firstPage,
   hasScheduledJob,
   MANAGER_SUBJECT,
   readScheduledFunctions,
@@ -11,6 +10,7 @@ import {
   scenarioDate,
   seedStaff,
 } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -23,7 +23,11 @@ describe("LINE通知連携シナリオ", () => {
 
   it("LINE連携からfollow/unfollow復帰まで、一覧表示と通知対象データに反映される", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const line = scenario.line();
+
+    // Arrange: 募集中シフトがある店舗にLINE未連携スタッフを用意する。
     const { staffId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -37,28 +41,28 @@ describe("LINE通知連携シナリオ", () => {
       });
       return { staffId };
     });
-    await asManager.mutation(api.recruitment.mutations.createRecruitment, {
+    await asManager.createRecruitment({
       periodStart: scenarioDate(7),
       periodEnd: scenarioDate(13),
       deadline: scenarioDate(3),
     });
 
-    const link = await asManager.mutation(api.line.mutations.generateLinkToken, {
-      staffId,
-    });
+    // Act: 店長がLINE連携トークンを発行し、スタッフが連携を完了する。
+    const link = await asManager.generateLineLinkToken(staffId);
     expect(link.token).toBeTypeOf("string");
-    const validation = await t.mutation(internal.line.mutations.validateLinkToken, { state: link.token });
+    const validation = await line.validateLinkToken(link.token);
     expect(validation.status).toBe("ok");
     if (validation.status !== "ok") throw new Error("LINE token validation failed");
 
-    await t.mutation(internal.line.mutations.finalizeLinking, {
+    await line.finalizeLinking({
       staffId,
       tokenDocId: validation.tokenDocId,
       lineUserId: "U_line_scenario",
       lineFollowing: true,
     });
 
-    const staffPage = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+    // Assert: 一覧、通知対象データ、連携後通知予約にLINE連携状態が反映される。
+    const staffPage = await asManager.getDashboardStaffs();
     expect(staffPage.page.find((staff) => staff._id === staffId)).toMatchObject({
       isLineLinked: true,
       isLineFollowing: true,
@@ -83,19 +87,21 @@ describe("LINE通知連携シナリオ", () => {
       }),
     ).toBe(true);
 
-    await t.mutation(internal.line.mutations.dispatchWebhookEvents, {
-      events: [{ type: "unfollow", userId: "U_line_scenario" }],
-    });
-    const staffPageAfterUnfollow = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+    // Act: LINE webhookでunfollowを受け取る。
+    await line.dispatchWebhookEvents([{ type: "unfollow", userId: "U_line_scenario" }]);
+
+    // Assert: 一覧表示のfollow状態が落ちる。
+    const staffPageAfterUnfollow = await asManager.getDashboardStaffs();
     expect(staffPageAfterUnfollow.page.find((staff) => staff._id === staffId)).toMatchObject({
       isLineLinked: true,
       isLineFollowing: false,
     });
 
-    await t.mutation(internal.line.mutations.dispatchWebhookEvents, {
-      events: [{ type: "follow", userId: "U_line_scenario" }],
-    });
-    const staffPageAfterRefollow = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+    // Act: 同じLINEユーザーが再followする。
+    await line.dispatchWebhookEvents([{ type: "follow", userId: "U_line_scenario" }]);
+
+    // Assert: follow状態が復帰し、募集中通知が再度予約される。
+    const staffPageAfterRefollow = await asManager.getDashboardStaffs();
     expect(staffPageAfterRefollow.page.find((staff) => staff._id === staffId)).toMatchObject({
       isLineLinked: true,
       isLineFollowing: true,

--- a/convex/_scenario/managerSetup.test.ts
+++ b/convex/_scenario/managerSetup.test.ts
@@ -1,7 +1,7 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api } from "../_generated/api";
-import { firstPage, hasScheduledJob, readScheduledFunctions, SCENARIO_NOW } from "../_test/scenarioBuilders";
+import { hasScheduledJob, readScheduledFunctions, SCENARIO_NOW } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { modules, schema } from "../_test/setup.test-helper";
 
 const SETUP_MANAGER_SUBJECT = "scenario_setup_manager";
@@ -15,13 +15,15 @@ describe("管理者セットアップシナリオ", () => {
 
   it("初回セットアップで店舗・管理者・owner staff・同意・初期positionが揃い、ダッシュボードに反映される", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({
+    const scenario = createScenario(t);
+    const asManager = scenario.manager({
       subject: SETUP_MANAGER_SUBJECT,
       name: "山田 太郎",
       email: "owner@example.com",
     });
 
-    const shopId = await asManager.mutation(api.setup.mutations.setupShopAndOwner, {
+    // Arrange / Act: 初回ユーザーがセットアップ画面から店舗とowner情報を登録する。
+    const shopId = await asManager.setupShopAndOwner({
       shopName: "初回セットアップ店舗",
       shiftStartTime: "09:30",
       shiftEndTime: "22:30",
@@ -30,11 +32,12 @@ describe("管理者セットアップシナリオ", () => {
       acceptedLegal: true,
     });
 
+    // Assert: セットアップ後にダッシュボードへ必要な状態が揃う。
     const [currentUser, shop, staffPage, consentStatus] = await Promise.all([
-      asManager.query(api.dashboard.queries.getCurrentUser, {}),
-      asManager.query(api.dashboard.queries.getDashboardShop, {}),
-      asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage()),
-      asManager.query(api.legal.queries.getManagerConsentStatus, {}),
+      asManager.getCurrentUser(),
+      asManager.getDashboardShop(),
+      asManager.getDashboardStaffs(),
+      asManager.getManagerConsentStatus(),
     ]);
     expect(currentUser).toEqual({ isNewUser: false, name: "山田 太郎", email: "owner@example.com" });
     expect(shop).toEqual({
@@ -67,13 +70,16 @@ describe("管理者セットアップシナリオ", () => {
     const scheduled = await readScheduledFunctions(t);
     expect(hasScheduledJob(scheduled, "line/actions:sendInviteEmail", { staffId: state.ownerStaff._id })).toBe(true);
 
-    await asManager.mutation(api.staff.mutations.editStaff, {
+    // Act: owner自身のスタッフ情報を編集する。
+    await asManager.editStaff({
       staffId: state.ownerStaff._id,
       name: "山田 太郎 更新",
       email: "owner-updated@example.com",
     });
-    const updatedUser = await asManager.query(api.dashboard.queries.getCurrentUser, {});
-    const updatedStaffPage = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+
+    // Assert: スタッフ表示名と管理者プロフィールが同期される。
+    const updatedUser = await asManager.getCurrentUser();
+    const updatedStaffPage = await asManager.getDashboardStaffs();
     expect(updatedUser).toEqual({ isNewUser: false, name: "山田 太郎 更新", email: "owner-updated@example.com" });
     expect(updatedStaffPage.page[0]).toMatchObject({
       name: "山田 太郎 更新",

--- a/convex/_scenario/securityBoundaries.test.ts
+++ b/convex/_scenario/securityBoundaries.test.ts
@@ -1,0 +1,744 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { internal } from "../_generated/api";
+import { selectChannel } from "../_lib/notification";
+import {
+  countScheduledJobs,
+  hasScheduledJob,
+  MANAGER_SUBJECT,
+  readScheduledFunctions,
+  SCENARIO_NOW,
+  scenarioDate,
+  seedSession,
+  seedStaff,
+} from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
+import { seedManagerShop, seedShop, seedStaffLineAccount } from "../_test/seed";
+import { modules, schema } from "../_test/setup.test-helper";
+
+describe("セキュリティ境界シナリオ", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(SCENARIO_NOW);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("シフト確定通知は対象店舗の有効スタッフだけをメール/LINE/magic link対象にする", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+
+    const ids = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, {
+        subject: MANAGER_SUBJECT,
+        email: "security-manager@example.com",
+        shopName: "通知対象店舗",
+      });
+      const { shopId: otherShopId } = await seedManagerShop(ctx, {
+        subject: "security_other_manager",
+        email: "security-other-manager@example.com",
+        shopName: "別店舗",
+      });
+      const emailStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "メールスタッフ",
+        email: "email-staff@example.com",
+      });
+      const lineStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "LINEスタッフ",
+        email: "line-staff@example.com",
+      });
+      const unfollowStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "未followスタッフ",
+        email: "unfollow-staff@example.com",
+      });
+      const deletedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "削除済みスタッフ",
+        email: "deleted-staff@example.com",
+        isDeleted: true,
+      });
+      const otherShopStaffId = await seedStaff(ctx, {
+        shopId: otherShopId,
+        name: "別店舗スタッフ",
+        email: "other-shop-staff@example.com",
+      });
+      await seedStaffLineAccount(ctx, { staffId: lineStaffId, shopId, lineUserId: "U_confirm_line", following: true });
+      await seedStaffLineAccount(ctx, {
+        staffId: unfollowStaffId,
+        shopId,
+        lineUserId: "U_confirm_unfollow",
+        following: false,
+      });
+      await seedStaffLineAccount(ctx, {
+        staffId: otherShopStaffId,
+        shopId: otherShopId,
+        lineUserId: "U_confirm_other_shop",
+        following: true,
+      });
+
+      const positionId = await ctx.db.insert("positions", {
+        shopId,
+        name: "シフト",
+        color: "#3b82f6",
+        sortOrder: 0,
+        isDefault: true,
+        isDeleted: false,
+      });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(9),
+        deadline: scenarioDate(3),
+        status: "open",
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      await ctx.db.insert("shiftAssignments", {
+        recruitmentId,
+        staffId: emailStaffId,
+        date: scenarioDate(7),
+        startTime: "10:00",
+        endTime: "18:00",
+        positionId,
+      });
+      await ctx.db.insert("shiftAssignments", {
+        recruitmentId,
+        staffId: lineStaffId,
+        date: scenarioDate(7),
+        startTime: "11:00",
+        endTime: "19:00",
+        positionId,
+      });
+      await ctx.db.insert("shiftAssignments", {
+        recruitmentId,
+        staffId: otherShopStaffId,
+        date: scenarioDate(7),
+        startTime: "12:00",
+        endTime: "20:00",
+        positionId,
+      });
+
+      return { shopId, recruitmentId, emailStaffId, lineStaffId, unfollowStaffId, deletedStaffId, otherShopStaffId };
+    });
+
+    await asManager.confirmRecruitment(ids.recruitmentId);
+    const scheduledAfterConfirm = await readScheduledFunctions(t);
+    expect(
+      hasScheduledJob(scheduledAfterConfirm, "notification/actions:sendShiftConfirmationEmails", {
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).toBe(true);
+
+    const confirmationData = await t.query(internal.notification.queries.getConfirmationEmailData, {
+      recruitmentId: ids.recruitmentId,
+    });
+    expect(confirmationData?.shopId).toBe(ids.shopId);
+    expect(confirmationData?.staffEntries.map((staff) => staff.staffId)).toEqual(
+      expect.arrayContaining([ids.emailStaffId, ids.lineStaffId, ids.unfollowStaffId]),
+    );
+    expect(confirmationData?.staffEntries.map((staff) => staff.staffId)).not.toEqual(
+      expect.arrayContaining([ids.deletedStaffId, ids.otherShopStaffId]),
+    );
+
+    const lineEntry = confirmationData?.staffEntries.find((staff) => staff.staffId === ids.lineStaffId);
+    const unfollowEntry = confirmationData?.staffEntries.find((staff) => staff.staffId === ids.unfollowStaffId);
+    const emailEntry = confirmationData?.staffEntries.find((staff) => staff.staffId === ids.emailStaffId);
+    expect(selectChannel({ lineUserId: lineEntry?.lineUserId, lineFollowing: lineEntry?.lineFollowing }, null)).toBe(
+      "line",
+    );
+    expect(
+      selectChannel({ lineUserId: unfollowEntry?.lineUserId, lineFollowing: unfollowEntry?.lineFollowing }, null),
+    ).toBe("email");
+    expect(selectChannel({ lineUserId: emailEntry?.lineUserId, lineFollowing: emailEntry?.lineFollowing }, null)).toBe(
+      "email",
+    );
+
+    if (!confirmationData) throw new Error("confirmation data was not found");
+    for (const staff of confirmationData.staffEntries) {
+      await t.mutation(internal.notification.mutations.createMagicLink, {
+        staffId: staff.staffId,
+        shopId: confirmationData.shopId,
+        recruitmentId: ids.recruitmentId,
+      });
+    }
+
+    const magicLinks = await t.run(async (ctx) => ctx.db.query("magicLinks").collect());
+    expect(magicLinks.map((link) => link.staffId)).toEqual(
+      expect.arrayContaining([ids.emailStaffId, ids.lineStaffId, ids.unfollowStaffId]),
+    );
+    expect(magicLinks.map((link) => link.staffId)).not.toEqual(
+      expect.arrayContaining([ids.deletedStaffId, ids.otherShopStaffId]),
+    );
+    expect(magicLinks.every((link) => link.shopId === ids.shopId && link.recruitmentId === ids.recruitmentId)).toBe(
+      true,
+    );
+  });
+
+  it("募集開始通知と未提出催促も対象店舗の有効スタッフだけを対象にする", async () => {
+    const t = convexTest(schema, modules);
+
+    const ids = await t.run(async (ctx) => {
+      const shopId = await seedShop(ctx, "募集通知店舗");
+      const otherShopId = await seedShop(ctx, "別店舗");
+      const unsubmittedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "未提出スタッフ",
+        email: "unsubmitted@example.com",
+      });
+      const submittedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "提出済みスタッフ",
+        email: "submitted@example.com",
+      });
+      const lineStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "LINE未提出スタッフ",
+        email: "line-unsubmitted@example.com",
+      });
+      const deletedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "削除済みスタッフ",
+        email: "deleted@example.com",
+        isDeleted: true,
+      });
+      const otherShopStaffId = await seedStaff(ctx, {
+        shopId: otherShopId,
+        name: "別店舗スタッフ",
+        email: "other@example.com",
+      });
+      await seedStaffLineAccount(ctx, { staffId: lineStaffId, shopId, lineUserId: "U_open_line", following: true });
+
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(13),
+        deadline: scenarioDate(3),
+        status: "open",
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      await ctx.db.insert("shiftSubmissions", {
+        recruitmentId,
+        staffId: submittedStaffId,
+        firstSubmittedAt: Date.now(),
+        submittedAt: Date.now(),
+      });
+      return { recruitmentId, unsubmittedStaffId, submittedStaffId, lineStaffId, deletedStaffId, otherShopStaffId };
+    });
+
+    const recruitmentData = await t.query(internal.notification.queries.getRecruitmentEmailData, {
+      recruitmentId: ids.recruitmentId,
+    });
+    expect(recruitmentData?.staffEntries.map((staff) => staff.staffId)).toEqual(
+      expect.arrayContaining([ids.unsubmittedStaffId, ids.submittedStaffId, ids.lineStaffId]),
+    );
+    expect(recruitmentData?.staffEntries.map((staff) => staff.staffId)).not.toEqual(
+      expect.arrayContaining([ids.deletedStaffId, ids.otherShopStaffId]),
+    );
+
+    const reminderData = await t.query(internal.notification.reminderQueries.getReminderEmailData, {
+      recruitmentId: ids.recruitmentId,
+    });
+    expect(reminderData?.staffEntries.map((staff) => staff.staffId)).toEqual(
+      expect.arrayContaining([ids.unsubmittedStaffId, ids.lineStaffId]),
+    );
+    expect(reminderData?.staffEntries.map((staff) => staff.staffId)).not.toEqual(
+      expect.arrayContaining([ids.submittedStaffId, ids.deletedStaffId, ids.otherShopStaffId]),
+    );
+  });
+
+  it("シフト下書き保存では別店舗・削除済みのスタッフ/positionを混ぜられない", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+
+    const ids = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, {
+        subject: MANAGER_SUBJECT,
+        email: "draft-security-manager@example.com",
+        shopName: "下書き店舗",
+      });
+      const otherShopId = await seedShop(ctx, "別店舗");
+      const targetStaffId = await seedStaff(ctx, { shopId, name: "対象スタッフ", email: "target@example.com" });
+      const otherShopStaffId = await seedStaff(ctx, {
+        shopId: otherShopId,
+        name: "別店舗スタッフ",
+        email: "other@example.com",
+      });
+      const deletedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "削除済みスタッフ",
+        email: "deleted@example.com",
+        isDeleted: true,
+      });
+      const targetPositionId = await ctx.db.insert("positions", {
+        shopId,
+        name: "シフト",
+        color: "#3b82f6",
+        sortOrder: 0,
+        isDefault: true,
+        isDeleted: false,
+      });
+      const otherShopPositionId = await ctx.db.insert("positions", {
+        shopId: otherShopId,
+        name: "別店舗ポジション",
+        color: "#ef4444",
+        sortOrder: 0,
+        isDefault: true,
+        isDeleted: false,
+      });
+      const deletedPositionId = await ctx.db.insert("positions", {
+        shopId,
+        name: "削除済みポジション",
+        color: "#64748b",
+        sortOrder: 1,
+        isDeleted: true,
+      });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(9),
+        deadline: scenarioDate(3),
+        status: "open",
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      return {
+        recruitmentId,
+        targetStaffId,
+        otherShopStaffId,
+        deletedStaffId,
+        targetPositionId,
+        otherShopPositionId,
+        deletedPositionId,
+      };
+    });
+
+    await expect(
+      asManager.saveShiftAssignments({
+        recruitmentId: ids.recruitmentId,
+        assignments: [{ staffId: ids.otherShopStaffId, date: scenarioDate(7), startTime: "10:00", endTime: "18:00" }],
+      }),
+    ).rejects.toThrow("Not found");
+    await expect(
+      asManager.saveShiftAssignments({
+        recruitmentId: ids.recruitmentId,
+        assignments: [{ staffId: ids.deletedStaffId, date: scenarioDate(7), startTime: "10:00", endTime: "18:00" }],
+      }),
+    ).rejects.toThrow("Not found");
+    await expect(
+      asManager.saveShiftAssignments({
+        recruitmentId: ids.recruitmentId,
+        assignments: [
+          {
+            staffId: ids.targetStaffId,
+            date: scenarioDate(7),
+            startTime: "10:00",
+            endTime: "18:00",
+            positionId: ids.otherShopPositionId,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Not found");
+    await expect(
+      asManager.saveShiftAssignments({
+        recruitmentId: ids.recruitmentId,
+        assignments: [
+          {
+            staffId: ids.targetStaffId,
+            date: scenarioDate(7),
+            startTime: "10:00",
+            endTime: "18:00",
+            positionId: ids.deletedPositionId,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Not found");
+
+    await asManager.saveShiftAssignments({
+      recruitmentId: ids.recruitmentId,
+      assignments: [
+        {
+          staffId: ids.targetStaffId,
+          date: scenarioDate(7),
+          startTime: "10:00",
+          endTime: "18:00",
+          positionId: ids.targetPositionId,
+        },
+      ],
+    });
+    const assignments = await t.run(async (ctx) =>
+      ctx.db
+        .query("shiftAssignments")
+        .withIndex("by_recruitmentId", (q) => q.eq("recruitmentId", ids.recruitmentId))
+        .collect(),
+    );
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]).toMatchObject({ staffId: ids.targetStaffId, positionId: ids.targetPositionId });
+  });
+
+  it("確定シフト閲覧はsession・スタッフ・店舗・募集の境界を越えない", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    const ids = await t.run(async (ctx) => {
+      const shopId = await seedShop(ctx, "閲覧境界店舗");
+      const otherShopId = await seedShop(ctx, "別店舗");
+      const staffId = await seedStaff(ctx, { shopId, name: "閲覧スタッフ", email: "view@example.com" });
+      const deletedStaffId = await seedStaff(ctx, {
+        shopId,
+        name: "削除済み閲覧スタッフ",
+        email: "deleted-view@example.com",
+        isDeleted: true,
+      });
+      const otherShopStaffId = await seedStaff(ctx, {
+        shopId: otherShopId,
+        name: "別店舗閲覧スタッフ",
+        email: "other-view@example.com",
+      });
+      const positionId = await ctx.db.insert("positions", {
+        shopId,
+        name: "シフト",
+        color: "#3b82f6",
+        sortOrder: 0,
+        isDefault: true,
+        isDeleted: false,
+      });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(9),
+        deadline: scenarioDate(3),
+        status: "confirmed",
+        confirmedAt: Date.now(),
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      const otherRecruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(14),
+        periodEnd: scenarioDate(16),
+        deadline: scenarioDate(10),
+        status: "confirmed",
+        confirmedAt: Date.now(),
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      const deletedRecruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(21),
+        periodEnd: scenarioDate(23),
+        deadline: scenarioDate(17),
+        status: "confirmed",
+        confirmedAt: Date.now(),
+        isDeleted: true,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      await ctx.db.insert("shiftAssignments", {
+        recruitmentId,
+        staffId,
+        date: scenarioDate(7),
+        startTime: "10:00",
+        endTime: "18:00",
+        positionId,
+      });
+      await seedSession(ctx, { sessionToken: "valid-view-session", staffId, shopId, recruitmentId });
+      await seedSession(ctx, {
+        sessionToken: "other-recruitment-session",
+        staffId,
+        shopId,
+        recruitmentId: otherRecruitmentId,
+      });
+      await seedSession(ctx, {
+        sessionToken: "other-shop-session",
+        staffId: otherShopStaffId,
+        shopId: otherShopId,
+        recruitmentId,
+      });
+      await seedSession(ctx, { sessionToken: "deleted-staff-session", staffId: deletedStaffId, shopId, recruitmentId });
+      await seedSession(ctx, {
+        sessionToken: "deleted-recruitment-session",
+        staffId,
+        shopId,
+        recruitmentId: deletedRecruitmentId,
+      });
+      await ctx.db.insert("sessions", {
+        sessionToken: "expired-view-session",
+        staffId,
+        shopId,
+        recruitmentId,
+        expiresAt: Date.now() - 1,
+      });
+      return { recruitmentId, deletedRecruitmentId };
+    });
+
+    const validView = await staff.getShiftViewData({
+      sessionToken: "valid-view-session",
+      recruitmentId: ids.recruitmentId,
+    });
+    expect(validView?.assignments).toHaveLength(1);
+    await expect(
+      staff.getShiftViewData({ sessionToken: "other-recruitment-session", recruitmentId: ids.recruitmentId }),
+    ).resolves.toBeNull();
+    await expect(
+      staff.getShiftViewData({ sessionToken: "other-shop-session", recruitmentId: ids.recruitmentId }),
+    ).resolves.toBeNull();
+    await expect(
+      staff.getShiftViewData({ sessionToken: "deleted-staff-session", recruitmentId: ids.recruitmentId }),
+    ).resolves.toBeNull();
+    await expect(
+      staff.getShiftViewData({ sessionToken: "expired-view-session", recruitmentId: ids.recruitmentId }),
+    ).resolves.toBeNull();
+    await expect(
+      staff.getShiftViewData({
+        sessionToken: "deleted-recruitment-session",
+        recruitmentId: ids.deletedRecruitmentId,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("再発行通知は対象募集の店舗スタッフだけに予約され、内部通知データも店舗不一致を返さない", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    const ids = await t.run(async (ctx) => {
+      const targetShopId = await seedShop(ctx, "再発行対象店舗");
+      const otherShopId = await seedShop(ctx, "別店舗");
+      const targetStaffId = await seedStaff(ctx, {
+        shopId: targetShopId,
+        name: "対象スタッフ",
+        email: "shared@example.com",
+      });
+      const otherShopStaffId = await seedStaff(ctx, {
+        shopId: otherShopId,
+        name: "別店舗スタッフ",
+        email: "shared@example.com",
+      });
+      const deletedStaffId = await seedStaff(ctx, {
+        shopId: targetShopId,
+        name: "削除済みスタッフ",
+        email: "deleted-reissue@example.com",
+        isDeleted: true,
+      });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId: targetShopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(9),
+        deadline: scenarioDate(3),
+        status: "confirmed",
+        confirmedAt: Date.now(),
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      const deletedRecruitmentId = await ctx.db.insert("recruitments", {
+        shopId: targetShopId,
+        periodStart: scenarioDate(14),
+        periodEnd: scenarioDate(16),
+        deadline: scenarioDate(10),
+        status: "confirmed",
+        confirmedAt: Date.now(),
+        isDeleted: true,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      const openRecruitmentId = await ctx.db.insert("recruitments", {
+        shopId: targetShopId,
+        periodStart: scenarioDate(21),
+        periodEnd: scenarioDate(23),
+        deadline: scenarioDate(17),
+        status: "open",
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      return {
+        recruitmentId,
+        deletedRecruitmentId,
+        openRecruitmentId,
+        targetStaffId,
+        otherShopStaffId,
+        deletedStaffId,
+      };
+    });
+
+    await staff.requestReissue({ email: "shared@example.com", recruitmentId: ids.recruitmentId });
+    const scheduled = await readScheduledFunctions(t);
+    expect(
+      hasScheduledJob(scheduled, "notification/actions:sendReissueEmail", {
+        staffId: ids.targetStaffId,
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).toBe(true);
+    expect(
+      hasScheduledJob(scheduled, "notification/actions:sendReissueEmail", {
+        staffId: ids.otherShopStaffId,
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).toBe(false);
+
+    await expect(
+      t.query(internal.notification.queries.getReissueEmailData, {
+        staffId: ids.targetStaffId,
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).resolves.toMatchObject({ staffName: "対象スタッフ", staffEmail: "shared@example.com" });
+    await expect(
+      t.query(internal.notification.queries.getReissueEmailData, {
+        staffId: ids.otherShopStaffId,
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      t.query(internal.notification.queries.getReissueEmailData, {
+        staffId: ids.deletedStaffId,
+        recruitmentId: ids.recruitmentId,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      t.query(internal.notification.queries.getReissueEmailData, {
+        staffId: ids.targetStaffId,
+        recruitmentId: ids.deletedRecruitmentId,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      t.query(internal.notification.queries.getReissueEmailData, {
+        staffId: ids.targetStaffId,
+        recruitmentId: ids.openRecruitmentId,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("スタッフ削除後は既存リンク・session・LINE連携から提出/閲覧/通知に進めない", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const staff = scenario.staff();
+
+    const ids = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, {
+        subject: MANAGER_SUBJECT,
+        email: "delete-security-manager@example.com",
+        shopName: "削除境界店舗",
+      });
+      const staffId = await seedStaff(ctx, { shopId, name: "削除対象スタッフ", email: "delete-target@example.com" });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: scenarioDate(7),
+        periodEnd: scenarioDate(9),
+        deadline: scenarioDate(3),
+        status: "open",
+        isDeleted: false,
+        shiftStartTime: "09:00",
+        shiftEndTime: "22:00",
+      });
+      await seedSession(ctx, { sessionToken: "deleted-target-session", staffId, shopId, recruitmentId });
+      await seedStaffLineAccount(ctx, { staffId, shopId, lineUserId: "U_deleted_target", following: true });
+      return { shopId, staffId, recruitmentId };
+    });
+    const { token: magicToken } = await t.mutation(internal.notification.mutations.createMagicLink, {
+      staffId: ids.staffId,
+      shopId: ids.shopId,
+      recruitmentId: ids.recruitmentId,
+    });
+    await t.mutation(internal.line.mutations.createLinkTokenInternal, { staffId: ids.staffId, shopId: ids.shopId });
+
+    await asManager.deleteStaff(ids.staffId);
+
+    await expect(staff.verifyMagicLink(magicToken)).resolves.toMatchObject({ status: "expired" });
+    await expect(
+      staff.getSubmissionPageData({ sessionToken: "deleted-target-session", recruitmentId: ids.recruitmentId }),
+    ).resolves.toBeNull();
+    await expect(
+      staff.submitShiftRequests({
+        sessionToken: "deleted-target-session",
+        recruitmentId: ids.recruitmentId,
+        acceptedLegal: true,
+        requests: [{ date: scenarioDate(7), startTime: "10:00", endTime: "18:00" }],
+      }),
+    ).rejects.toThrow("Session expired");
+    await expect(
+      t.query(internal.notification.queries.getOpenRecruitmentNotificationDataForStaff, { staffId: ids.staffId }),
+    ).resolves.toBeNull();
+    await expect(
+      t.query(internal.legal.queries.getStaffConsentNotificationDataInternal, { staffId: ids.staffId }),
+    ).resolves.toBeNull();
+  });
+
+  it("同じLINE userIdを再連携したら古いスタッフにはLINE通知対象が残らない", async () => {
+    const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const line = scenario.line();
+
+    const ids = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, {
+        subject: MANAGER_SUBJECT,
+        email: "line-relink-manager@example.com",
+        shopName: "LINE再連携店舗",
+      });
+      const oldStaffId = await seedStaff(ctx, { shopId, name: "旧スタッフ", email: "old-line@example.com" });
+      const newStaffId = await seedStaff(ctx, { shopId, name: "新スタッフ", email: "new-line@example.com" });
+      await seedStaffLineAccount(ctx, { staffId: oldStaffId, shopId, lineUserId: "U_relink_shared", following: true });
+      return { oldStaffId, newStaffId };
+    });
+    await asManager.createRecruitment({
+      periodStart: scenarioDate(7),
+      periodEnd: scenarioDate(13),
+      deadline: scenarioDate(3),
+    });
+
+    const link = await asManager.generateLineLinkToken(ids.newStaffId);
+    const validation = await line.validateLinkToken(link.token);
+    expect(validation.status).toBe("ok");
+    if (validation.status !== "ok") throw new Error("LINE token validation failed");
+
+    await line.finalizeLinking({
+      staffId: ids.newStaffId,
+      tokenDocId: validation.tokenDocId,
+      lineUserId: "U_relink_shared",
+      lineFollowing: true,
+    });
+
+    const accounts = await t.run(async (ctx) => {
+      const oldAccount = await ctx.db
+        .query("staffLineAccounts")
+        .withIndex("by_staffId", (q) => q.eq("staffId", ids.oldStaffId))
+        .first();
+      const newAccount = await ctx.db
+        .query("staffLineAccounts")
+        .withIndex("by_staffId", (q) => q.eq("staffId", ids.newStaffId))
+        .first();
+      return { oldAccount, newAccount };
+    });
+    expect(accounts.oldAccount).toMatchObject({ isDeleted: true, following: false });
+    expect(accounts.newAccount).toMatchObject({
+      isDeleted: false,
+      following: true,
+      lineUserId: "U_relink_shared",
+    });
+
+    const scheduled = await readScheduledFunctions(t);
+    expect(
+      countScheduledJobs(scheduled, "notification/actions:sendOpenRecruitmentNotificationLinesForStaff", {
+        staffId: ids.oldStaffId,
+      }),
+    ).toBe(0);
+    expect(
+      countScheduledJobs(scheduled, "notification/actions:sendOpenRecruitmentNotificationLinesForStaff", {
+        staffId: ids.newStaffId,
+      }),
+    ).toBe(1);
+  });
+});

--- a/convex/_scenario/shiftBoardConfirmation.test.ts
+++ b/convex/_scenario/shiftBoardConfirmation.test.ts
@@ -1,7 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import { MANAGER_SUBJECT, SCENARIO_NOW, scenarioDate, seedSession, seedStaff } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -14,7 +15,11 @@ describe("シフト表作成・確定シナリオ", () => {
 
   it("提出状況の混在から下書き保存、下書き後再提出、確定、スタッフ閲覧まで整合する", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const staff = scenario.staff();
+
+    // Arrange: 下書き保存前後で提出タイミングが異なるスタッフを用意する。
     const ids = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -38,7 +43,7 @@ describe("シフト表作成・確定シナリオ", () => {
       periodEnd: scenarioDate(9),
       deadline: scenarioDate(3),
     };
-    const recruitmentId = await asManager.mutation(api.recruitment.mutations.createRecruitment, recruitmentInput);
+    const recruitmentId = await asManager.createRecruitment(recruitmentInput);
     await t.run(async (ctx) => {
       await seedSession(ctx, {
         sessionToken: "scenario-before-draft-session",
@@ -54,36 +59,40 @@ describe("シフト表作成・確定シナリオ", () => {
       });
     });
 
+    // Act: 保存前スタッフが希望を提出する。
     vi.setSystemTime(SCENARIO_NOW + 1_000);
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    await staff.submitShiftRequests({
       sessionToken: "scenario-before-draft-session",
       recruitmentId,
       acceptedLegal: true,
       requests: [{ date: recruitmentInput.periodStart, startTime: "10:00", endTime: "18:00" }],
     });
 
+    // Act: 店長が提出済み希望を元に下書き保存する。
     vi.setSystemTime(SCENARIO_NOW + 2_000);
-    await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+    await asManager.saveShiftAssignments({
       recruitmentId,
       assignments: [
         { staffId: ids.beforeDraftStaffId, date: recruitmentInput.periodStart, startTime: "11:00", endTime: "17:00" },
       ],
     });
 
+    // Act: 下書き後に別スタッフが提出し、保存前スタッフも再提出する。
     vi.setSystemTime(SCENARIO_NOW + 3_000);
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    await staff.submitShiftRequests({
       sessionToken: "scenario-after-draft-session",
       recruitmentId,
       acceptedLegal: true,
       requests: [{ date: recruitmentInput.periodStart, startTime: "12:00", endTime: "20:00" }],
     });
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    await staff.submitShiftRequests({
       sessionToken: "scenario-before-draft-session",
       recruitmentId,
       requests: [{ date: recruitmentInput.periodStart, startTime: "13:00", endTime: "21:00" }],
     });
 
-    const draftBoard = await asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+    // Assert: 下書き時点の提出済み判定と最新希望がシフト表に反映される。
+    const draftBoard = await asManager.getShiftBoardData(recruitmentId);
     const staffById = new Map(draftBoard?.staffs.map((staff) => [staff._id, staff]));
     expect(staffById.get(ids.beforeDraftStaffId)).toMatchObject({ isSubmitted: true, wasSubmittedAtDraft: true });
     expect(staffById.get(ids.afterDraftStaffId)).toMatchObject({ isSubmitted: true, wasSubmittedAtDraft: false });
@@ -105,14 +114,16 @@ describe("シフト表作成・確定シナリオ", () => {
       true,
     );
 
+    // Act: 店長がシフトを確定する。
     vi.setSystemTime(SCENARIO_NOW + 4_000);
-    await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+    await asManager.confirmRecruitment(recruitmentId);
 
-    const confirmedBoard = await asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+    // Assert: 確定状態、スタッフ閲覧、確定通知データが下書き保存内容を参照する。
+    const confirmedBoard = await asManager.getShiftBoardData(recruitmentId);
     expect(confirmedBoard?.recruitment.status).toBe("confirmed");
     expect(confirmedBoard?.recruitment.confirmedAt).toBe(SCENARIO_NOW + 4_000);
 
-    const staffView = await t.query(api.shiftView.queries.getShiftViewData, {
+    const staffView = await staff.getShiftViewData({
       sessionToken: "scenario-before-draft-session",
       recruitmentId,
     });
@@ -133,7 +144,10 @@ describe("シフト表作成・確定シナリオ", () => {
 
   it("確定済み募集には未提出催促を送れない", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+
+    // Arrange: 確定済み募集を用意する。
     const recruitmentId = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -153,10 +167,7 @@ describe("シフト表作成・確定シナリオ", () => {
       });
     });
 
-    await expect(
-      asManager.mutation(api.shiftReminder.mutations.sendReminderEmails, {
-        recruitmentId,
-      }),
-    ).rejects.toThrow("募集中のシフトだけ");
+    // Act / Assert: 確定済み募集への催促操作は拒否される。
+    await expect(asManager.sendReminderEmails(recruitmentId)).rejects.toThrow("募集中のシフトだけ");
   });
 });

--- a/convex/_scenario/shiftRequestCollection.test.ts
+++ b/convex/_scenario/shiftRequestCollection.test.ts
@@ -1,8 +1,7 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import {
-  firstPage,
   MANAGER_SUBJECT,
   readScheduledFunctions,
   SCENARIO_NOW,
@@ -10,6 +9,7 @@ import {
   seedSession,
   seedStaff,
 } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -22,7 +22,11 @@ describe("シフト希望回収シナリオ", () => {
 
   it("募集作成から提出リンク、希望提出、再提出、催促対象まで整合する", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const staff = scenario.staff();
+
+    // Arrange: 募集対象のスタッフを提出済み、全休み、未提出に分けて用意する。
     const ids = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -52,25 +56,29 @@ describe("シフト希望回収シナリオ", () => {
       deadline: scenarioDate(3),
     };
 
-    const recruitmentId = await asManager.mutation(api.recruitment.mutations.createRecruitment, recruitmentInput);
+    // Act: 店長が募集を作成する。
+    const recruitmentId = await asManager.createRecruitment(recruitmentInput);
 
+    // Assert: 募集作成直後の通知予約とダッシュボード集計が整合する。
     const scheduledAfterCreate = await readScheduledFunctions(t);
     expect(
       scheduledAfterCreate.some((job) => job.name === "notification/actions:sendRecruitmentNotificationEmails"),
     ).toBe(true);
-    const initialRecruitments = await asManager.query(api.dashboard.queries.getDashboardRecruitments, firstPage());
+    const initialRecruitments = await asManager.getDashboardRecruitments();
     expect(initialRecruitments.page[0]).toMatchObject({ _id: recruitmentId, responseCount: 0, status: "open" });
 
+    // Act: 提出スタッフが通知リンクから提出フォームを開く。
     const { token } = await t.mutation(internal.notification.mutations.createMagicLink, {
       staffId: ids.submittedStaffId,
       shopId: ids.shopId,
       recruitmentId,
     });
-    const verified = await t.mutation(api.staffAuth.mutations.verifyToken, { token });
+    const verified = await staff.verifyMagicLink(token);
     expect(verified.status).toBe("ok");
     if (verified.status !== "ok") throw new Error("magic link verification failed");
 
-    const submissionPage = await t.query(api.shiftSubmission.queries.getSubmissionPageData, {
+    // Assert: 提出ページには募集作成時点の店舗情報と未提出状態が表示される。
+    const submissionPage = await staff.getSubmissionPageData({
       sessionToken: verified.sessionToken,
       recruitmentId,
     });
@@ -82,7 +90,8 @@ describe("シフト希望回収シナリオ", () => {
       timeRange: { startTime: "09:00", endTime: "22:00" },
     });
 
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    // Act: 通常提出、全休み提出、再提出を行う。
+    await staff.submitShiftRequests({
       sessionToken: verified.sessionToken,
       recruitmentId,
       acceptedLegal: true,
@@ -96,22 +105,23 @@ describe("シフト希望回収シナリオ", () => {
         recruitmentId,
       });
     });
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    await staff.submitShiftRequests({
       sessionToken: "scenario-all-off-session",
       recruitmentId,
       acceptedLegal: true,
       requests: [],
     });
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    await staff.submitShiftRequests({
       sessionToken: verified.sessionToken,
       recruitmentId,
       requests: [{ date: recruitmentInput.periodStart, startTime: "12:00", endTime: "20:00" }],
     });
 
-    const recruitmentsAfterSubmit = await asManager.query(api.dashboard.queries.getDashboardRecruitments, firstPage());
+    // Assert: 提出集計、シフト表、催促対象が提出状態を正しく反映する。
+    const recruitmentsAfterSubmit = await asManager.getDashboardRecruitments();
     expect(recruitmentsAfterSubmit.page[0].responseCount).toBe(2);
 
-    const board = await asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+    const board = await asManager.getShiftBoardData(recruitmentId);
     const staffById = new Map(board?.staffs.map((staff) => [staff._id, staff]));
     expect(staffById.get(ids.submittedStaffId)?.isSubmitted).toBe(true);
     expect(staffById.get(ids.allOffStaffId)?.isSubmitted).toBe(true);
@@ -126,7 +136,11 @@ describe("シフト希望回収シナリオ", () => {
 
   it("店舗時間変更後も、募集作成時のシフト時間スナップショットで提出できる", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+    const staff = scenario.staff();
+
+    // Arrange: 募集作成後に店舗営業時間を変更するための店舗とスタッフを用意する。
     const { shopId, staffId } = await t.run(async (ctx) => {
       const seeded = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -146,8 +160,9 @@ describe("シフト希望回収シナリオ", () => {
       deadline: scenarioDate(3),
     };
 
-    const recruitmentId = await asManager.mutation(api.recruitment.mutations.createRecruitment, recruitmentInput);
-    await asManager.mutation(api.shop.mutations.updateShopSettings, {
+    // Act: 募集作成後に店舗設定を変更し、スタッフの提出セッションを用意する。
+    const recruitmentId = await asManager.createRecruitment(recruitmentInput);
+    await asManager.updateShopSettings({
       shopName: "時間変更店舗",
       shiftStartTime: "12:00",
       shiftEndTime: "20:00",
@@ -161,19 +176,23 @@ describe("シフト希望回収シナリオ", () => {
       });
     });
 
-    const submissionPage = await t.query(api.shiftSubmission.queries.getSubmissionPageData, {
+    // Assert: 提出ページは募集作成時点のシフト時間スナップショットを使う。
+    const submissionPage = await staff.getSubmissionPageData({
       sessionToken: "scenario-snapshot-session",
       recruitmentId,
     });
     expect(submissionPage?.timeRange).toEqual({ startTime: "09:00", endTime: "22:00" });
 
-    await t.mutation(api.shiftSubmission.mutations.submitShiftRequests, {
+    // Act: 変更前スナップショットの時間帯で提出する。
+    await staff.submitShiftRequests({
       sessionToken: "scenario-snapshot-session",
       recruitmentId,
       acceptedLegal: true,
       requests: [{ date: recruitmentInput.periodStart, startTime: "10:00", endTime: "18:00" }],
     });
-    const board = await asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+
+    // Assert: シフト表も募集作成時点の時間範囲を保持する。
+    const board = await asManager.getShiftBoardData(recruitmentId);
     expect(board?.timeRange.editableStartMinutes).toBe(540);
     expect(board?.timeRange.editableEndMinutes).toBe(1320);
   });

--- a/convex/_scenario/shiftViewReissue.test.ts
+++ b/convex/_scenario/shiftViewReissue.test.ts
@@ -1,6 +1,6 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import {
   hasScheduledJob,
   MANAGER_SUBJECT,
@@ -10,6 +10,7 @@ import {
   seedSession,
   seedStaff,
 } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -22,6 +23,10 @@ describe("確定シフト閲覧・再発行シナリオ", () => {
 
   it("確定シフトは既存セッションで閲覧でき、再発行依頼は通知 job と通知データにつながる", async () => {
     const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    // Arrange: 確定済みシフトと閲覧セッションを用意する。
     const ids = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -69,14 +74,15 @@ describe("確定シフト閲覧・再発行シナリオ", () => {
       return { staffId, recruitmentId, positionId };
     });
 
-    const info = await t.query(api.staffAuth.queries.getRecruitmentInfo, { recruitmentId: ids.recruitmentId });
+    // Assert: 確定募集の基本情報とスタッフ閲覧データを取得できる。
+    const info = await staff.getRecruitmentInfo(ids.recruitmentId);
     expect(info).toMatchObject({
       shopName: "閲覧店舗",
       periodStart: scenarioDate(7),
       periodEnd: scenarioDate(9),
     });
 
-    const view = await t.query(api.shiftView.queries.getShiftViewData, {
+    const view = await staff.getShiftViewData({
       sessionToken: "scenario-shift-view-session",
       recruitmentId: ids.recruitmentId,
     });
@@ -90,10 +96,13 @@ describe("確定シフト閲覧・再発行シナリオ", () => {
       },
     ]);
 
-    await t.mutation(api.staffAuth.mutations.requestReissue, {
+    // Act: スタッフが確定シフトURLの再発行を依頼する。
+    await staff.requestReissue({
       email: "view-staff@example.com",
       recruitmentId: ids.recruitmentId,
     });
+
+    // Assert: 再発行通知jobと通知データが作られる。
     const scheduled = await readScheduledFunctions(t);
     expect(
       hasScheduledJob(scheduled, "notification/actions:sendReissueEmail", {
@@ -115,6 +124,10 @@ describe("確定シフト閲覧・再発行シナリオ", () => {
 
   it("募集中のシフトでは閲覧データも再発行通知も出さない", async () => {
     const t = convexTest(schema, modules);
+    const scenario = createScenario(t);
+    const staff = scenario.staff();
+
+    // Arrange: まだ確定していない募集中シフトとセッションを用意する。
     const ids = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -145,16 +158,21 @@ describe("確定シフト閲覧・再発行シナリオ", () => {
       return { recruitmentId };
     });
 
+    // Act / Assert: 募集中シフトは閲覧データを返さない。
     await expect(
-      t.query(api.shiftView.queries.getShiftViewData, {
+      staff.getShiftViewData({
         sessionToken: "scenario-open-view-session",
         recruitmentId: ids.recruitmentId,
       }),
     ).resolves.toBeNull();
-    await t.mutation(api.staffAuth.mutations.requestReissue, {
+
+    // Act: 募集中シフトに再発行依頼を出す。
+    await staff.requestReissue({
       email: "open-view-staff@example.com",
       recruitmentId: ids.recruitmentId,
     });
+
+    // Assert: 再発行通知jobは予約されない。
     const scheduled = await readScheduledFunctions(t);
     expect(scheduled.some((job) => job.name === "notification/actions:sendReissueEmail")).toBe(false);
   });

--- a/convex/_scenario/staffManagement.test.ts
+++ b/convex/_scenario/staffManagement.test.ts
@@ -1,8 +1,7 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { api, internal } from "../_generated/api";
+import { internal } from "../_generated/api";
 import {
-  firstPage,
   hasScheduledJob,
   MANAGER_SUBJECT,
   readScheduledFunctions,
@@ -10,6 +9,7 @@ import {
   scenarioDate,
   seedSession,
 } from "../_test/scenarioBuilders";
+import { createScenario } from "../_test/scenarioFixtures";
 import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
@@ -22,7 +22,10 @@ describe("スタッフ管理シナリオ", () => {
 
   it("募集中の店舗でスタッフ追加すると一覧・提出依頼・法務/LINE案内に反映され、削除で関連トークンを無効化する", async () => {
     const t = convexTest(schema, modules);
-    const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+    const scenario = createScenario(t);
+    const asManager = scenario.manager(MANAGER_SUBJECT);
+
+    // Arrange: 募集中のシフトがある店舗を用意する。
     const { shopId } = await t.run(async (ctx) => {
       const seeded = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
@@ -31,16 +34,17 @@ describe("スタッフ管理シナリオ", () => {
       });
       return { shopId: seeded.shopId };
     });
-    const recruitmentId = await asManager.mutation(api.recruitment.mutations.createRecruitment, {
+    const recruitmentId = await asManager.createRecruitment({
       periodStart: scenarioDate(7),
       periodEnd: scenarioDate(13),
       deadline: scenarioDate(3),
     });
 
-    const [staffId] = await asManager.mutation(api.staff.mutations.addStaffs, {
-      entries: [{ name: "追加スタッフ", email: "new-staff@example.com" }],
-    });
-    const staffPage = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+    // Act: 店長がスタッフを追加する。
+    const [staffId] = await asManager.addStaffs([{ name: "追加スタッフ", email: "new-staff@example.com" }]);
+
+    // Assert: 一覧表示と追加直後の通知予約が更新される。
+    const staffPage = await asManager.getDashboardStaffs();
     expect(staffPage.page.find((staff) => staff._id === staffId)).toMatchObject({
       name: "追加スタッフ",
       email: "new-staff@example.com",
@@ -80,8 +84,10 @@ describe("スタッフ管理シナリオ", () => {
       });
     });
 
-    await asManager.mutation(api.staff.mutations.deleteStaff, { staffId });
+    // Act: 店長がスタッフを削除する。
+    await asManager.deleteStaff(staffId);
 
+    // Assert: スタッフと関連トークン/セッション/LINE連携が無効化される。
     const stateAfterDelete = await t.run(async (ctx) => {
       const staff = await ctx.db.get(staffId);
       const session = await ctx.db
@@ -108,7 +114,7 @@ describe("スタッフ管理シナリオ", () => {
     expect(stateAfterDelete.lineLink?.revokedAt).toBeTypeOf("number");
     expect(stateAfterDelete.lineAccount).toMatchObject({ isDeleted: true, following: false });
 
-    const staffPageAfterDelete = await asManager.query(api.dashboard.queries.getDashboardStaffs, firstPage());
+    const staffPageAfterDelete = await asManager.getDashboardStaffs();
     expect(staffPageAfterDelete.page.find((staff) => staff._id === staffId)).toBeUndefined();
   });
 });

--- a/convex/_test/scenarioFixtures.ts
+++ b/convex/_test/scenarioFixtures.ts
@@ -1,0 +1,149 @@
+import { api, internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { ScenarioTest } from "./scenarioBuilders";
+
+type ManagerIdentity =
+  | string
+  | {
+      subject: string;
+      name?: string;
+      email?: string;
+    };
+
+type RecruitmentInput = {
+  periodStart: string;
+  periodEnd: string;
+  deadline: string;
+};
+
+type StaffEntry = {
+  name: string;
+  email: string;
+};
+
+type ShiftRequest = {
+  date: string;
+  startTime: string;
+  endTime: string;
+};
+
+type ShiftAssignment = ShiftRequest & {
+  staffId: Id<"staffs">;
+  positionId?: Id<"positions">;
+};
+
+type ShopSettingsInput = {
+  shopName: string;
+  shiftStartTime: string;
+  shiftEndTime: string;
+};
+
+export function createScenario(t: ScenarioTest) {
+  return {
+    manager(identity: ManagerIdentity) {
+      const asManager = t.withIdentity(typeof identity === "string" ? { subject: identity } : identity);
+
+      return {
+        setupShopAndOwner(args: ShopSettingsInput & { ownerName: string; ownerEmail: string; acceptedLegal: true }) {
+          return asManager.mutation(api.setup.mutations.setupShopAndOwner, args);
+        },
+        createRecruitment(args: RecruitmentInput) {
+          return asManager.mutation(api.recruitment.mutations.createRecruitment, args);
+        },
+        updateShopSettings(args: ShopSettingsInput) {
+          return asManager.mutation(api.shop.mutations.updateShopSettings, args);
+        },
+        addStaffs(entries: StaffEntry[]) {
+          return asManager.mutation(api.staff.mutations.addStaffs, { entries });
+        },
+        editStaff(args: { staffId: Id<"staffs">; name: string; email: string }) {
+          return asManager.mutation(api.staff.mutations.editStaff, args);
+        },
+        deleteStaff(staffId: Id<"staffs">) {
+          return asManager.mutation(api.staff.mutations.deleteStaff, { staffId });
+        },
+        saveShiftAssignments(args: { recruitmentId: Id<"recruitments">; assignments: ShiftAssignment[] }) {
+          return asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, args);
+        },
+        confirmRecruitment(recruitmentId: Id<"recruitments">) {
+          return asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+        },
+        sendReminderEmails(recruitmentId: Id<"recruitments">) {
+          return asManager.mutation(api.shiftReminder.mutations.sendReminderEmails, { recruitmentId });
+        },
+        generateLineLinkToken(staffId: Id<"staffs">) {
+          return asManager.mutation(api.line.mutations.generateLinkToken, { staffId });
+        },
+        getCurrentUser() {
+          return asManager.query(api.dashboard.queries.getCurrentUser, {});
+        },
+        getDashboardShop() {
+          return asManager.query(api.dashboard.queries.getDashboardShop, {});
+        },
+        getDashboardStaffs(paginationOpts = { numItems: 20, cursor: null as string | null }) {
+          return asManager.query(api.dashboard.queries.getDashboardStaffs, { paginationOpts });
+        },
+        getDashboardRecruitments(paginationOpts = { numItems: 20, cursor: null as string | null }) {
+          return asManager.query(api.dashboard.queries.getDashboardRecruitments, { paginationOpts });
+        },
+        getManagerConsentStatus() {
+          return asManager.query(api.legal.queries.getManagerConsentStatus, {});
+        },
+        getShiftBoardData(recruitmentId: Id<"recruitments">) {
+          return asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+        },
+      };
+    },
+    staff() {
+      return {
+        verifyMagicLink(token: string) {
+          return t.mutation(api.staffAuth.mutations.verifyToken, { token });
+        },
+        getSubmissionPageData(args: { sessionToken: string; recruitmentId: Id<"recruitments"> }) {
+          return t.query(api.shiftSubmission.queries.getSubmissionPageData, args);
+        },
+        getRecruitmentInfo(recruitmentId: Id<"recruitments">) {
+          return t.query(api.staffAuth.queries.getRecruitmentInfo, { recruitmentId });
+        },
+        submitShiftRequests(args: {
+          sessionToken: string;
+          recruitmentId: Id<"recruitments">;
+          acceptedLegal?: boolean;
+          requests: ShiftRequest[];
+        }) {
+          return t.mutation(api.shiftSubmission.mutations.submitShiftRequests, args);
+        },
+        getShiftViewData(args: { sessionToken: string; recruitmentId: Id<"recruitments"> }) {
+          return t.query(api.shiftView.queries.getShiftViewData, args);
+        },
+        requestReissue(args: { email: string; recruitmentId: Id<"recruitments"> }) {
+          return t.mutation(api.staffAuth.mutations.requestReissue, args);
+        },
+        getStaffConsentPageData(token: string) {
+          return t.query(api.legal.queries.getStaffConsentPageData, { token });
+        },
+        acceptStaffLegalConsent(args: { token: string; acceptedLegal: true }) {
+          return t.mutation(api.legal.mutations.acceptStaffLegalConsent, args);
+        },
+      };
+    },
+    line() {
+      return {
+        validateLinkToken(state: string) {
+          return t.mutation(internal.line.mutations.validateLinkToken, { state });
+        },
+        finalizeLinking(args: {
+          staffId: Id<"staffs">;
+          tokenDocId: Id<"lineLinkTokens">;
+          lineUserId: string;
+          lineFollowing: boolean;
+        }) {
+          return t.mutation(internal.line.mutations.finalizeLinking, args);
+        },
+        dispatchWebhookEvents(events: Array<{ type: "follow" | "unfollow"; userId: string }>) {
+          return t.mutation(internal.line.mutations.dispatchWebhookEvents, { events });
+        },
+      };
+    },
+  };
+}

--- a/convex/notification/queries.ts
+++ b/convex/notification/queries.ts
@@ -177,6 +177,8 @@ export const getReissueEmailData = internalQuery({
   handler: async (ctx, { staffId, recruitmentId }) => {
     const [staff, recruitment] = await Promise.all([ctx.db.get(staffId), ctx.db.get(recruitmentId)]);
     if (!staff || staff.isDeleted || !recruitment || recruitment.isDeleted) return null;
+    if (staff.shopId !== recruitment.shopId) return null;
+    if (recruitment.status !== "confirmed") return null;
 
     const shop = await ctx.db.get(recruitment.shopId);
     if (!shop || shop.isDeleted) return null;


### PR DESCRIPTION
## Summary
Convex Scenario Test の共通操作を fixture 化し、業務フローの読みやすさを保ちながらセキュリティ境界の回帰検知を厚くしました。
特に通知・再発行・確定シフト閲覧で、対象店舗/対象スタッフを越えたデータや通知が混ざらないことを検証します。

## Design

### データフロー
```mermaid
sequenceDiagram
    participant Manager as 店長
    participant Staff as スタッフ
    participant Convex as Convex Scenario Test
    participant Notification as 通知データ

    Manager->>Convex: 募集作成・下書き保存・確定
    Staff->>Convex: 提出・閲覧・再発行依頼
    Convex->>Notification: 通知対象/LINE/magic linkデータ取得
    Notification-->>Convex: 対象店舗の有効スタッフだけ返却
```

## Changes
- **Scenario fixture化**: `manager` / `staff` / `line` の操作ラッパーを追加し、既存Scenarioをユーザー操作ベースで読みやすく整理
- **セキュリティ境界Scenario追加**: 確定通知、募集開始通知、未提出催促、下書き保存、確定シフト閲覧、再発行、スタッフ削除後、LINE再連携の境界ケースを追加
- **再発行通知の防御強化**: `getReissueEmailData` で店舗不一致と未確定募集を `null` にして、内部action経由でも対象外データを返さないよう修正
- **Biome設定更新**: schema version を更新

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm test:convex`
