### PR TITLE
fix: cleanup-previewでpnpmをセットアップ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: Preview
     steps:
+      - uses: actions/checkout@v6
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Delete Cloudflare Pages preview
         run: |
           DEPLOYMENTS=$(curl -s \


### PR DESCRIPTION
## Summary

cleanup-preview job が Convex preview 削除スクリプトを実行する前に pnpm が存在せず失敗していたため、他の deploy job と同じ共通セットアップを追加します。

## Changes

- **checkout追加**: cleanup-preview で repository contents を取得し、scripts/deleteConvexPreviews.ts を参照できるようにしました。
- **共通Setup追加**: ./.github/actions/setup を通して Node/pnpm/依存関係を準備し、pnpm exec tsx を実行できるようにしました。

## Verification

- pnpm lint
- pnpm type-check
- git diff --check