### PR TITLE
管理ユーザー所属とローディング体験を整備

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,12 @@ pnpm scaffdog         # コンポーネントの雛形生成
 pnpm convex:dev       # Convex開発サーバー
 ```
 
+### Codex sandboxで失敗しやすいコマンド
+
+- `pnpm lint` は `tsx scripts/check-convex-timezone.ts` が IPC pipe を作るため、Codex sandbox内では `EPERM: operation not permitted ... tsx-*.pipe` で失敗することがある。Biome自体が通っている場合は、同じ `pnpm lint` を権限付きで再実行すること。
+- `pnpm e2e` / Playwright / ブラウザ起動を伴う検証は、Codex sandbox内ではブラウザ起動・IPC・ローカルサーバー接続で失敗しやすい。E2Eを実行する必要がある場合は、最初から権限付き実行を検討し、sandbox由来の失敗なら同じコマンドを権限付きで再実行すること。
+- これらはテスト・lintの失敗とは区別する。`EPERM`、ブラウザ起動不可、IPC/listen失敗など実行環境由来のエラーは、コード修正ではなく実行権限の問題として扱う。
+
 ### 単一テスト実行
 
 ```bash

--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -46,6 +46,22 @@ describe("dashboard/queries", () => {
       expect(result).toBeNull();
     });
 
