### PR TITLE
fix: スタッフ参加申請の重複・申請済みをエラーではなくwarnで扱う

### DIFF
--- a/convex/_scenario/notificationDelivery.test.ts
+++ b/convex/_scenario/notificationDelivery.test.ts
@@ -1,7 +1,6 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, internal } from "../_generated/api";
-import type { Id } from "../_generated/dataModel";
 import type { ScenarioTest } from "../_test/scenarioBuilders";
 import { MANAGER_SUBJECT, SCENARIO_NOW, scenarioDate, seedStaff } from "../_test/scenarioBuilders";
 import { createScenario } from "../_test/scenarioFixtures";
@@ -528,6 +527,7 @@ describe("通知配送outboxシナリオ", () => {
       email: "digest-staff@example.com",
       acceptedLegal: true,
     });
+    if (request.status !== "ok") throw new Error(`unexpected status: ${request.status}`);
 
     await t.action(internal.staffRegistration.actions.sendOwnerDailyDigest, {});
 
@@ -545,7 +545,7 @@ describe("通知配送outboxシナリオ", () => {
     });
 
     await asManager.mutation(api.staffRegistration.mutations.approveRequest, {
-      requestId: request.requestId as Id<"staffRegistrationRequests">,
+      requestId: request.requestId,
     });
     await t.action(internal.staffRegistration.actions.sendOwnerDailyDigest, {});
 

--- a/convex/staffRegistration/mutations.test.ts
+++ b/convex/staffRegistration/mutations.test.ts
@@ -98,14 +98,13 @@ describe("staffRegistration/mutations", () => {
       acceptedLegal: true,
     });
 
-    await expect(
-      t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
-        token: link.token,
-        name: "別の申請スタッフ",
-        email: "Duplicate@Example.com",
-        acceptedLegal: true,
-      }),
-    ).rejects.toThrow("このメールアドレスは申請済みです。承認までしばらくおまちください");
+    const duplicateResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
+      token: link.token,
+      name: "別の申請スタッフ",
+      email: "Duplicate@Example.com",
+      acceptedLegal: true,
+    });
+    expect(duplicateResult).toEqual({ status: "already_applied" });
   });
 
   it("既存スタッフと同じメールアドレスでは参加申請できない", async () => {
@@ -126,14 +125,13 @@ describe("staffRegistration/mutations", () => {
       .withIdentity({ subject: "manager_existing_staff" })
       .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
 
-    await expect(
-      t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
-        token: link.token,
-        name: "申請スタッフ",
-        email: "existing@example.com",
-        acceptedLegal: true,
-      }),
-    ).rejects.toThrow("このメールアドレスはすでに登録されています。シフト申請開始、確定までしばらくおまちください。");
+    const existingResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
+      token: link.token,
+      name: "申請スタッフ",
+      email: "existing@example.com",
+      acceptedLegal: true,
+    });
+    expect(existingResult).toEqual({ status: "already_registered" });
 
     const requests = await t
       .withIdentity({ subject: "manager_existing_staff" })
@@ -150,12 +148,14 @@ describe("staffRegistration/mutations", () => {
     const link = await t
       .withIdentity({ subject: "manager_manager" })
       .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
-    const { requestId } = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
+    const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "承認待ちスタッフ",
       email: "pending@example.com",
       acceptedLegal: true,
     });
+    if (submitResult.status !== "ok") throw new Error(`unexpected status: ${submitResult.status}`);
+    const { requestId } = submitResult;
 
     const otherShopRequests = await t
       .withIdentity({ subject: "manager_other" })
@@ -192,12 +192,14 @@ describe("staffRegistration/mutations", () => {
     const link = await t
       .withIdentity({ subject: "manager_approve" })
       .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
-    const { requestId } = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
+    const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "承認スタッフ",
       email: "approved@example.com",
       acceptedLegal: true,
     });
+    if (submitResult.status !== "ok") throw new Error(`unexpected status: ${submitResult.status}`);
+    const { requestId } = submitResult;
 
     const { staffId } = await t
       .withIdentity({ subject: "manager_approve" })
@@ -248,12 +250,14 @@ describe("staffRegistration/mutations", () => {
     const link = await t
       .withIdentity({ subject: "manager_reject" })
       .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
-    const { requestId } = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
+    const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "却下スタッフ",
       email: "rejected@example.com",
       acceptedLegal: true,
     });
