### PR TITLE
chore: sync release version 0.0.26 to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yps-crispy-carnival",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": true,
   "packageManager": "pnpm@10.33.3",
   "type": "module",


### PR DESCRIPTION
main のリリース処理で更新された package version を develop に取り込みます。

- develop: 0.0.25
- main: 0.0.26

このPRは `package.json` の version 同期だけを対象にします。