+    it("削除済みmembershipでは店舗情報を返さない", async () => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        await seedManagerShop(ctx, {
+          subject: "user_deleted_membership",
+          shopName: "削除済みmembership店舗",
+          membershipDeleted: true,
+        });
+      });
+
+      const result = await t
+        .withIdentity({ subject: "user_deleted_membership" })
+        .query(api.dashboard.queries.getDashboardShop, {});
+      expect(result).toBeNull();
+    });
+
     it("返り値に不要なフィールドが含まれない", async () => {
       const t = convexTest(schema, modules);
       await t.run(async (ctx) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -54,7 +54,8 @@ const schema = defineSchema({
   })
     .index("by_shopId_and_isDeleted", ["shopId", "isDeleted"])
     .index("by_userId_and_isDeleted", ["userId", "isDeleted"])
-    .index("by_userId_and_shopId", ["userId", "shopId"]),
+    .index("by_userId_and_shopId", ["userId", "shopId"])
+    .index("by_userId_and_shopId_and_isDeleted", ["userId", "shopId", "isDeleted"]),
 
   // ========================================
   // スタッフ

--- a/convex/setup/mutations.test.ts
+++ b/convex/setup/mutations.test.ts
@@ -2,7 +2,7 @@ import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../_generated/api";
-import { seedManagerShop, seedUser, testAuthTokenIdentifier } from "../_test/seed";
+import { seedManagerShop, seedShop, seedShopMembership, seedUser, testAuthTokenIdentifier } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
 const setupArgs = {
@@ -131,6 +131,67 @@ describe("setup/mutations", () => {
       await expect(
         t.withIdentity({ subject: "user_existing" }).mutation(api.setup.mutations.setupShopAndManager, setupArgs),
       ).rejects.toThrow(ConvexError);
+    });
+
+    it("削除済みmembershipや削除済み店舗は既存店舗として扱わない", async () => {
+      const t = convexTest(schema, modules);
+
+      await t.run(async (ctx) => {
+        await seedManagerShop(ctx, {
+          subject: "user_deleted_membership",
+          email: "deleted-membership@example.com",
+          shopName: "削除済みmembership店舗",
+          membershipDeleted: true,
+        });
+        await seedManagerShop(ctx, {
+          subject: "user_deleted_shop",
+          email: "deleted-shop@example.com",
+          shopName: "削除済み店舗",
+          shopDeleted: true,
+        });
+      });
+
+      await expect(
+        t
+          .withIdentity({ subject: "user_deleted_membership" })
+          .mutation(api.setup.mutations.setupShopAndManager, setupArgs),
+      ).resolves.toBeDefined();
+      await expect(
+        t.withIdentity({ subject: "user_deleted_shop" }).mutation(api.setup.mutations.setupShopAndManager, setupArgs),
+      ).resolves.toBeDefined();
+    });
+
+    it("shopMembersはuserIdとshopIdとisDeletedでactive所属を引ける", async () => {
+      const t = convexTest(schema, modules);
+
+      const { userId, activeShopId, deletedShopId } = await t.run(async (ctx) => {
+        const userId = await seedUser(ctx, "membership_lookup", "lookup@example.com");
+        const activeShopId = await seedShop(ctx, "Active店舗");
+        const deletedShopId = await seedShop(ctx, "Deleted membership店舗");
+        await seedShopMembership(ctx, { userId, shopId: activeShopId });
+        await seedShopMembership(ctx, { userId, shopId: deletedShopId, isDeleted: true });
+        return { userId, activeShopId, deletedShopId };
+      });
+
+      const activeMembership = await t.run(async (ctx) =>
+        ctx.db
+          .query("shopMembers")
+          .withIndex("by_userId_and_shopId_and_isDeleted", (q) =>
+            q.eq("userId", userId).eq("shopId", activeShopId).eq("isDeleted", false),
+          )
+          .first(),
+      );
+      const deletedMembership = await t.run(async (ctx) =>
+        ctx.db
+          .query("shopMembers")
+          .withIndex("by_userId_and_shopId_and_isDeleted", (q) =>
+            q.eq("userId", userId).eq("shopId", deletedShopId).eq("isDeleted", false),
+          )
+          .first(),
+      );
+
+      expect(activeMembership?.shopId).toBe(activeShopId);
+      expect(deletedMembership).toBeNull();
     });
 
     it("既存ユーザーレコードがある場合は名前・メールと同意を更新する", async () => {

--- a/convex/staffRegistration/notificationQueries.test.ts
+++ b/convex/staffRegistration/notificationQueries.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
-import { seedManagerShop, seedShopMembership, seedStaffLineAccount, seedUser } from "../_test/seed";
+import { seedManagerShop, seedShop, seedShopMembership, seedStaffLineAccount, seedUser } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
 async function insertPendingRequest(
@@ -141,6 +141,43 @@ describe("staffRegistration/notificationQueries", () => {
       expect(result?.recipients.map((recipient) => recipient.email)).toEqual(["target-manager@example.com"]);
       expect(result?.recipients.map((recipient) => recipient.email)).not.toContain("staff-only@example.com");
       expect(result?.recipients.map((recipient) => recipient.email)).not.toContain("other-manager@example.com");
+    });
+
+    it("同じmanager userが複数店舗に所属していても対象店舗のmanager staffだけでLINE連携を判定する", async () => {
+      const t = convexTest(schema, modules);
+      const { shopId } = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "multi_shop_manager",
+          email: "multi-shop@example.com",
+          shopName: "対象店舗",
+        });
+        const otherShopId = await seedShop(ctx, "別店舗");
+        await seedShopMembership(ctx, { shopId: otherShopId, userId: seeded.userId });
+        const otherShopManagerStaffId = await ctx.db.insert("staffs", {
+          shopId: otherShopId,
+          userId: seeded.userId,
+          name: "別店舗の管理スタッフ",
+          email: "multi-shop@example.com",
+          emailNormalized: "multi-shop@example.com",
+          isDeleted: false,
+        });
+        await seedStaffLineAccount(ctx, {
+          shopId: otherShopId,
+          staffId: otherShopManagerStaffId,
+          lineUserId: "U_other_shop",
+          following: true,
+        });
+        await insertPendingRequest(ctx, { shopId: seeded.shopId, status: "pending" });
+        return { shopId: seeded.shopId };
+      });
+
+      const result = await t.query(internal.staffRegistration.notificationQueries.getOwnerDigestTargetForShop, {
+        shopId,
+      });
+
+      expect(result?.recipients).toEqual([expect.objectContaining({ email: "multi-shop@example.com" })]);
+      expect(result?.recipients[0]).not.toHaveProperty("lineUserId");
+      expect(result?.recipients[0]).not.toHaveProperty("lineFollowing");
     });
 
     it("承認待ちがない店舗、削除済み店舗、削除済みmanager/memberは対象外にする", async () => {

--- a/doc/INDEX.md
+++ b/doc/INDEX.md
@@ -10,6 +10,7 @@
 | [法務同意フロー](features/legal-consent.md) | 管理ユーザー/スタッフ向け利用規約・プライバシーポリシー同意を記録 | 実装済 |
 | [LINE通知連携](features/line-notification.md) | スタッフ向け通知をLINE Push / メールで自動振り分け（設定UIなし） | 実装済 |
 | [通知配送outbox](features/notification-outbox.md) | LINE / メール通知を予約し、少量ずつ配送・再試行するバックエンドキュー | 実装済 |
+| [管理ユーザーと店舗所属](features/manager-shop-membership.md) | 管理ユーザーと店舗を `shopMembers` で結ぶ所属モデル。複数店舗対応のDB土台 | 準備中 |
 | [スタッフ参加QR・承認導線](features/staff-registration.md) | 店舗専用QR/URLからスタッフ本人が参加申請し、シフト担当者が承認する導線 | 実装済 |
 | [店舗設定](features/shop-settings.md) | 店舗名、シフト時間帯、定休日などシフト作成の前提になる店舗情報を管理 | 実装済 |
 | [ログイン後オンボーディング](features/dashboard-onboarding.md) | 店舗登録後にシフト担当者自身で募集作成・通知確認・提出確認を試すDashboard内Callout | 実装済 |

--- a/doc/features/manager-shop-membership.md
+++ b/doc/features/manager-shop-membership.md
@@ -1,0 +1,32 @@
+# 管理ユーザーと店舗所属
+
+管理ユーザーと店舗の所属は `shopMembers` で管理する。将来の複数店舗対応に備え、`users` に店舗IDを直接持たせず、店舗ごとの権限・通知対象・操作対象は `shopMembers` と各ドメインデータの `shopId` で判定する。
+
+## 関連ファイル
+
+- `convex/schema.ts` — `users` / `shops` / `shopMembers` と所属検索index
+- `convex/_lib/functions.ts` — manager向けAPIの認証と現在店舗解決
+- `convex/dashboard/queries.ts` — dashboard表示用の現在店舗解決
+- `convex/setup/mutations.ts` — 初回店舗登録とmanager所属作成
+- `convex/staffRegistration/notificationQueries.ts` — 店舗のmanager usersを通知対象として取得
+
+## 画面一覧
+
+| 画面 | 役割 |
+|---|---|
+| ダッシュボード | 現在はログインmanagerの最初のactive所属店舗を表示する |
+
+## API一覧
+
+| API | 種別 | 用途 |
+|---|---|---|
+| `api.setup.mutations.setupShopAndManager` | mutation | 初回店舗とmanager所属を作成する。現時点ではactive所属があるmanagerの2店舗目作成は許可しない |
+| `api.dashboard.queries.getDashboardShop` | query | 現在店舗の基本情報を取得する |
+| `api.dashboard.queries.getDashboardRecruitments` | query | 現在店舗の募集一覧を取得する |
+| `api.dashboard.queries.getDashboardStaffs` | query | 現在店舗のスタッフ一覧を取得する |
+
+## 補足
+
+- 複数店舗切替UI、2店舗目作成、店舗招待は未実装。
+- 将来のmanager APIは、選択中 `shopId` を受け取り、`shopMembers.by_userId_and_shopId_and_isDeleted` でactive所属を確認してから各データの `shopId` と突合する。
+- managerの法務同意はuser単位で判定する。`legalConsentStates.shopId` は同意した店舗文脈の履歴として扱う。

--- a/src/components/features/Dashboard/DashboardContent/index.stories.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.stories.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 import { DASHBOARD_TOUR_TARGET } from "../dashboardTourTargets";
 import { mockRecruitments, mockStaffs } from "../storyMocks";
 import type { Recruitment, Staff, StaffRegistrationRequest } from "../types";
-import { DashboardContent } from "./index";
+import { DashboardContent, DashboardContentSkeleton } from "./index";
 
 const noop = () => {};
 
@@ -130,6 +130,17 @@ export const LegalReconsentRequired: Story = {
       },
     },
   },
+};
+
+export const Loading: Story = {
+  args: {
+    ...Normal.args,
+  },
+  render: () => (
+    <Box minH="100vh" bg="white" p={{ base: 4, lg: 8 }}>
+      <DashboardContentSkeleton />
+    </Box>
+  ),
 };
 
 export const Empty: Story = {

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -20,14 +20,14 @@ import type { EditShopFormData } from "../EditShopForm/index";
 import { EditShopForm } from "../EditShopForm/index.tsx";
 import type { EditStaffFormData } from "../EditStaffForm/index";
 import { EditStaffForm } from "../EditStaffForm/index.tsx";
-import { HeroSummary, WelcomeHero } from "../HeroSummary";
+import { HeroSummary, HeroSummarySkeleton, WelcomeHero } from "../HeroSummary";
 import { LegalReconsentBanner } from "../LegalReconsentBanner";
-import { RecruitmentBoard } from "../RecruitmentBoard";
+import { RecruitmentBoard, RecruitmentBoardSkeleton } from "../RecruitmentBoard";
 import type { SetupData } from "../SetupModal";
 import { SetupModal } from "../SetupModal";
 import { StaffRegistrationLinkPanel } from "../StaffRegistrationLinkPanel";
 import { StaffRegistrationRequestBanner, StaffRegistrationRequestDialog } from "../StaffRegistrationRequests";
-import { StaffRoster } from "../StaffRoster";
+import { StaffRoster, StaffRosterSkeleton } from "../StaffRoster";
 import type { PaginationStatus, Recruitment, Staff, StaffRegistrationRequest } from "../types";
 import { OnboardingCallout } from "./OnboardingCallout";
 import {
@@ -635,6 +635,14 @@ export const DashboardContent = ({
     </>
   );
 };
+
+export const DashboardContentSkeleton = () => (
+  <ContentWrapper>
+    <HeroSummarySkeleton />
+    <RecruitmentBoardSkeleton />
+    <StaffRosterSkeleton />
+  </ContentWrapper>
+);
 
 function readReviewedRecruitmentIds(): string[] {
   if (typeof window === "undefined") return [];

--- a/src/components/features/Dashboard/HeroSummary/index.stories.tsx
+++ b/src/components/features/Dashboard/HeroSummary/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import dayjs from "dayjs";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { Recruitment } from "@/src/components/features/Dashboard/types";
-import { HeroSummary, WelcomeHero } from ".";
+import { HeroSummary, HeroSummarySkeleton, WelcomeHero } from ".";
 
 const meta = {
   title: "Features/Dashboard/HeroSummary",
@@ -77,6 +77,9 @@ export const Variants: Story = {
       </Section>
       <Section label="初回ログイン時">
         <WelcomeHero onSetupClick={() => {}} />
+      </Section>
+      <Section label="読み込み中">
+        <HeroSummarySkeleton />
       </Section>
     </Stack>
   ),

--- a/src/components/features/Dashboard/HeroSummary/index.tsx
+++ b/src/components/features/Dashboard/HeroSummary/index.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Flex, Heading, HStack, Image, Stack, Text } from "@chakra-ui/react";
+import { Badge, Box, Flex, Heading, HStack, Image, Skeleton, Stack, Text } from "@chakra-ui/react";
 import type { ComponentProps, ReactNode } from "react";
 import type { IconType } from "react-icons";
 import {
@@ -90,6 +90,53 @@ export const HeroSummary = ({
     </Stack>
   );
 };
+
+export const HeroSummarySkeleton = () => (
+  <Stack gap={{ base: 5, lg: 6 }} aria-label="ダッシュボード概要を読み込み中">
+    <Stack gap={3} pb={{ base: 4, lg: 6 }} borderBottomWidth="1px" borderColor="gray.200">
+      <Skeleton display={{ base: "none", md: "block" }} h="18px" w="40px" />
+
+      <Flex align="center" justify="space-between" direction="row" gap={4} minW={0}>
+        <Skeleton h={{ base: "28px", md: "40px" }} w={{ base: "160px", md: "240px" }} maxW="60%" />
+        <Skeleton h="32px" w="48px" flexShrink={0} />
+      </Flex>
+    </Stack>
+
+    <Stack gap={{ base: 3, lg: 4 }}>
+      <HStack gap={2.5} align="center">
+        <Skeleton boxSize={{ base: "24px", lg: "28px" }} borderRadius="full" />
+        <Skeleton h={{ base: "26px", lg: "30px" }} w="112px" />
+      </HStack>
+
+      <Flex
+        bg="teal.50/30"
+        borderRadius="xl"
+        borderWidth="1px"
+        borderColor="teal.100"
+        boxShadow="xs"
+        px={{ base: 4, md: 6, lg: 7 }}
+        py={{ base: 5, lg: 6 }}
+        gap={{ base: 4, md: 6 }}
+        align={{ base: "stretch", md: "center" }}
+        direction={{ base: "column", md: "row" }}
+        minH={{ base: "154px", md: "130px" }}
+      >
+        <HStack gap={{ base: 3, md: 5 }} flex={1} minW={0}>
+          <Skeleton boxSize={{ base: "48px", md: "80px" }} borderRadius="full" flexShrink={0} />
+          <Stack gap={3} minW={0} flex={1}>
+            <Skeleton h={{ base: "24px", md: "32px" }} w={{ base: "220px", md: "320px" }} maxW="100%" />
+            <HStack gap={2} wrap="wrap">
+              <Skeleton h="26px" w="112px" borderRadius="full" />
+              <Skeleton h="26px" w="92px" borderRadius="full" />
+              <Skeleton h="26px" w="128px" borderRadius="full" />
+            </HStack>
+          </Stack>
+        </HStack>
+        <Skeleton h={{ base: "36px", md: "40px" }} w={{ base: "100%", md: "132px" }} flexShrink={0} />
+      </Flex>
+    </Stack>
+  </Stack>
+);
 
 type WelcomeHeroProps = {
   onSetupClick: () => void;

--- a/src/components/features/Dashboard/RecruitmentBoard/index.stories.tsx
+++ b/src/components/features/Dashboard/RecruitmentBoard/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { mockRecruitments } from "@/src/components/features/Dashboard/storyMocks";
-import { RecruitmentBoard } from ".";
+import { RecruitmentBoard, RecruitmentBoardSkeleton } from ".";
 
 const meta = {
   title: "Features/Dashboard/RecruitmentBoard",
@@ -67,6 +67,12 @@ export const Variants: Story = {
           onDeleteRecruitment={() => {}}
           onLoadMore={() => {}}
         />
+      </Stack>
+      <Stack gap={3}>
+        <Text fontSize="xs" fontWeight="semibold" color="fg.muted" letterSpacing="0.08em" textTransform="uppercase">
+          読み込み中
+        </Text>
+        <RecruitmentBoardSkeleton />
       </Stack>
     </Stack>
   ),

--- a/src/components/features/Dashboard/RecruitmentBoard/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentBoard/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, HStack, Stack } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Skeleton, Stack } from "@chakra-ui/react";
 import type { PaginationStatus } from "convex/browser";
 import { LuCalendarDays, LuChevronDown, LuInbox, LuPlus } from "react-icons/lu";
 import type { Recruitment } from "@/src/components/features/Dashboard/types";
@@ -109,3 +109,56 @@ export const RecruitmentBoard = ({
     </Stack>
   );
 };
+
+export const RecruitmentBoardSkeleton = () => (
+  <Stack as="section" aria-label="シフト募集を読み込み中" gap={{ base: 4, lg: 5 }}>
+    <Flex justify="space-between" align="flex-end" gap={3} wrap="wrap">
+      <HStack gap={2.5} align="center">
+        <Skeleton boxSize={{ base: "24px", lg: "28px" }} borderRadius="full" />
+        <Skeleton h={{ base: "28px", lg: "30px" }} w="112px" />
+      </HStack>
+      <Skeleton h="32px" w={{ base: "148px", md: "164px" }} />
+    </Flex>
+
+    <Stack gap={{ base: 3, lg: 3.5 }}>
+      {Array.from({ length: 3 }).map((_, index) => (
+        <RecruitmentRowSkeleton key={index} />
+      ))}
+    </Stack>
+  </Stack>
+);
+
+const RecruitmentRowSkeleton = () => (
+  <Flex
+    align="stretch"
+    bg="white"
+    borderRadius="xl"
+    overflow="hidden"
+    borderWidth="1px"
+    borderColor="blackAlpha.50"
+    boxShadow="xs"
+    w="full"
+    minH={{ base: "88px", lg: "66px" }}
+  >
+    <Box w="4px" bg="teal.100" flexShrink={0} />
+    <Flex flex={1} minW={0} px={{ base: 3.5, lg: 4 }} py={3} align="stretch" gap={{ base: 2, lg: 3 }}>
+      <Flex
+        flex={1}
+        minW={0}
+        direction={{ base: "column", lg: "row" }}
+        align={{ base: "stretch", lg: "center" }}
+        gap={{ base: 2, lg: 4 }}
+      >
+        <Skeleton h="22px" w={{ base: "152px", lg: "140px" }} flexShrink={0} />
+        <HStack gap={{ base: 2, lg: 5 }} flex={1} minW={0} wrap={{ base: "wrap", lg: "nowrap" }}>
+          <Skeleton h="24px" w="72px" borderRadius="full" flexShrink={0} />
+          <Skeleton h="18px" w="120px" flexShrink={0} />
+          <Skeleton h="18px" w="80px" flexShrink={0} />
+        </HStack>
+      </Flex>
+    </Flex>
+    <Flex align="center" justify="center" pe={{ base: 2, lg: 3 }} flexShrink={0}>
+      <Skeleton boxSize="32px" borderRadius="md" />
+    </Flex>
+  </Flex>
+);

--- a/src/components/features/Dashboard/StaffRegistrationLinkPanel/index.tsx
+++ b/src/components/features/Dashboard/StaffRegistrationLinkPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Code, Flex, HStack, Separator, Spinner, Stack, Text } from "@chakra-ui/react";
+import { Box, Code, Flex, HStack, Separator, Skeleton, Stack, Text } from "@chakra-ui/react";
 import QRCode from "qrcode";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
@@ -60,14 +60,7 @@ export function StaffRegistrationLinkPanel({ registrationUrl, isLoading, manualE
   };
 
   if (isLoading || !registrationUrl) {
-    return (
-      <Stack align="center" py={10} gap={3}>
-        <Spinner color="teal.500" />
-        <Text fontSize="sm" color="fg.muted">
-          登録用リンクを準備しています
-        </Text>
-      </Stack>
-    );
+    return <StaffRegistrationLinkPanelSkeleton showManualEntryAction={Boolean(manualEntryAction)} />;
   }
 
   return (
@@ -97,7 +90,7 @@ export function StaffRegistrationLinkPanel({ registrationUrl, isLoading, manualE
               bg="white"
             />
           ) : (
-            <Spinner color="teal.500" />
+            <QrSkeleton />
           )}
           <Text fontSize="xs" color="fg.muted">
             スタッフに読み取ってもらってください
@@ -168,3 +161,44 @@ export function StaffRegistrationLinkPanel({ registrationUrl, isLoading, manualE
     </Stack>
   );
 }
+
+const QrSkeleton = () => (
+  <Box width="200px" height="200px" borderRadius="md" borderWidth="1px" borderColor="blackAlpha.100" bg="white">
+    <Skeleton width="full" height="full" borderRadius="md" />
+  </Box>
+);
+
+const StaffRegistrationLinkPanelSkeleton = ({ showManualEntryAction }: { showManualEntryAction: boolean }) => (
+  <Stack gap={5} aria-busy="true">
+    <Stack gap={2}>
+      <Skeleton h="16px" w="94%" />
+      <Skeleton h="16px" w="74%" />
+      <Skeleton h="16px" w="86%" />
+    </Stack>
+
+    <InviteSection title="QRコードで招待">
+      <Stack align="center" gap={2}>
+        <QrSkeleton />
+        <Skeleton h="14px" w="172px" />
+      </Stack>
+    </InviteSection>
+
+    <InviteSection title="招待リンクを共有">
+      <HStack gap={0} align="stretch" minW={0} borderWidth="1px" borderColor="border.default" borderRadius="md">
+        <Skeleton h="40px" flex={1} borderRadius={0} />
+        <Skeleton boxSize="40px" borderRadius={0} />
+      </HStack>
+    </InviteSection>
+
+    {showManualEntryAction && (
+      <>
+        <Separator />
+        <Stack gap={3}>
+          <Skeleton h="16px" w="128px" />
+          <Skeleton h="16px" w="88%" />
+          <Skeleton h="36px" w="144px" borderRadius="md" />
+        </Stack>
+      </>
+    )}
+  </Stack>
+);

--- a/src/components/features/Dashboard/StaffRoster/index.stories.tsx
+++ b/src/components/features/Dashboard/StaffRoster/index.stories.tsx
@@ -1,7 +1,7 @@
 import { Stack, Text } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { mockStaffs, mockStaffsMany } from "@/src/components/features/Dashboard/storyMocks";
-import { StaffRoster } from ".";
+import { StaffRoster, StaffRosterSkeleton } from ".";
 
 const noop = () => {};
 
@@ -77,6 +77,12 @@ export const Variants: Story = {
           onSendLineInvite={noop}
           onLoadMore={noop}
         />
+      </Stack>
+      <Stack gap={3}>
+        <Text fontSize="xs" fontWeight="semibold" color="fg.muted" letterSpacing="0.08em" textTransform="uppercase">
+          読み込み中
+        </Text>
+        <StaffRosterSkeleton />
       </Stack>
     </Stack>
   ),

--- a/src/components/features/Dashboard/StaffRoster/index.tsx
+++ b/src/components/features/Dashboard/StaffRoster/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, HStack, Stack } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Skeleton, Stack } from "@chakra-ui/react";
 import type { PaginationStatus } from "convex/browser";
 import { LuChevronDown, LuPlus, LuUsers } from "react-icons/lu";
 import type { Staff } from "@/src/components/features/Dashboard/types";
@@ -118,3 +118,45 @@ export const StaffRoster = ({
     </Stack>
   );
 };
+
+export const StaffRosterSkeleton = () => (
+  <Stack as="section" aria-label="スタッフ一覧を読み込み中" gap={{ base: 4, lg: 5 }}>
+    <Flex justify="space-between" align="flex-end" gap={3} wrap="wrap">
+      <HStack gap={2.5} align="center">
+        <Skeleton boxSize={{ base: "24px", lg: "28px" }} borderRadius="full" />
+        <Skeleton h={{ base: "28px", lg: "30px" }} w="112px" />
+      </HStack>
+      <Skeleton h="32px" w={{ base: "120px", md: "132px" }} />
+    </Flex>
+
+    <Box bg="white" borderRadius="xl" borderWidth="1px" borderColor="blackAlpha.50" boxShadow="xs" overflow="hidden">
+      <Stack gap={0} divideY="1px" divideColor="blackAlpha.50">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <StaffRowSkeleton key={index} isManager={index === 0} />
+        ))}
+      </Stack>
+    </Box>
+  </Stack>
+);
+
+const StaffRowSkeleton = ({ isManager }: { isManager: boolean }) => (
+  <HStack
+    as="article"
+    gap={3}
+    px={{ base: 3, lg: 4 }}
+    py={3.5}
+    align="center"
+    bg={isManager ? "teal.50/50" : "transparent"}
+    minH="68px"
+  >
+    <Skeleton boxSize="40px" borderRadius="full" flexShrink={0} />
+    <Stack gap={2} flex={1} minW={0}>
+      <HStack gap={2} align="center" wrap="wrap">
+        <Skeleton h="20px" w={{ base: "96px", lg: "112px" }} />
+        {isManager && <Skeleton h="20px" w="52px" borderRadius="full" />}
+      </HStack>
+      <Skeleton h="16px" w="180px" display={{ base: "none", lg: "block" }} />
+    </Stack>
+    <Skeleton boxSize="32px" borderRadius="md" flexShrink={0} />
+  </HStack>
+);

--- a/src/components/features/Line/LineLinkQrDialog/index.tsx
+++ b/src/components/features/Line/LineLinkQrDialog/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Code, HStack, Spinner, Stack, Text } from "@chakra-ui/react";
+import { Box, Code, HStack, Skeleton, Stack, Text } from "@chakra-ui/react";
 import QRCode from "qrcode";
 import { useEffect, useState } from "react";
 import { LuCheck, LuCopy } from "react-icons/lu";
@@ -47,14 +47,7 @@ export const LineLinkQrDialog = ({ authorizeUrl, isLoading, staffName }: Props) 
   };
 
   if (isLoading || !authorizeUrl) {
-    return (
-      <Stack align="center" py={10} gap={3}>
-        <Spinner color="teal.500" />
-        <Text fontSize="sm" color="fg.muted">
-          連携用リンクを発行しています
-        </Text>
-      </Stack>
-    );
+    return <LineLinkQrDialogSkeleton />;
   }
 
   return (
@@ -75,7 +68,7 @@ export const LineLinkQrDialog = ({ authorizeUrl, isLoading, staffName }: Props) 
             bg="white"
           />
         ) : (
-          <Spinner color="teal.500" />
+          <QrSkeleton />
         )}
         <Text fontSize="xs" color="fg.muted">
           スマホのカメラで読み取ってください
