### PR TITLE
fix: Convex preview削除対象projectを解決

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -52,7 +52,6 @@ CI/CDパイプラインの構成と運用ルール。
 |---|---|
 | `CONVEX_DEPLOY_KEY` | dev Convexプロジェクトのデプロイキー |
 | `CONVEX_MANAGEMENT_TOKEN` | PRマージ時のConvex preview削除に使うManagement APIトークン |
-| `CONVEX_PROJECT_ID` | dev ConvexプロジェクトID。SecretではなくEnvironment Variableでも可 |
 | `VITE_CONVEX_URL` | dev Convexの永続URL |
 | `VITE_CLERK_PUBLISHABLE_KEY` | Clerk開発用Publishableキー |
 | `CLERK_SECRET_KEY` | Clerk開発用シークレットキー |
@@ -91,7 +90,7 @@ CI/CDパイプラインの構成と運用ルール。
 | ジョブ | トリガー | 処理 |
 |---|---|---|
 | `deploy-preview` | PR to develop (open/sync) | Convex preview作成 → seed → ビルド → CF dev プレビューデプロイ |
-| `cleanup-preview` | PR to develop (close) | CF dev プレビュー削除。merged時のみConvex previewも削除 |
+| `cleanup-preview` | PR to develop (close) | CF dev プレビュー削除。merged時のみ `dev-yps-crispy-carnival` のConvex previewも削除 |
 | `deploy-develop` | push to develop | Convex devデプロイ → ビルド → CF dev メインデプロイ |
 
 ### リリース (`release.yml`)

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -52,7 +52,6 @@ CI/CDパイプラインの構成と運用ルール。
 |---|---|
 | `CONVEX_DEPLOY_KEY` | dev Convexプロジェクトのデプロイキー |
 | `CONVEX_MANAGEMENT_TOKEN` | PRマージ時のConvex preview削除に使うManagement APIトークン |
-| `CONVEX_PROJECT_ID` | dev ConvexプロジェクトID。SecretではなくEnvironment Variableでも可 |
 | `VITE_CONVEX_URL` | dev Convexの永続URL |
 | `VITE_CLERK_PUBLISHABLE_KEY` | Clerk開発用Publishableキー |
 | `CLERK_SECRET_KEY` | Clerk開発用シークレットキー |
@@ -91,7 +90,7 @@ CI/CDパイプラインの構成と運用ルール。
 | ジョブ | トリガー | 処理 |
 |---|---|---|
 | `deploy-preview` | PR to develop (open/sync) | Convex preview作成 → seed → ビルド → CF dev プレビューデプロイ |
-| `cleanup-preview` | PR to develop (close) | CF dev プレビュー削除。merged時のみConvex previewも削除 |
+| `cleanup-preview` | PR to develop (close) | CF dev プレビュー削除。merged時のみ `dev-yps-crispy-carnival` のConvex previewも削除 |
 | `deploy-develop` | push to develop | Convex devデプロイ → ビルド → CF dev メインデプロイ |
 
 ### リリース (`release.yml`)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,10 +100,10 @@ jobs:
         if: ${{ github.event.pull_request.merged == true }}
         run: |
           pnpm exec tsx scripts/deleteConvexPreviews.ts \
+            --project-slug dev-yps-crispy-carnival \
             --names "pr-${{ github.event.pull_request.number }}-deploy,pr-${{ github.event.pull_request.number }}-e2e"
         env:
           CONVEX_MANAGEMENT_TOKEN: ${{ secrets.CONVEX_MANAGEMENT_TOKEN }}
-          CONVEX_PROJECT_ID: ${{ vars.CONVEX_PROJECT_ID || secrets.CONVEX_PROJECT_ID }}
 
   deploy-develop:
     if: github.event_name == 'push' && github.ref == 'refs/heads/develop'

