### PR TITLE
feat(ShiftForm): 一覧タブの人×時間/勤務区分を日別ビューと同じ早い順に並べ替え

### DIFF
--- a/src/components/features/Shift/ShiftForm/sp/OverviewView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/OverviewView/index.tsx
@@ -4,6 +4,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo, useState } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 import { buildWeeklyGrid, formatDateShort, getWeekdayLabel } from "@/src/domains/shift/date";
+import { sortDailyStaffsByDate } from "@/src/domains/shift/sortStaffs";
 import { formatShiftClockTime, timeToMinutes } from "@/src/domains/shift/time";
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { IssueCountBadge } from "../../components";
@@ -76,6 +77,9 @@ export const SPOverviewView = () => {
     return map;
   }, [shifts]);
 
+  // 日別ビューと同じ「早い順」で日付ごとにスタッフを並べ替える。
+  const sortedStaffsByDate = useMemo(() => sortDailyStaffsByDate({ staffs, shifts, mode: "time" }), [staffs, shifts]);
+
   const handleDateTap = useCallback(
     (iso: string) => {
       if (isReadOnly) return;
@@ -131,7 +135,9 @@ export const SPOverviewView = () => {
                 <Box>
                   {wkDates.map((d, i) => {
                     const isClosed = d.inRange && holidays.includes(d.iso);
-                    const working = d.inRange && !isClosed ? staffs.filter((s) => lookup.has(`${s.id}-${d.iso}`)) : [];
+                    const dailyStaffs = sortedStaffsByDate.get(d.iso) ?? staffs;
+                    const working =
+                      d.inRange && !isClosed ? dailyStaffs.filter((s) => lookup.has(`${s.id}-${d.iso}`)) : [];
                     const canOpenDaily = !isReadOnly && d.inRange;
                     const warningCount = warningCounts.get(d.iso) ?? 0;
                     return (

--- a/src/components/features/Shift/ShiftForm/sp/ShiftTypeOverviewView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/ShiftTypeOverviewView/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import { LuChevronDown, LuChevronRight } from "react-icons/lu";
 import { buildWeeklyGrid, formatDateShort, getWeekdayLabel } from "@/src/domains/shift/date";
 import { getAssignedShiftTypeOptionIdsInOptionOrder } from "@/src/domains/shift/shiftTypeAssignments";
+import { sortDailyStaffsByDate } from "@/src/domains/shift/sortStaffs";
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { IssueCountBadge } from "../../components";
 import { getShiftTypeOptionColor, type ShiftTypeOptionColor } from "../../pc/shiftTypeOptionStyles";
@@ -96,6 +97,12 @@ export const SPShiftTypeOverviewView = () => {
     return map;
   }, [shifts]);
 
+  // 日別ビューと同じ「早い順」で日付ごとにスタッフを並べ替える。
+  const sortedStaffsByDate = useMemo(
+    () => sortDailyStaffsByDate({ staffs, shifts, mode: "shiftType" }),
+    [staffs, shifts],
+  );
+
   const handleDateTap = useCallback(
     (iso: string) => {
       if (isReadOnly) return;
@@ -151,10 +158,11 @@ export const SPShiftTypeOverviewView = () => {
                 <Box>
                   {weekDates.map((date, index) => {
                     const isClosed = date.inRange && holidays.includes(date.iso);
+                    const dailyStaffs = sortedStaffsByDate.get(date.iso) ?? staffs;
                     const workingStaffs =
                       !date.inRange || isClosed
                         ? []
-                        : staffs
+                        : dailyStaffs
                             .map((staff) => {
                               const shift = shiftByStaffDate.get(`${staff.id}-${date.iso}`);
                               const assignedOptionIds = getAssignedShiftTypeOptionIdsInOptionOrder(

--- a/src/domains/shift/sortStaffs.test.ts
+++ b/src/domains/shift/sortStaffs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { indexShiftsByStaffIdForDate } from "./shiftLookup";
-import { compareDefaultStaffOrder, sortDailyStaffs, sortStaffs } from "./sortStaffs";
+import { compareDefaultStaffOrder, sortDailyStaffs, sortDailyStaffsByDate, sortStaffs } from "./sortStaffs";
 import type { PositionSegment, ShiftData, StaffType } from "./types";
 
 const staffs = [
@@ -252,6 +252,49 @@ describe("sortDailyStaffs", () => {
     expect(
       sortDailyStaffs({ staffs: dailyStaffs, shiftByStaffId, mode: "shiftType" }).map((staff) => staff.id),
     ).toEqual(["staff-a", "staff-b", "staff-c", "staff-d", "staff-e", "staff-f"]);
+  });
+
+  test("日付ごとに、その日のシフトで早い順に並べたMapを返す", () => {
+    const shifts = [
+      shift({
+        staffId: "staff-a",
+        date: "2026-06-01",
+        positions: [segment({ start: "10:00", end: "18:00" })],
+      }),
+      shift({
+        staffId: "staff-b",
+        date: "2026-06-01",
+        positions: [segment({ start: "09:00", end: "17:00" })],
+      }),
+      // staff-aは2日目だけ早い → 日付ごとに並びが変わることを確認
+      shift({
+        staffId: "staff-a",
+        date: "2026-06-02",
+        positions: [segment({ start: "08:00", end: "12:00" })],
+      }),
+      shift({
+        staffId: "staff-b",
+        date: "2026-06-02",
+        positions: [segment({ start: "13:00", end: "21:00" })],
+      }),
+    ];
+
+    const result = sortDailyStaffsByDate({ staffs: dailyStaffs, shifts, mode: "time" });
+
+    expect(
+      result
+        .get("2026-06-01")
+        ?.map((staff) => staff.id)
+        .slice(0, 2),
+    ).toEqual(["staff-b", "staff-a"]);
+    expect(
+      result
+        .get("2026-06-02")
+        ?.map((staff) => staff.id)
+        .slice(0, 2),
+    ).toEqual(["staff-a", "staff-b"]);
+    // シフトのない日付はキーを持たない
+    expect(result.has("2026-06-03")).toBe(false);
   });
 
   test("日ごとは勤務ありグループ内を時間ではなくデフォルト順にする", () => {

--- a/src/domains/shift/sortStaffs.ts
+++ b/src/domains/shift/sortStaffs.ts
@@ -1,4 +1,5 @@
 import { BREAK_POSITION } from "./constants";
+import { indexShiftsByStaffId } from "./shiftLookup";
 import { timeToMinutes } from "./time";
 import type { ShiftData, SortMode, StaffType } from "./types";
 
@@ -154,6 +155,31 @@ export const sortDailyStaffs = ({ staffs, shiftByStaffId, mode }: SortDailyStaff
 
     return compareDefaultStaffOrder(a, b);
   });
+
+// 日付ごとに、その日のシフトをもとに日別ビューと同じ「早い順」でスタッフを並べ替える。
+// 一覧タブ（人×時間／人×勤務区分）で日別ビューと並びを揃えるために使う。
+export const sortDailyStaffsByDate = ({
+  staffs,
+  shifts,
+  mode,
+}: {
+  staffs: StaffType[];
+  shifts: readonly ShiftData[];
+  mode: DailyStaffSortMode;
+}): Map<string, StaffType[]> => {
+  const shiftsByDate = new Map<string, ShiftData[]>();
+  for (const shift of shifts) {
+    const list = shiftsByDate.get(shift.date);
+    if (list) list.push(shift);
+    else shiftsByDate.set(shift.date, [shift]);
+  }
+
+  const sortedByDate = new Map<string, StaffType[]>();
+  for (const [date, dateShifts] of shiftsByDate) {
+    sortedByDate.set(date, sortDailyStaffs({ staffs, shiftByStaffId: indexShiftsByStaffId(dateShifts), mode }));
+  }
+  return sortedByDate;
+};
 
 export const sortStaffs = ({ staffs, shiftByStaffId, sortMode }: SortStaffsParams) => {
   if (sortMode === "default") return [...staffs];


### PR DESCRIPTION
時間入力・勤務区分の一覧タブ（SP）で日付ごとに表示するスタッフを、日別ビューと
同じ「早い順」（割当開始→終了→デフォルト順）に並べ替える。日付ごとのシフトをもと
に並びを算出する sortDailyStaffsByDate を追加し、両一覧ビューで利用する。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019tB6WfYU6YHPeSxTZXZoa2