@@ -101,3 +94,24 @@ export const LineLinkQrDialog = ({ authorizeUrl, isLoading, staffName }: Props) 
     </Stack>
   );
 };
+
+const QrSkeleton = () => (
+  <Box width="200px" height="200px" borderRadius="md" borderWidth="1px" borderColor="blackAlpha.100" bg="white">
+    <Skeleton width="full" height="full" borderRadius="md" />
+  </Box>
+);
+
+const LineLinkQrDialogSkeleton = () => (
+  <Stack gap={4} aria-busy="true">
+    <Stack gap={2}>
+      <Skeleton h="16px" w="92%" />
+      <Skeleton h="16px" w="64%" />
+    </Stack>
+    <Stack align="center" gap={3}>
+      <QrSkeleton />
+      <Skeleton h="14px" w="152px" />
+    </Stack>
+    <Skeleton h="56px" w="full" borderRadius="md" />
+    <Skeleton h="32px" w="120px" borderRadius="md" />
+  </Stack>
+);

--- a/src/components/ui/FullPageSpinner/index.tsx
+++ b/src/components/ui/FullPageSpinner/index.tsx
@@ -1,9 +1,5 @@
-import { Flex, Spinner } from "@chakra-ui/react";
+import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
 
 export function FullPageSpinner() {
-  return (
-    <Flex justify="center" align="center" minH="100vh">
-      <Spinner />
-    </Flex>
-  );
+  return <ShiftoriLoading variant="page" />;
 }

