### PR TITLE
chore: sync release version 0.0.34 to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yps-crispy-carnival",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "private": true,
   "packageManager": "pnpm@10.33.3",
   "type": "module",


### PR DESCRIPTION
main のリリース処理で更新された package version を develop に取り込みます。

- develop: 0.0.33
- main: 0.0.34

このPRは `package.json` の version 同期だけを対象にします。