### PR TITLE
fix(vrt): 縦長Storyのちぎれ画像を解消（スティッチ回避で1枚撮りに変更）

### DIFF
--- a/.storybook/vitest.vrt.setup.ts
+++ b/.storybook/vitest.vrt.setup.ts
@@ -1,4 +1,4 @@
-import { screenshot } from "@storycap-testrun/browser";
+import { type BrowserScreenshotHook, screenshot } from "@storycap-testrun/browser";
 import { afterEach, beforeEach } from "vitest";
 import { page } from "vitest/browser";
 
@@ -7,10 +7,12 @@ const VRT_VIEWPORT = {
   height: 1080,
 } as const;
 
+// 1枚撮りの上限。Chromiumのキャプチャ限界(16384px)とレポートサイズへの配慮
+const MAX_CAPTURE_HEIGHT = 8000;
+
 const FREEZE_STYLE_ID = "vrt-freeze-animations";
 
-// fullPageキャプチャはスクロール＆スティッチ方式のため、タイル撮影中に動く要素があると
-// 画像がちぎれる。アニメーションを即時完了させて最終状態で静止させる
+// play実行中〜安定性チェック中も画面を静止させる
 // （animation: none だとfade-in系が初期状態のまま固まるため、duration≒0 + 1回再生にする）
 function freezeAnimations() {
   if (document.getElementById(FREEZE_STYLE_ID)) return;
@@ -30,6 +32,28 @@ function freezeAnimations() {
   document.head.appendChild(style);
 }
 
+function measureContentHeight() {
+  return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+}
+
+// コンテンツがビューポート(1080px)より高いStoryを fullPage: true で撮ると、
+// スクロールしながら分割撮影→Canvas結合（スティッチ）が走り、チャンク間のズレで
+// 画像がちぎれる。代わりにStoryを描画しているiframeのラッパーをコンテンツの
+// 高さまで広げ、スクロール不要の状態にして1枚で撮る
+const expandViewportToContent: BrowserScreenshotHook = {
+  async preCapture() {
+    const wrapper = window.parent?.document.querySelector("iframe[data-vitest]")?.parentElement;
+    if (!wrapper) return;
+    // dvh基準の要素は拡張後に再レイアウトされるため、高さが安定するまで再測定する
+    for (let i = 0; i < 3; i++) {
+      const target = Math.min(Math.max(measureContentHeight(), VRT_VIEWPORT.height), MAX_CAPTURE_HEIGHT);
+      if (wrapper.getBoundingClientRect().height >= target) break;
+      wrapper.style.height = `${target}px`;
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+  },
+};
+
 beforeEach(async () => {
   await page.viewport(VRT_VIEWPORT.width, VRT_VIEWPORT.height);
   freezeAnimations();
@@ -37,9 +61,13 @@ beforeEach(async () => {
 
 afterEach(async (context) => {
   applyLegacySnapshotSkip(context);
+  const needsExpansion = measureContentHeight() > VRT_VIEWPORT.height;
   await screenshot(page, context, {
-    fullPage: true,
+    // 縦長Storyは fullPage: false + iframe拡張で1枚撮り（スティッチ回避）。
+    // ビューポート内に収まるStoryは従来どおりbody要素のキャプチャ
+    fullPage: !needsExpansion,
     scale: "css",
+    hooks: needsExpansion ? [expandViewportToContent] : [],
     flakiness: {
       retake: {
         enabled: true,

--- a/.storybook/vitest.vrt.setup.ts
+++ b/.storybook/vitest.vrt.setup.ts
@@ -7,8 +7,32 @@ const VRT_VIEWPORT = {
   height: 1080,
 } as const;
 
+const FREEZE_STYLE_ID = "vrt-freeze-animations";
+
+// fullPageキャプチャはスクロール＆スティッチ方式のため、タイル撮影中に動く要素があると
+// 画像がちぎれる。アニメーションを即時完了させて最終状態で静止させる
+// （animation: none だとfade-in系が初期状態のまま固まるため、duration≒0 + 1回再生にする）
+function freezeAnimations() {
+  if (document.getElementById(FREEZE_STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = FREEZE_STYLE_ID;
+  style.textContent = `
+    *, *::before, *::after {
+      animation-duration: 0.001s !important;
+      animation-delay: 0s !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+      scroll-behavior: auto !important;
+      caret-color: transparent !important;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
 beforeEach(async () => {
   await page.viewport(VRT_VIEWPORT.width, VRT_VIEWPORT.height);
+  freezeAnimations();
 });
 
 afterEach(async (context) => {


### PR DESCRIPTION
## Summary
VRTレポートで縦長Story（スクロールが必要な画面）のキャプチャが分断され、透明の隙間ができる「ちぎれ」が多発していた（例: `features-stafflegalconsent-consentpage--expired`、`features-demo-shiftoridemoflow--variants`）。

**根本原因**: storycap-testrunの `fullPage: true` は、コンテンツがビューポート高（1080px）を超えるとiframe内をスクロールしながら分割撮影し、Canvasで結合する（スティッチ）。このチャンク結合がズレて隙間・分断が発生していた。なおアニメーションはライブラリが撮影中に組み込みで無効化しているため、アニメーション位相は主因ではなかった。

## Changes
- **`.storybook/vitest.vrt.setup.ts`**:
  - コンテンツ高がビューポート（1080px）を超えるStoryは、`preCapture` フックでStory描画用iframeのラッパーを**コンテンツの高さまで拡張**し、`fullPage: false` でスクロール不要の**1枚撮り**に切り替え（= 1920x1080 の高さ制限を撤廃。スティッチ処理を完全回避）
  - `dvh` 基準のレイアウト（`minH="100dvh"` 等）は拡張後に再レイアウトされるため、高さが安定するまで再測定（最大3回、上限8000px）
  - ビューポート内に収まるStoryは従来どおりbody要素キャプチャ（ベースライン差分を最小化）
  - 補助対策として、play実行中〜安定性チェック中のアニメーション静止CSSも注入（duration≒0 + 1回再生。`animation: none` だとfill-mode依存の要素が初期状態で固まるため不採用）

## 確認方法
このPRのVRTレポートで以下を確認:
- スクロールが必要な縦長Story（ConsentPage、Demo Variants等）が透明の隙間なく1枚絵で写っていること
- 縦長Storyの画像高さがコンテンツ全体の高さになっていること（キャプチャ枚数は不変）

⚠️ 縦長Storyの画像サイズが変わるため、該当Storyに差分が出るのは想定どおりです（ベースライン更新のapproveが必要）。

https://claude.ai/code/session_01JitMKkgYBv4xc3hHap8oLc