--- a/scripts/deleteConvexPreviews.test.ts
+++ b/scripts/deleteConvexPreviews.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { collectTargetPreviewMatches, getDeploymentIdentifiers, getTargetNames } from "./deleteConvexPreviews";
+
+describe("deleteConvexPreviews", () => {
+  it("matches preview deployments by previewIdentifier and reference", () => {
+    const deployments = [
+      {
+        name: "amicable-ibis-71",
+        reference: "preview/pr-426-deploy",
+        previewIdentifier: "pr-426-deploy",
+        deploymentType: "preview",
+      },
+      {
+        name: "silent-salamander-701",
+        reference: "preview/pr-426-e2e",
+        previewIdentifier: "pr-426-e2e",
+        deploymentType: "preview",
+      },
+      {
+        name: "production-like-123",
+        reference: "preview/pr-426-deploy",
+        previewIdentifier: "pr-426-deploy",
+        deploymentType: "prod",
+      },
+    ];
+
+    const result = collectTargetPreviewMatches(deployments, ["pr-426-deploy", "pr-426-e2e"]);
+
+    expect(result.missingTargetNames).toEqual([]);
+    expect(result.matchesByTarget.get("pr-426-deploy")).toEqual([deployments[0]]);
+    expect(result.matchesByTarget.get("pr-426-e2e")).toEqual([deployments[1]]);
+  });
+
+  it("reports missing target previews before deleting anything", () => {
+    const result = collectTargetPreviewMatches(
+      [
+        {
+          name: "amicable-ibis-71",
+          reference: "preview/pr-426-deploy",
+          previewIdentifier: "pr-426-deploy",
+          deploymentType: "preview",
+        },
+      ],
+      ["pr-426-deploy", "pr-426-e2e"],
+    );
+
+    expect(result.missingTargetNames).toEqual(["pr-426-e2e"]);
+  });
+
+  it("normalizes preview references to their plain identifiers", () => {
+    const identifiers = getDeploymentIdentifiers({
+      reference: "preview/pr-426-deploy",
+    });
+
+    expect([...identifiers]).toContain("pr-426-deploy");
+  });
+
+  it("rejects names outside the expected PR preview pattern", () => {
+    expect(() => getTargetNames(["production"])).toThrow(
+      "Refusing to delete unexpected Convex preview name: production",
+    );
+  });
+});

--- a/scripts/deleteConvexPreviews.ts
+++ b/scripts/deleteConvexPreviews.ts
@@ -1,15 +1,21 @@
 #!/usr/bin/env tsx
 
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 const API_BASE_URL = "https://api.convex.dev/v1";
 const TARGET_NAME_PATTERN = /^pr-\d+-(deploy|e2e)$/;
 
 type DeploymentRecord = Record<string, unknown>;
+type ProjectRecord = Record<string, unknown>;
+type TokenDetailsRecord = Record<string, unknown>;
 
 type Options = {
   dryRun: boolean;
   names: string[];
+  projectId?: string;
+  projectSlug?: string;
+  teamId?: string;
 };
 
 const isRecord = (value: unknown): value is DeploymentRecord =>
@@ -27,6 +33,22 @@ const getStringProperty = (record: DeploymentRecord, keys: string[]) => {
 
     if (typeof value === "string" && value.trim()) {
       return value.trim();
+    }
+  }
+
+  return undefined;
+};
+
+const getStringLikeProperty = (record: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = record[key];
+
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
     }
   }
 
@@ -56,7 +78,7 @@ const addIdentifierVariants = (identifiers: Set<string>, rawValue: string) => {
   }
 };
 
-const getDeploymentIdentifiers = (deployment: DeploymentRecord) => {
+export const getDeploymentIdentifiers = (deployment: DeploymentRecord) => {
   const identifiers = new Set<string>();
   const identifierKeys = [
     "previewName",
@@ -82,7 +104,7 @@ const getDeploymentIdentifiers = (deployment: DeploymentRecord) => {
   return identifiers;
 };
 
-const getDeploymentName = (deployment: DeploymentRecord) =>
+export const getDeploymentName = (deployment: DeploymentRecord) =>
   getStringProperty(deployment, ["deploymentName", "deployment_name", "slug", "name"]);
 
 const getDeploymentType = (deployment: DeploymentRecord) =>
@@ -108,6 +130,23 @@ const matchesTargetPreview = (deployment: DeploymentRecord, targetName: string) 
   }
 
   return true;
+};
+
+export const collectTargetPreviewMatches = (deployments: DeploymentRecord[], targetNames: string[]) => {
+  const matchesByTarget = new Map<string, DeploymentRecord[]>();
+  const missingTargetNames: string[] = [];
+
+  for (const targetName of targetNames) {
+    const matches = deployments.filter((deployment) => matchesTargetPreview(deployment, targetName));
+
+    if (matches.length === 0) {
+      missingTargetNames.push(targetName);
+    } else {
+      matchesByTarget.set(targetName, matches);
+    }
+  }
+
+  return { matchesByTarget, missingTargetNames };
 };
 
 const parseArgs = (args: string[]): Options => {
@@ -141,8 +180,61 @@ const parseArgs = (args: string[]): Options => {
       continue;
     }
 
+    if (arg === "--project-id") {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error("--project-id requires a value");
+      }
+
+      options.projectId = value.trim();
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith("--project-id=")) {
+      options.projectId = arg.slice("--project-id=".length).trim();
+      continue;
+    }
+
+    if (arg === "--project-slug") {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error("--project-slug requires a value");
+      }
+
+      options.projectSlug = value.trim();
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith("--project-slug=")) {
+      options.projectSlug = arg.slice("--project-slug=".length).trim();
+      continue;
+    }
+
+    if (arg === "--team-id") {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error("--team-id requires a value");
+      }
+
+      options.teamId = value.trim();
+      index++;
+      continue;
+    }
+
+    if (arg.startsWith("--team-id=")) {
+      options.teamId = arg.slice("--team-id=".length).trim();
+      continue;
+    }
+
     if (arg === "--help") {
-      console.log("Usage: tsx scripts/deleteConvexPreviews.ts --names pr-123-deploy,pr-123-e2e [--dry-run]");
+      console.log(
+        "Usage: tsx scripts/deleteConvexPreviews.ts --project-slug dev-yps-crispy-carnival --names pr-123-deploy,pr-123-e2e [--dry-run]",
+      );
       process.exit(0);
     }
 