--- a/src/components/ui/LoadingState/index.tsx
+++ b/src/components/ui/LoadingState/index.tsx
@@ -1,17 +1,11 @@
-import { Box, Spinner, Text, VStack } from "@chakra-ui/react";
+import type { BoxProps } from "@chakra-ui/react";
+import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
 
 type Props = {
   message?: string;
-  minH?: string;
+  minH?: BoxProps["minH"];
 };
 
-export const LoadingState = ({ message = "読み込んでいます", minH = "400px" }: Props) => {
-  return (
-    <Box display="flex" justifyContent="center" alignItems="center" minH={minH}>
-      <VStack gap="4">
-        <Spinner size="xl" color="teal.500" />
-        <Text color="fg.muted">{message}</Text>
-      </VStack>
-    </Box>
-  );
-};
+export const LoadingState = ({ message = "Loading...", minH = "400px" }: Props) => (
+  <ShiftoriLoading variant="section" message={message} minH={minH} />
+);

--- a/src/components/ui/ShiftoriLoading/index.stories.tsx
+++ b/src/components/ui/ShiftoriLoading/index.stories.tsx
@@ -1,0 +1,56 @@
+import { Box, SimpleGrid, Stack, Text } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ShiftoriLoading } from ".";
+
+const meta = {
+  title: "UI/ShiftoriLoading",
+  component: ShiftoriLoading,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof ShiftoriLoading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  render: () => (
+    <Stack gap={6}>
+      <Text fontSize="sm" fontWeight="bold">
+        Variants
+      </Text>
+      <SimpleGrid columns={{ base: 1, lg: 3 }} gap={4}>
+        <Surface label="page">
+          <ShiftoriLoading variant="page" minH="280px" animated={false} />
+        </Surface>
+        <Surface label="section">
+          <ShiftoriLoading variant="section" minH="220px" animated={false} />
+        </Surface>
+        <Surface label="compact">
+          <ShiftoriLoading variant="compact" animated={false} />
+        </Surface>
+      </SimpleGrid>
+    </Stack>
+  ),
+};
+
+export const Animated: Story = {
+  args: {
+    variant: "page",
+    minH: "360px",
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+const Surface = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <Box bg="white" borderWidth="1px" borderColor="border.muted" borderRadius="lg" p={4}>
+    <Stack gap={3}>
+      <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
+        {label}
+      </Text>
+      {children}
+    </Stack>
+  </Box>
+);

--- a/src/components/ui/ShiftoriLoading/index.tsx
+++ b/src/components/ui/ShiftoriLoading/index.tsx
@@ -1,0 +1,79 @@
+import { Box, type BoxProps, Image, type ImageProps, Stack, Text } from "@chakra-ui/react";
+import type { ReactNode } from "react";
+
+type ShiftoriLoadingVariant = "page" | "section" | "compact";
+
+type Props = Omit<BoxProps, "children"> & {
+  variant?: ShiftoriLoadingVariant;
+  message?: ReactNode;
+  minH?: BoxProps["minH"];
+  logoSize?: ImageProps["boxSize"];
+  animated?: boolean;
+};
+
+const VARIANT_STYLES: Record<
+  ShiftoriLoadingVariant,
+  {
+    minH: BoxProps["minH"];
+    logoSize: ImageProps["boxSize"];
+    gap: BoxProps["gap"];
+    fontSize: BoxProps["fontSize"];
+  }
+> = {
+  page: {
+    minH: "100vh",
+    logoSize: { base: "64px", md: "80px" },
+    gap: 4,
+    fontSize: "md",
+  },
+  section: {
+    minH: "400px",
+    logoSize: "64px",
+    gap: 3,
+    fontSize: "sm",
+  },
+  compact: {
+    minH: "160px",
+    logoSize: "44px",
+    gap: 2,
+    fontSize: "sm",
+  },
+};
+
+export const ShiftoriLoading = ({
+  variant = "section",
+  message = "Loading...",
+  minH,
+  logoSize,
+  animated = true,
+  ...props
+}: Props) => {
+  const styles = VARIANT_STYLES[variant];
+
+  return (
+    <Box
+      role="status"
+      aria-live="polite"
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      minH={minH ?? styles.minH}
+      w="full"
+      {...props}
+    >
+      <Stack align="center" textAlign="center" gap={styles.gap}>
+        <Image
+          src="/logo192.webp"
+          alt="シフトリ"
+          boxSize={logoSize ?? styles.logoSize}
+          objectFit="contain"
+          animation={animated ? "pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite" : undefined}
+          _motionReduce={{ animation: "none" }}
+        />
+        <Text fontSize={styles.fontSize} fontWeight="semibold" color="fg.muted" letterSpacing="0">
+          {message}
+        </Text>
+      </Stack>
+    </Box>
+  );
+};

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,8 +1,8 @@
-import { Box, Flex, Spinner } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import { usePaginatedQuery, useQuery } from "convex/react";
 import { type ReactNode, useState } from "react";
 import { api } from "@/convex/_generated/api";
-import { DashboardContent } from "@/src/components/features/Dashboard/DashboardContent";
+import { DashboardContent, DashboardContentSkeleton } from "@/src/components/features/Dashboard/DashboardContent";
 import { Animation } from "@/src/components/templates/Animation";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { RootContentWrapper } from "@/src/components/templates/RootContentWrapper";
@@ -58,12 +58,21 @@ export function DashboardPage() {
     }
   };
 
