### PR TITLE
シフト表示の24時間超え時刻を「翌H:MM」形式に統一

### DIFF
--- a/src/components/features/Shift/ShiftForm/__mocks__/storyData.tsx
+++ b/src/components/features/Shift/ShiftForm/__mocks__/storyData.tsx
@@ -249,6 +249,40 @@ export const mockShiftsHalfHourBusinessHours: ShiftData[] = [
   },
 ];
 
+// ==========================================
+// 深夜営業（24時超え）: 1/26
+// ==========================================
+const overnightDate = "2026-01-26";
+
+export const mockOvernightDates = [overnightDate];
+
+export const mockOvernightTimeRange: TimeRange = { start: 17, end: 29, unit: 30 };
+
+export const mockShiftsOvernight: ShiftData[] = [
+  // A: 翌5:00までの深夜シフト（希望と一致）
+  {
+    id: "overnight-staff1",
+    staffId: "staff1",
+    staffName: "Aさん",
+    date: overnightDate,
+    requestedTime: { start: "21:00", end: "29:00" },
+    positions: [workSeg("staff1", overnightDate, "21:00", "29:00")],
+  },
+  // B: 休憩を挟んで翌2:00までのシフト
+  {
+    id: "overnight-staff2",
+    staffId: "staff2",
+    staffName: "Bさん",
+    date: overnightDate,
+    requestedTime: { start: "18:00", end: "26:00" },
+    positions: [
+      workSeg("staff2", overnightDate, "18:00", "22:00"),
+      breakSeg("staff2", overnightDate, "22:00", "23:00"),
+      workSeg("staff2", overnightDate, "23:00", "26:00"),
+    ],
+  },
+];
+
 const shiftTypeDate = "2026-05-21";
 
 export const mockShiftTypeDates = [

--- a/src/components/features/Shift/ShiftForm/pc/DailyView/ShiftGrid/ShiftBar.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/DailyView/ShiftGrid/ShiftBar.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { computeVisualBreaks } from "@/src/domains/shift/operations";
-import { timeToMinutes } from "@/src/domains/shift/time";
+import { formatShiftClockTime, timeToMinutes } from "@/src/domains/shift/time";
 import type { LinkedResizeTarget, PositionSegment, ShiftData, TimeRange } from "@/src/domains/shift/types";
 import { BREAK_POSITION } from "../../../constants";
 import { hourWidthAtom } from "../../../stores";
@@ -106,7 +106,7 @@ export const ShiftBar = ({
                 whiteSpace="nowrap"
                 fontVariantNumeric="tabular-nums"
               >
-                希望: {request.start}-{request.end}
+                希望: {formatShiftClockTime(request.start)}-{formatShiftClockTime(request.end)}
               </Text>
             </Box>
           );
@@ -235,7 +235,7 @@ export const ShiftBar = ({
                 fontVariantNumeric="tabular-nums"
                 whiteSpace="nowrap"
               >
-                {earliestStart}–{latestEnd}
+                {formatShiftClockTime(earliestStart)}–{formatShiftClockTime(latestEnd)}
               </Text>
             </Box>
           );

--- a/src/components/features/Shift/ShiftForm/pc/DailyView/ShiftPopover.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/DailyView/ShiftPopover.tsx
@@ -2,7 +2,7 @@ import { Badge, Box, Flex, Portal, Text } from "@chakra-ui/react";
 import { useEffect } from "react";
 import { LuTrash2, LuX } from "react-icons/lu";
 import { IconButton } from "@/src/components/ui/Button";
-import { timeToMinutes } from "@/src/domains/shift/time";
+import { formatShiftClockTimeRange, timeToMinutes } from "@/src/domains/shift/time";
 import type { ShiftData } from "@/src/domains/shift/types";
 import { BREAK_POSITION } from "../../constants";
 
@@ -94,9 +94,9 @@ export const ShiftPopover = ({
             <Flex align="center" gap={2} pr={8}>
               <Text fontWeight="bold" fontSize="sm" color="gray.700">
                 {(shift.requestedTimes?.length ?? 0) > 0
-                  ? `希望: ${shift.requestedTimes?.map((request) => `${request.start} - ${request.end}`).join(" / ")}`
+                  ? `希望: ${shift.requestedTimes?.map((request) => formatShiftClockTimeRange(request.start, request.end)).join(" / ")}`
                   : shift.requestedTime
-                    ? `希望: ${shift.requestedTime.start} - ${shift.requestedTime.end}`
+                    ? `希望: ${formatShiftClockTimeRange(shift.requestedTime.start, shift.requestedTime.end)}`
                     : "希望: なし"}
               </Text>
               {!isStaffSubmitted && (
@@ -114,7 +114,7 @@ export const ShiftPopover = ({
             {visibleSegments.map((pos) => (
               <Flex key={pos.id} align="center" justify="space-between" mb={2} _last={{ mb: 0 }}>
                 <Text fontSize="sm" color="gray.700">
-                  {pos.start}-{pos.end}
+                  {formatShiftClockTimeRange(pos.start, pos.end)}
                 </Text>
                 {!isReadOnly && (
                   <IconButton

--- a/src/components/features/Shift/ShiftForm/pc/DailyView/TimeHeader.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/DailyView/TimeHeader.tsx
@@ -31,7 +31,7 @@ export const TimeHeader = ({ timeRange }: TimeHeaderProps) => {
           whiteSpace="nowrap"
           fontVariantNumeric="tabular-nums"
         >
-          {hour}:00
+          {hour >= 24 ? `翌${hour - 24}:00` : `${hour}:00`}
         </Text>
       ))}
     </Box>

--- a/src/components/features/Shift/ShiftForm/pc/OverviewView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/OverviewView/index.tsx
@@ -4,7 +4,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useState } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 import { buildWeeklyGrid, formatDateShort, getWeekdayLabel, type WeekStart } from "@/src/domains/shift/date";
-import { timeToMinutes } from "@/src/domains/shift/time";
+import { formatShiftClockTime, timeToMinutes } from "@/src/domains/shift/time";
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { selectedDateAtom, shiftConfigAtom, shiftsAtom, viewModeAtom } from "../../stores";
 
@@ -299,7 +299,7 @@ const WeekTable = ({ staffs, wkDates, lookup, holidays, onDateClick, isReadOnly 
                         color="teal.700"
                         style={{ fontVariantNumeric: "tabular-nums" }}
                       >
-                        {asn[0]}–{asn[1]}
+                        {formatShiftClockTime(asn[0])}–{formatShiftClockTime(asn[1])}
                       </Box>
                     ) : (
                       <Box as="span" color={d.inRange ? "gray.300" : "gray.200"} textStyle="caption">

--- a/src/components/features/Shift/ShiftForm/sp/DailyView/ShiftDetailSheet.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/DailyView/ShiftDetailSheet.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, VStack } from "@chakra-ui/react";
 import { Dialog } from "@/src/components/ui/Dialog";
 import { formatDateWithWeekday } from "@/src/domains/shift/date";
+import { formatShiftClockTime } from "@/src/domains/shift/time";
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { BREAK_POSITION } from "../../constants";
 
@@ -34,7 +35,7 @@ export const ShiftDetailSheet = ({ staff, shift, selectedDate, isOpen, onOpenCha
             <VStack gap={2} align="stretch">
               {visibleSegments.map((seg) => (
                 <Text key={seg.id} fontSize="sm" color="gray.700">
-                  {seg.start} - {seg.end}
+                  {formatShiftClockTime(seg.start)} - {formatShiftClockTime(seg.end)}
                 </Text>
               ))}
             </VStack>

--- a/src/components/features/Shift/ShiftForm/sp/DailyView/ShiftEditSheet.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/DailyView/ShiftEditSheet.tsx
@@ -9,7 +9,12 @@ import type { SelectItemType } from "@/src/components/ui/Select";
 import { Select } from "@/src/components/ui/Select";
 import { formatDateWithWeekday } from "@/src/domains/shift/date";
 import { normalizePositions, paintPosition } from "@/src/domains/shift/operations";
-import { generateShiftTimeOptions, minutesToTime, timeToMinutes } from "@/src/domains/shift/time";
+import {
+  formatShiftClockTimeRange,
+  generateShiftTimeOptions,
+  minutesToTime,
+  timeToMinutes,
+} from "@/src/domains/shift/time";
 import type { PositionType, ShiftData, StaffType, TimeRange } from "@/src/domains/shift/types";
 import { BREAK_POSITION, DEFAULT_POSITION } from "../../constants";
 import { getEditableEndMinutes, getEditableStartMinutes } from "../../utils/timelineGeometry";
@@ -94,7 +99,7 @@ export const ShiftEditSheet = ({
   const requestTimes = shift?.requestedTimes ?? (shift?.requestedTime ? [shift.requestedTime] : []);
   const requestLabel =
     requestTimes.length > 0
-      ? `希望: ${requestTimes.map((request) => `${request.start} - ${request.end}`).join(" / ")}`
+      ? `希望: ${requestTimes.map((request) => formatShiftClockTimeRange(request.start, request.end)).join(" / ")}`
       : "希望: なし";
 
   const currentShift: ShiftData = shift ?? {

--- a/src/components/features/Shift/ShiftForm/sp/DailyView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/DailyView/index.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { useDialog } from "@/src/components/ui/Dialog";
 import { getWeekdayLabel } from "@/src/domains/shift/date";
 import { computeVisualBreaks } from "@/src/domains/shift/operations";
-import { timeToMinutes } from "@/src/domains/shift/time";
+import { formatShiftClockTime, timeToMinutes } from "@/src/domains/shift/time";
 import type { PositionSegment, ShiftData, StaffType, TimeRange } from "@/src/domains/shift/types";
 import { BREAK_POSITION } from "../../constants";
 import { selectedDateAtom, shiftConfigAtom, shiftsAtom, sortedStaffsAtom } from "../../stores";
@@ -416,7 +416,7 @@ const SPDailyCard = ({ staff, shift, timeRange, onTap }: CardProps) => {
         )}
         {hasAsn && asn && (
           <Box textStyle="caption" fontWeight={700} color="teal.700" fontVariantNumeric="tabular-nums">
-            {asn[0]}–{asn[1]}
+            {formatShiftClockTime(asn[0])}–{formatShiftClockTime(asn[1])}
           </Box>
         )}
         {!hasReq && !hasAsn && staff.isSubmitted && (

--- a/src/components/features/Shift/ShiftForm/sp/OverviewView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/OverviewView/index.tsx
@@ -4,7 +4,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useState } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 import { buildWeeklyGrid, formatDateShort, getWeekdayLabel } from "@/src/domains/shift/date";
-import { timeToMinutes } from "@/src/domains/shift/time";
+import { formatShiftClockTime, timeToMinutes } from "@/src/domains/shift/time";
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { selectedDateAtom, shiftConfigAtom, shiftsAtom, viewModeAtom } from "../../stores";
 
@@ -211,7 +211,7 @@ const DayStaffList = ({
             {s.name}
           </Box>
           <Box color="teal.700" fontWeight={600} fontVariantNumeric="tabular-nums">
-            {asn[0]}–{asn[1]}
+            {formatShiftClockTime(asn[0])}–{formatShiftClockTime(asn[1])}
           </Box>
         </Flex>
       );

--- a/src/components/features/Shift/ShiftForm/stories/pc-daily.stories.tsx
+++ b/src/components/features/Shift/ShiftForm/stories/pc-daily.stories.tsx
@@ -3,8 +3,10 @@ import { ShiftForm } from "..";
 import {
   allPatternsArgs,
   emptyOrAllUnsubmittedArgs,
+  expectVisibleText,
   fullscreenParameters,
   halfHourBusinessHoursArgs,
+  overnightArgs,
   shiftFormDecorators,
 } from "./shared";
 
@@ -26,6 +28,15 @@ export const TimeBasic: Story = {
 export const TimeHalfHourBusinessHours: Story = {
   name: "Half Hour Business Hours",
   args: halfHourBusinessHoursArgs,
+};
+
+export const TimeOvernight: Story = {
+  name: "Overnight",
+  args: overnightArgs,
+  play: async ({ canvasElement }) => {
+    await expectVisibleText(canvasElement, "21:00–翌5:00");
+    await expectVisibleText(canvasElement, "翌5:00");
+  },
 };
 
 export const TimeEmptyOrAllUnsubmitted: Story = {

--- a/src/components/features/Shift/ShiftForm/stories/pc-overview.stories.tsx
+++ b/src/components/features/Shift/ShiftForm/stories/pc-overview.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ShiftForm } from "..";
-import { expectVisibleText, fullscreenParameters, overviewCalendarRangeArgs, shiftFormDecorators } from "./shared";
+import {
+  expectVisibleText,
+  fullscreenParameters,
+  overnightArgs,
+  overviewCalendarRangeArgs,
+  shiftFormDecorators,
+} from "./shared";
 
 const meta = {
   title: "Features/Shift/ShiftForm/Time/PC/Overview",
@@ -25,4 +31,13 @@ export const TimeTwoWeeks: Story = {
 export const TimeReadOnly: Story = {
   name: "Read Only",
   args: { ...overviewCalendarRangeArgs, isReadOnly: true, currentStaffId: "staff1" },
+};
+
+export const TimeOvernight: Story = {
+  name: "Overnight",
+  args: { ...overnightArgs, initialViewMode: "overview" as const },
+  play: async ({ canvasElement }) => {
+    await expectVisibleText(canvasElement, "21:00–翌5:00");
+    await expectVisibleText(canvasElement, "18:00–翌2:00");
+  },
 };

--- a/src/components/features/Shift/ShiftForm/stories/shared.tsx
+++ b/src/components/features/Shift/ShiftForm/stories/shared.tsx
@@ -10,10 +10,13 @@ import {
   mockDatesMidWeekStart,
   mockHalfHourTimeRange,
   mockHolidays,
+  mockOvernightDates,
+  mockOvernightTimeRange,
   mockPositions,
   mockShifts,
   mockShiftsAllPatterns,
   mockShiftsHalfHourBusinessHours,
+  mockShiftsOvernight,
   mockShiftTypeDates,
   mockShiftTypePattern,
   mockShiftTypeShifts,
@@ -65,6 +68,13 @@ export const halfHourBusinessHoursArgs = {
   dates: ["2026-01-28"],
   initialShifts: mockShiftsHalfHourBusinessHours,
   timeRange: mockHalfHourTimeRange,
+} satisfies ShiftFormArgs;
+
+export const overnightArgs = {
+  ...baseArgs,
+  dates: mockOvernightDates,
+  initialShifts: mockShiftsOvernight,
+  timeRange: mockOvernightTimeRange,
 } satisfies ShiftFormArgs;
 
 export const emptyOrAllUnsubmittedArgs = {

--- a/src/components/features/Shift/ShiftForm/stories/sp-daily.stories.tsx
+++ b/src/components/features/Shift/ShiftForm/stories/sp-daily.stories.tsx
@@ -3,9 +3,11 @@ import { ShiftForm } from "..";
 import {
   allPatternsArgs,
   emptyOrAllUnsubmittedArgs,
+  expectVisibleText,
   fullscreenParameters,
   halfHourBusinessHoursArgs,
   mobileGlobals,
+  overnightArgs,
   shiftFormDecorators,
 } from "./shared";
 
@@ -29,6 +31,15 @@ export const TimeHalfHourBusinessHours: Story = {
   name: "Half Hour Business Hours",
   args: halfHourBusinessHoursArgs,
   globals: mobileGlobals,
+};
+
+export const TimeOvernight: Story = {
+  name: "Overnight",
+  args: overnightArgs,
+  globals: mobileGlobals,
+  play: async ({ canvasElement }) => {
+    await expectVisibleText(canvasElement, "21:00–翌5:00");
+  },
 };
 
 export const TimeEmptyOrAllUnsubmitted: Story = {

--- a/src/components/features/Shift/ShiftForm/stories/sp-overview.stories.tsx
+++ b/src/components/features/Shift/ShiftForm/stories/sp-overview.stories.tsx
@@ -4,6 +4,7 @@ import {
   expectVisibleText,
   fullscreenParameters,
   mobileGlobals,
+  overnightArgs,
   overviewCalendarRangeArgs,
   shiftFormDecorators,
 } from "./shared";
@@ -34,4 +35,14 @@ export const TimeReadOnly: Story = {
   name: "Read Only",
   args: { ...overviewCalendarRangeArgs, isReadOnly: true, currentStaffId: "staff1" },
   globals: mobileGlobals,
+};
+
+export const TimeOvernight: Story = {
+  name: "Overnight",
+  args: { ...overnightArgs, initialViewMode: "overview" as const },
+  globals: mobileGlobals,
+  play: async ({ canvasElement }) => {
+    await expectVisibleText(canvasElement, "21:00–翌5:00");
+    await expectVisibleText(canvasElement, "18:00–翌2:00");
+  },
 };


### PR DESCRIPTION
スタッフのシフト確認画面などで29:00のように表示されていた深夜時刻を、
他画面と同じくformatShiftClockTimeで「翌5:00」形式に揃える。
対象: Overview(PC/SP)・Daily(PC/SP)のシフト時刻/希望時刻ラベル、
詳細シート、ポップオーバー、PC時間軸ヘッダー。VRT用Overnight Storyを追加。

https://claude.ai/code/session_012Wqr3VQAVtt4xRgzEc4rY1