@@ -156,7 +248,7 @@ const parseArgs = (args: string[]): Options => {
   return options;
 };
 
-const getTargetNames = (names: string[]) => {
+export const getTargetNames = (names: string[]) => {
   const targetNames = [...new Set(names)];
 
   for (const name of targetNames) {
@@ -168,7 +260,7 @@ const getTargetNames = (names: string[]) => {
   return targetNames;
 };
 
-const convexRequest = async <T>(method: "GET" | "POST", path: string, token: string) => {
+export const convexRequest = async <T>(method: "GET" | "POST", path: string, token: string) => {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method,
     headers: {
@@ -192,31 +284,101 @@ const convexRequest = async <T>(method: "GET" | "POST", path: string, token: str
   return JSON.parse(body) as T;
 };
 
-const extractDeployments = (response: unknown) => {
+const extractRecords = <T extends Record<string, unknown>>(response: unknown, keys: string[]) => {
   if (Array.isArray(response)) {
-    return response.filter(isRecord);
+    return response.filter(isRecord) as T[];
   }
 
   if (!isRecord(response)) {
     return [];
   }
 
-  for (const key of ["deployments", "data", "result"]) {
+  for (const key of keys) {
     const value = response[key];
 
     if (Array.isArray(value)) {
-      return value.filter(isRecord);
+      return value.filter(isRecord) as T[];
     }
   }
 
   return [];
 };
 
+const extractDeployments = (response: unknown) =>
+  extractRecords<DeploymentRecord>(response, ["deployments", "data", "result"]);
+
+const extractProjects = (response: unknown) => extractRecords<ProjectRecord>(response, ["projects", "data", "result"]);
+
+const getTeamIdFromToken = async (token: string) => {
+  const tokenDetails = await convexRequest<TokenDetailsRecord>("GET", "/token_details", token);
+  const teamId = getStringLikeProperty(tokenDetails, ["teamId", "team_id"]);
+
+  if (!teamId) {
+    throw new Error("CONVEX_TEAM_ID is required when CONVEX_PROJECT_SLUG is used with a token that has no teamId");
+  }
+
+  return teamId;
+};
+
+const resolveProjectId = async ({
+  token,
+  projectId,
+  projectSlug,
+  teamId,
+}: {
+  token: string;
+  projectId?: string;
+  projectSlug?: string;
+  teamId?: string;
+}) => {
+  if (!projectSlug) {
+    if (!projectId) {
+      throw new Error("CONVEX_PROJECT_ID or CONVEX_PROJECT_SLUG is required");
+    }
+
+    return { projectId, projectLabel: projectId };
+  }
+
+  const resolvedTeamId = teamId ?? (await getTeamIdFromToken(token));
+  const projectsResponse = await convexRequest<unknown>(
+    "GET",
+    `/teams/${encodeURIComponent(resolvedTeamId)}/list_projects`,
+    token,
+  );
+  const projects = extractProjects(projectsResponse);
+  const project = projects.find((candidate) => {
+    const candidateSlug = getStringLikeProperty(candidate, ["slug"]);
+    const candidateName = getStringLikeProperty(candidate, ["name"]);
+
+    return candidateSlug === projectSlug || candidateName === projectSlug;
+  });
+
+  if (!project) {
+    throw new Error(`Convex project not found for slug: ${projectSlug}`);
+  }
+
+  const resolvedProjectId = getStringLikeProperty(project, ["id", "projectId", "project_id"]);
+
+  if (!resolvedProjectId) {
+    throw new Error(`Convex project ${projectSlug} did not include a project id`);
+  }
+
+  if (projectId && projectId !== resolvedProjectId) {
+    throw new Error(
+      `CONVEX_PROJECT_ID (${projectId}) does not match CONVEX_PROJECT_SLUG ${projectSlug} (${resolvedProjectId})`,
+    );
+  }
+
+  return { projectId: resolvedProjectId, projectLabel: `${projectSlug} (${resolvedProjectId})` };
+};
+
 const main = async () => {
   const options = parseArgs(process.argv.slice(2));
   const targetNames = getTargetNames(options.names);
   const token = process.env.CONVEX_MANAGEMENT_TOKEN?.trim();
-  const projectId = process.env.CONVEX_PROJECT_ID?.trim();
+  const projectId = options.projectId ?? process.env.CONVEX_PROJECT_ID?.trim();
+  const projectSlug = options.projectSlug ?? process.env.CONVEX_PROJECT_SLUG?.trim();
+  const teamId = options.teamId ?? process.env.CONVEX_TEAM_ID?.trim();
 
   if (targetNames.length === 0) {
     throw new Error("No Convex preview names were provided");
@@ -226,26 +388,25 @@ const main = async () => {
     throw new Error("CONVEX_MANAGEMENT_TOKEN is required");
   }
 
-  if (!projectId) {
-    throw new Error("CONVEX_PROJECT_ID is required");
-  }
+  const resolvedProject = await resolveProjectId({ token, projectId, projectSlug, teamId });
+  console.log(`Looking for Convex previews in project ${resolvedProject.projectLabel}`);
 
   const deploymentsResponse = await convexRequest<unknown>(
     "GET",
-    `/projects/${encodeURIComponent(projectId)}/list_deployments`,
+    `/projects/${encodeURIComponent(resolvedProject.projectId)}/list_deployments?deploymentType=preview`,
     token,
   );
   const deployments = extractDeployments(deploymentsResponse);
   const deletedDeploymentNames = new Set<string>();
+  const { matchesByTarget, missingTargetNames } = collectTargetPreviewMatches(deployments, targetNames);
 
-  for (const targetName of targetNames) {
-    const matches = deployments.filter((deployment) => matchesTargetPreview(deployment, targetName));
+  if (missingTargetNames.length > 0) {
+    throw new Error(
+      `Convex preview not found: ${missingTargetNames.join(", ")}. Checked project ${resolvedProject.projectLabel}.`,
+    );
+  }
 
-    if (matches.length === 0) {
-      console.log(`Convex preview not found: ${targetName}`);
-      continue;
-    }
-
+  for (const [targetName, matches] of matchesByTarget) {
     for (const deployment of matches) {
       const deploymentName = getDeploymentName(deployment);
 
@@ -274,7 +435,9 @@ const main = async () => {
   }
 };
 
-main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ const logicProject = defineConfig({
     globals: true,
     name: "logic",
     setupFiles: ["./src/configs/vitest/vitest-setup.ts"],
-    include: ["./src/**/*.test.ts"],
+    include: ["./src/**/*.test.ts", "./scripts/**/*.test.ts"],
     exclude: ["node_modules"],
     env: {
       VITE_CLERK_PUBLISHABLE_KEY: process.env.VITE_CLERK_PUBLISHABLE_KEY,


### PR DESCRIPTION
## Summary

cleanup-preview が誤った `CONVEX_PROJECT_ID` を参照すると、実際には存在する Convex preview を `not found` として見逃していました。workflow では dev project slug を明示し、スクリプト側で Management API から project ID を解決することで、設定値の取り違えを避けます。

## Changes

- **project解決をslug基準に変更**: `dev-yps-crispy-carnival` を指定し、token details と project一覧から正しい project ID を解決するようにしました。
- **not foundを失敗化**: 指定された preview が見つからない場合は exit 1 にして、CIで設定ミスを検知できるようにしました。
- **テスト追加**: previewIdentifier/reference での照合、missing検知、想定外名の拒否を logic test で確認します。
- **CIドキュメント更新**: cleanup-preview が dev project の Convex preview を削除することに合わせて説明を更新しました。

## Verification

- `pnpm lint`
- `pnpm type-check`
- `pnpm vitest --project=logic scripts/deleteConvexPreviews.test.ts`
- `pnpm test:logic`
- `git diff --check`
- `--dry-run --project-slug dev-yps-crispy-carnival --names pr-426-deploy,pr-426-e2e` で `amicable-ibis-71` / `silent-salamander-701` を検出