-  if (shop === undefined) {
+  const isDashboardInitialLoading =
+    shop === undefined ||
+    (shop !== null &&
+      (currentUser === undefined ||
+        managerLegalConsentStatus === undefined ||
+        pendingStaffRequests === undefined ||
+        recruitments.status === "LoadingFirstPage" ||
+        staffs.status === "LoadingFirstPage"));
+
+  if (isDashboardInitialLoading) {
     return (
       <DashboardPageShell>
-        <Flex justify="center" align="center" minH="200px">
-          <Spinner />
-        </Flex>
+        <Animation>
+          <DashboardContentSkeleton />
+        </Animation>
       </DashboardPageShell>
     );
   }

--- a/src/pages/shift-board/index.tsx
+++ b/src/pages/shift-board/index.tsx
@@ -1,9 +1,9 @@
-import { Flex, Spinner } from "@chakra-ui/react";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { ShiftBoardPage } from "@/src/components/features/ShiftBoard/ShiftBoardPage";
 import { Animation } from "@/src/components/templates/Animation";
+import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
 
 type Props = {
   recruitmentId: string;
@@ -15,11 +15,7 @@ export function ShiftBoardRoutePage({ recruitmentId }: Props) {
   });
 
   if (data === undefined) {
-    return (
-      <Flex justify="center" align="center" minH="200px">
-        <Spinner />
-      </Flex>
-    );
+    return <ShiftoriLoading variant="section" minH="200px" />;
   }
 
   if (data === null) return null;


### PR DESCRIPTION
## Summary
将来の管理ユーザー複数店舗対応に向けて、`shopMembers` の active 所属参照と関連テスト・機能ドキュメントを整えます。
あわせて Dashboard 初期ロードやQR生成待ちを Spinner から画面構造を保つ Skeleton / シフトリロゴの共通ローディングへ置き換え、待ち時間の見え方を改善します。

## Design

### コンポーネント構成
```mermaid
graph TD
    DashboardPage[DashboardPage] --> DashboardContentSkeleton[DashboardContentSkeleton]
    DashboardContentSkeleton --> HeroSummarySkeleton[HeroSummarySkeleton]
    DashboardContentSkeleton --> RecruitmentBoardSkeleton[RecruitmentBoardSkeleton]
    DashboardContentSkeleton --> StaffRosterSkeleton[StaffRosterSkeleton]
    LoadingState[LoadingState] --> ShiftoriLoading[ShiftoriLoading]
    FullPageSpinner[FullPageSpinner] --> ShiftoriLoading
    ShiftBoardRoutePage[ShiftBoardRoutePage] --> ShiftoriLoading
    StaffRegistrationLinkPanel[StaffRegistrationLinkPanel] --> QrSkeleton[QR Skeleton]
    LineLinkQrDialog[LineLinkQrDialog] --> QrSkeleton
```

### 所属データの参照
```mermaid
graph TD
    ManagerUser[manager user] --> ShopMembers[shopMembers]
    ShopMembers --> Shops[shops]
    ShopMembers --> ActiveLookup[by_userId_and_shopId_and_isDeleted]
    ActiveLookup --> ManagerApis[manager向けAPI / 通知対象判定]
```

## Changes
- **管理ユーザー所属の土台を補強**: `shopMembers.by_userId_and_shopId_and_isDeleted` を追加し、削除済みmembershipや削除済み店舗を active 店舗として扱わないことをテストで保証。
- **通知対象判定の複数店舗ケースを追加**: 同じmanager userが複数店舗に所属していても、対象店舗側のmanager staffだけでLINE連携状態を判定するテストを追加。
- **Dashboard初期ロードをSkeleton化**: `DashboardContentSkeleton` / `HeroSummarySkeleton` / `RecruitmentBoardSkeleton` / `StaffRosterSkeleton` を追加し、初期ロード中も実画面に近い構造を表示。
- **ローディング表現を統一**: `ShiftoriLoading` を追加し、`FullPageSpinner` / `LoadingState` / ShiftBoardロード表示をシフトリらしいロゴ表示へ統一。
- **QR生成待ちの見え方を改善**: スタッフ登録リンクとLINE連携QRの待機中表示をSkeletonに変更。
- **ドキュメントを更新**: 管理ユーザーと店舗所属の機能概要を追加し、Codex sandbox由来のlint/e2e失敗パターンをAGENTSに追記。

## Verification
- `pnpm lint`
- `pnpm type-check`
- `pnpm test:convex`
