### PR TITLE
ローディング表示の体験を調整

### DIFF
--- a/src/components/features/auths/AuthGuard.tsx
+++ b/src/components/features/auths/AuthGuard.tsx
@@ -33,7 +33,7 @@ export const AuthGuard = ({ children }: Props) => {
   }
 
   if (!isLoaded) {
-    return <FullPageSpinner />;
+    return <FullPageSpinner showHeader />;
   }
 
   if (!isSignedIn) {
@@ -43,7 +43,7 @@ export const AuthGuard = ({ children }: Props) => {
   }
 
   if (currentUser === undefined) {
-    return <FullPageSpinner />;
+    return <FullPageSpinner showHeader />;
   }
 
   return children;

--- a/src/components/templates/Header/index.stories.tsx
+++ b/src/components/templates/Header/index.stories.tsx
@@ -31,6 +31,12 @@ export const User: Story = {
   args: {},
 };
 
+export const UserWithoutMenu: Story = {
+  args: {
+    showUserMenu: false,
+  },
+};
+
 export const Public: Story = {
   args: {
     variant: "public",

--- a/src/components/templates/Header/index.tsx
+++ b/src/components/templates/Header/index.tsx
@@ -27,6 +27,7 @@ type PublicHeaderVariantProps = {
 
 type UserHeaderVariantProps = {
   variant?: "user";
+  showUserMenu?: boolean;
 };
 
 type StaffHeaderVariantProps = {
@@ -65,7 +66,7 @@ export const Header = (props: HeaderProps = {}) => {
   return (
     <HeaderShell>
       <HeaderBrand to="/" ariaLabel="シフトリのトップページへ" />
-      <UserMenu tone="light" />
+      {props.showUserMenu !== false && <UserMenu tone="light" />}
     </HeaderShell>
   );
 };

--- a/src/components/ui/FullPageSpinner/index.tsx
+++ b/src/components/ui/FullPageSpinner/index.tsx
@@ -13,7 +13,7 @@ export function FullPageSpinner({ showHeader = false }: Props) {
         <Header showUserMenu={false} />
         <Box pt={HEADER_HEIGHT}>
           <ShiftoriLoading
-            variant="page"
+            variant="section"
             minH={{
               base: `calc(100dvh - ${HEADER_HEIGHT.base})`,
               md: `calc(100dvh - ${HEADER_HEIGHT.md})`,

--- a/src/components/ui/FullPageSpinner/index.tsx
+++ b/src/components/ui/FullPageSpinner/index.tsx
@@ -1,5 +1,28 @@
+import { Box } from "@chakra-ui/react";
+import { HEADER_HEIGHT, Header } from "@/src/components/templates/Header";
 import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
 
-export function FullPageSpinner() {
+type Props = {
+  showHeader?: boolean;
+};
+
+export function FullPageSpinner({ showHeader = false }: Props) {
+  if (showHeader) {
+    return (
+      <Box w="100%">
+        <Header showUserMenu={false} />
+        <Box pt={HEADER_HEIGHT}>
+          <ShiftoriLoading
+            variant="page"
+            minH={{
+              base: `calc(100dvh - ${HEADER_HEIGHT.base})`,
+              md: `calc(100dvh - ${HEADER_HEIGHT.md})`,
+            }}
+          />
+        </Box>
+      </Box>
+    );
+  }
+
   return <ShiftoriLoading variant="page" />;
 }

--- a/src/pages/shift-board/index.tsx
+++ b/src/pages/shift-board/index.tsx
@@ -3,6 +3,7 @@ import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { ShiftBoardPage } from "@/src/components/features/ShiftBoard/ShiftBoardPage";
 import { Animation } from "@/src/components/templates/Animation";
+import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
 
 type Props = {
@@ -15,7 +16,15 @@ export function ShiftBoardRoutePage({ recruitmentId }: Props) {
   });
 
   if (data === undefined) {
-    return <ShiftoriLoading variant="section" minH="200px" />;
+    return (
+      <ShiftoriLoading
+        variant="section"
+        minH={{
+          base: `calc(100dvh - ${HEADER_HEIGHT.base})`,
+          md: `calc(100dvh - ${HEADER_HEIGHT.md})`,
+        }}
+      />
+    );
   }
 
   if (data === null) return null;


### PR DESCRIPTION
## Summary
認証確認中や ShiftForm 遷移時のローディング表示が、画面全体の文脈に合うように調整します。
認証確認中は既存ヘッダーを表示しつつユーザー情報を隠し、ローディング本体は少し控えめなサイズにしています。

## Changes
- **認証確認中のヘッダー表示**: `AuthGuard` のローディング中に既存 `Header` を表示し、右上のユーザーメニューだけ非表示にしました。
- **ローディングサイズ調整**: 認証中の `FullPageSpinner` は `ShiftoriLoading` の `section` 表示を使うようにしました。
- **ShiftForm 遷移時の中央寄せ**: シフトボード読み込み中のローディングを、ヘッダーを除いた表示領域の上下中央に配置しました。
- **Storybook 追加**: ユーザーメニューなしのヘッダー状態を `UserWithoutMenu` として追加しました。

## Verification
- `pnpm type-check`
- `pnpm lint`