+    if (submitResult.status !== "ok") throw new Error(`unexpected status: ${submitResult.status}`);
+    const { requestId } = submitResult;
 
     await t.withIdentity({ subject: "manager_reject" }).mutation(api.staffRegistration.mutations.rejectRequest, {
       requestId,

--- a/convex/staffRegistration/mutations.ts
+++ b/convex/staffRegistration/mutations.ts
@@ -80,11 +80,16 @@ export const submitRegistrationRequest = mutation({
     const name = parsed.data.name;
     const email = normalizeEmail(parsed.data.email);
 
+    // 重複・申請済みは「想定内の利用フロー」なので throw せず status を返す。
+    // throw すると Convex のログにエラーとして残ってしまうため、observability は warn で残す。
+    // メールアドレスは生で残さず domain 部分のみログに含める（Dashboard 共有時の漏洩防止）。
+    const logSkip = (reason: string) =>
+      console.warn("[submitRegistrationRequest] skip", { reason, shopId: shop._id, emailDomain: email.split("@")[1] });
+
     const existingStaff = await findActiveStaffByEmail(ctx, shop._id, email);
     if (existingStaff) {
-      throw new ConvexError(
-        "このメールアドレスはすでに登録されています。シフト申請開始、確定までしばらくおまちください。",
-      );
+      logSkip("already_registered");
+      return { status: "already_registered" as const };
     }
 
     const pendingRequest = await ctx.db
@@ -94,7 +99,8 @@ export const submitRegistrationRequest = mutation({
       )
       .first();
     if (pendingRequest) {
-      throw new ConvexError("このメールアドレスは申請済みです。承認までしばらくおまちください");
+      logSkip("already_applied");
+      return { status: "already_applied" as const };
     }
 
     const versions = getLegalConsentVersions("staff");

--- a/src/pages/staff-registration/index.tsx
+++ b/src/pages/staff-registration/index.tsx
@@ -20,6 +20,12 @@ const expiredRegistrationData: StaffRegistrationPageData = {
   },
 };
 
+// 重複・申請済みはエラーではなく「想定内の案内」なので warning トーストで知らせる。
+const DUPLICATE_REGISTRATION_MESSAGE = {
+  already_registered: "このメールアドレスはすでに登録されています。シフト申請開始、確定までしばらくおまちください。",
+  already_applied: "このメールアドレスは申請済みです。承認までしばらくおまちください",
+} as const;
+
 export function StaffRegistrationRoutePage({ token }: Props) {
   const data = useQuery(api.staffRegistration.queries.getRegistrationPageData, token ? { token } : "skip");
   const submit = useMutation(api.staffRegistration.mutations.submitRegistrationRequest);
@@ -29,14 +35,22 @@ export function StaffRegistrationRoutePage({ token }: Props) {
       if (!token) return;
 
       try {
-        await submit({
+        const result = await submit({
           token,
           name: formData.name,
           email: formData.email,
           acceptedLegal: formData.acceptedLegal,
         });
-        setSubmitted(true);
-        toaster.create({ title: "参加申請を送りました", type: "success" });
+        if (result.status === "ok") {
+          setSubmitted(true);
+          toaster.create({ title: "参加申請を送りました", type: "success" });
+        } else {
+          toaster.create({
+            title: DUPLICATE_REGISTRATION_MESSAGE[result.status],
+            type: "warning",
+            duration: Number.POSITIVE_INFINITY,
+          });
+        }
       } catch (error) {
         showErrorToast(error);
       }


### PR DESCRIPTION
同じメールアドレスでの「すでに登録済み」「申請済み」は想定内の利用フロー
だが、ConvexError を throw していたため Convex のログにエラーとして残って
いた。throw をやめて status を返す方式に変更し、observability は console.warn
（メールドメインのみ記録）で残すようにした。

- submitRegistrationRequest: 重複/申請済みは
  { status: "already_registered" | "already_applied" } を返す
- フロントは返り値で分岐し、warning トーストで案内（文言は従来どおり）
- テストを返り値アサーションに更新

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0194YjHqJsvtUoZdVDumyo9W