### PR TITLE
fix: SignupにClerk CAPTCHA描画先を追加

### DIFF
--- a/src/components/features/AuthPage/index.tsx
+++ b/src/components/features/AuthPage/index.tsx
@@ -505,6 +505,7 @@ export function SignupForm({
         <PasswordInput autoComplete="new-password" placeholder="8文字以上" {...register("password")} />
         <Field.ErrorText>{errors.password?.message}</Field.ErrorText>
       </Field.Root>
+      <ClerkCaptcha />
       <Button type="submit" colorPalette="teal" size="lg" loading={isSubmitting} loadingText="作成中">
         アカウントを作成
       </Button>
@@ -685,6 +686,11 @@ const AuthError = ({ message }: { message?: string }) => {
     </Alert.Root>
   );
 };
+
+// Clerk の Bot sign-up protection はこの ID を起点に CAPTCHA を描画する。
+const ClerkCaptcha = () => (
+  <Box id="clerk-captcha" w="full" minH="1px" data-cl-theme="light" data-cl-size="flexible" data-cl-language="ja-JP" />
+);
 
 function buildAuthHref(path: "/login" | "/signup" | "/forgot-password", redirectTo: string) {
   return `${path}?redirect=${encodeURIComponent(redirectTo)}`;


### PR DESCRIPTION
## Summary
SignupのカスタムUIにClerkのBot sign-up protection用の描画先がなく、登録開始時にinvisible CAPTCHA fallbackへ回る可能性がありました。
登録フォーム内に `#clerk-captcha` を追加し、スマホでも正規のCAPTCHA経路を使えるようにします。

## Changes
- **Signupフォーム**: ClerkがCAPTCHAを描画する `ClerkCaptcha` を追加
- **表示設定**: `data-cl-size="flexible"` と `data-cl-language="ja-JP"` を指定
- **保守性**: Clerk要件であることが分かる短いコメントを追加

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm vitest --project=logic src/components/features/AuthPage/index.test.ts`
- `pnpm vitest --project=ui src/components/features/AuthPage/index.stories.tsx`
- モバイル幅の `/signup` で `#clerk-captcha` が存在することをPlaywrightで確認