### PR TITLE
fix: prerender中のGTM起動を抑止しClarityの二重初期化を解消

### DIFF
--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -228,6 +228,14 @@ function assertRenderedHtml(route: string, html: string): void {
     const [name, count] = duplicatedOptionalMeta;
     throw new Error(`[prerender] ${route} produced ${count} ${name} meta tags — expected at most one`);
   }
+  // GTM が prerender 中に起動すると、注入されたタグ (Clarity / GA4 等) が焼き込まれて
+  // 実行時に二重初期化される (initGTM は isPrerendering() で起動を抑止している)。
+  // 計測スクリプトの混入をビルド失敗として検出し、再発を防ぐ。
+  if (/googletagmanager\.com|clarity\.ms/i.test(html)) {
+    throw new Error(
+      `[prerender] ${route} contains baked analytics scripts (googletagmanager.com / clarity.ms) — GTM must not run while prerendering`,
+    );
+  }
   // Emotion (Chakra UI) の動的注入スタイルが textContent にダンプされているか確認
   const styleBytes = (html.match(/<style\b[^>]*>([\s\S]*?)<\/style>/gi) ?? []).reduce((sum, s) => sum + s.length, 0);
   if (styleBytes < MIN_INLINE_STYLE_BYTES) {

--- a/src/helpers/gtm/index.test.ts
+++ b/src/helpers/gtm/index.test.ts
@@ -2,10 +2,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { initGTM, resetGTM, sendEvent, sendPageView } from ".";
 
+const prerenderFlag = () => window as unknown as { __PRERENDER__?: boolean };
+
 describe("GTM ヘルパー", () => {
   beforeEach(() => {
     resetGTM();
     window.dataLayer = [];
+    delete prerenderFlag().__PRERENDER__;
     for (const el of document.head.querySelectorAll('script[src*="googletagmanager"]')) el.remove();
     for (const el of document.body.querySelectorAll("noscript")) el.remove();
   });
@@ -43,6 +46,14 @@ describe("GTM ヘルパー", () => {
       initGTM("GTM-TEST123");
       const scripts = document.head.querySelectorAll('script[src*="googletagmanager"]');
       expect(scripts.length).toBe(1);
+    });
+
+    it("prerender中は何もしない（タグの焼き込み防止）", () => {
+      prerenderFlag().__PRERENDER__ = true;
+      initGTM("GTM-TEST123");
+      expect(document.head.querySelector('script[src*="googletagmanager"]')).toBeNull();
+      expect(document.body.querySelector("noscript")).toBeNull();
+      expect(window.dataLayer).toEqual([]);
     });
 
     it("prerender済みのGTMタグがある場合はDOMへ二重挿入しない", () => {

--- a/src/helpers/gtm/index.ts
+++ b/src/helpers/gtm/index.ts
@@ -1,3 +1,5 @@
+import { isPrerendering } from "@/src/helpers/seo";
+
 declare global {
   interface Window {
     dataLayer: Record<string, unknown>[];
@@ -24,7 +26,9 @@ function hasNoscriptFallback(gtmId: string): boolean {
 }
 
 export const initGTM = (gtmId: string): void => {
-  if (!gtmId || initialized) return;
+  // prerender 中に起動すると、GTM が注入したタグ (Clarity 等) が page.content() で
+  // 静的 HTML に焼き込まれ、実行時に GTM 発火分と二重初期化されてしまうため起動しない
+  if (!gtmId || initialized || isPrerendering()) return;
   initialized = true;
 
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
prerenderの待機ロジック変更(PR #505)以降、GTMが注入したClarityタグが
page.content()で静的HTMLに焼き込まれ、実行時にGTM発火分と二重初期化されて
Clarityのセッションが計上されなくなっていた。

- initGTM: isPrerendering()の場合は起動しない
- prerender: 生成HTMLへの計測スクリプト混入をビルド失敗として検出
- テスト: prerender中にタグが注入されないことを検証

https://claude.ai/code/session_01JuacJ7LJ8VUK6mgrBer2x5