### PR TITLE
feat(line): 複数店舗に所属するユーザーのLINE連携を店舗ごとに保持

### DIFF
--- a/convex/_lib/functions.ts
+++ b/convex/_lib/functions.ts
@@ -1,7 +1,7 @@
 import type { UserIdentity } from "convex/server";
 import { ConvexError, v } from "convex/values";
 import { customMutation, customQuery } from "convex-helpers/server/customFunctions";
-import type { Doc } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { type MutationCtx, mutation, type QueryCtx, query } from "../_generated/server";
 import { sessionMatchesAccessKind, staffAccessKindValidator } from "./staffAccess";
 
@@ -30,6 +30,27 @@ async function getShopByUser(ctx: DbCtx, user: Doc<"users">) {
     return await ctx.db.get(membership.shopId);
   }
   return null;
+}
+
+/**
+ * 操作対象の店舗を解決する。
+ * - shopId 指定あり: その店舗にユーザーが所属しているかを検証して返す（未所属なら null）
+ * - shopId 未指定: 先頭の所属店舗にフォールバック（後方互換）
+ *
+ * 複数店舗に所属するマネージャーが、フロントから操作対象店舗を明示できるようにするための入口。
+ */
+async function resolveShopForUser(ctx: DbCtx, user: Doc<"users">, shopId?: Id<"shops">) {
+  if (!shopId) {
+    return await getShopByUser(ctx, user);
+  }
+  const membership = await ctx.db
+    .query("shopMembers")
+    .withIndex("by_userId_and_shopId_and_isDeleted", (q) =>
+      q.eq("userId", user._id).eq("shopId", shopId).eq("isDeleted", false),
+    )
+    .first();
+  if (!membership) return null;
+  return await ctx.db.get(shopId);
 }
 
 // Query用: 全フィールド nullable（throw しないため）
@@ -89,14 +110,14 @@ export const authenticatedMutation = customMutation(mutation, {
  * - 用途: createRecruitment, addStaffs 等の shop スコープ操作
  */
 export const managerQuery = customQuery(query, {
-  args: {},
-  input: async (ctx): Promise<{ ctx: ManagerQueryCtx; args: Record<string, never> }> => {
+  args: { shopId: v.optional(v.id("shops")) },
+  input: async (ctx, { shopId }): Promise<{ ctx: ManagerQueryCtx; args: Record<string, never> }> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       return { ctx: { user: null, shop: null }, args: {} };
     }
     const user = await getUserByIdentity(ctx, identity);
-    const shop = user ? await getShopByUser(ctx, user) : null;
+    const shop = user ? await resolveShopForUser(ctx, user, shopId) : null;
     if (!user || user.isDeleted || !shop || shop.isDeleted) {
       return { ctx: { user: null, shop: null }, args: {} };
     }
@@ -105,14 +126,14 @@ export const managerQuery = customQuery(query, {
 });
 
 export const managerMutation = customMutation(mutation, {
-  args: {},
-  input: async (ctx): Promise<{ ctx: ManagerMutationCtx; args: Record<string, never> }> => {
+  args: { shopId: v.optional(v.id("shops")) },
+  input: async (ctx, { shopId }): Promise<{ ctx: ManagerMutationCtx; args: Record<string, never> }> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       throw new ConvexError("Unauthenticated");
     }
     const user = await getUserByIdentity(ctx, identity);
-    const shop = user ? await getShopByUser(ctx, user) : null;
+    const shop = user ? await resolveShopForUser(ctx, user, shopId) : null;
     if (!user || user.isDeleted || !shop || shop.isDeleted) {
       throw new ConvexError("Not found");
     }

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -149,6 +149,26 @@ export const getDashboardShop = authenticatedQuery({
   },
 });
 
+/**
+ * ログインユーザーが所属する全店舗を返す。
+ * 複数店舗マネージャーが操作対象店舗を選ぶための一覧（フロントの selectedShopAtom 初期化に使う）。
+ */
+export const getMyShops = authenticatedQuery({
+  args: {},
+  handler: async (ctx) => {
+    if (!ctx.identity || !ctx.user) return [];
+    const user = ctx.user;
+    const memberships = await ctx.db
+      .query("shopMembers")
+      .withIndex("by_userId_and_isDeleted", (q) => q.eq("userId", user._id).eq("isDeleted", false))
+      .collect();
+    const shops = await Promise.all(memberships.map((m) => ctx.db.get(m.shopId)));
+    return shops
+      .filter((shop): shop is Doc<"shops"> => shop !== null && !shop.isDeleted)
+      .map((shop) => ({ shopId: shop._id, shopName: shop.name }));
+  },
+});
+
 export const getActiveDashboardAnnouncement = authenticatedQuery({
   args: {},
   handler: async (ctx) => {

--- a/convex/line/mutations.test.ts
+++ b/convex/line/mutations.test.ts
@@ -3,7 +3,7 @@ import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
-import { seedManagerShop, seedShop, seedStaffLineAccount } from "../_test/seed";
+import { seedManagerShop, seedShop, seedShopMembership, seedStaffLineAccount } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
 async function setupShop(t: TestConvex<typeof schema>) {
@@ -91,6 +91,57 @@ describe("line/mutations", () => {
         t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.generateLinkToken, {
           staffId: otherStaffId,
         }),
+      ).rejects.toThrow("Not found");
+    });
+
+    it("複数店舗マネージャーは shopId 指定でその店舗のスタッフにトークンを発行できる", async () => {
+      const t = convexTest(schema, modules);
+      // user_mgr は setupShop で店舗A（先頭）に所属。さらに店舗Bにも所属させる
+      const { shopBId, staffBId } = await t.run(async (ctx) => {
+        const { userId } = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "店舗A",
+        });
+        const shopBId = await seedShop(ctx, "店舗B");
+        await seedShopMembership(ctx, { userId, shopId: shopBId });
+        const staffBId = await ctx.db.insert("staffs", {
+          shopId: shopBId,
+          name: "B店スタッフ",
+          email: "b@example.com",
+          isDeleted: false,
+        });
+        return { shopBId, staffBId };
+      });
+
+      // shopId 未指定だと先頭店舗(A)に解決され、店舗Bスタッフは Not found
+      await expect(
+        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.generateLinkToken, { staffId: staffBId }),
+      ).rejects.toThrow("Not found");
+
+      // shopId=店舗B を指定すれば発行できる
+      const { token } = await t
+        .withIdentity({ subject: "user_mgr" })
+        .mutation(api.line.mutations.generateLinkToken, { staffId: staffBId, shopId: shopBId });
+      const link = await t.run(async (ctx) =>
+        ctx.db
+          .query("lineLinkTokens")
+          .withIndex("by_token", (q) => q.eq("token", token))
+          .first(),
+      );
+      expect(link?.staffId).toBe(staffBId);
+      expect(link?.shopId).toBe(shopBId);
+    });
+
+    it("未所属の shopId 指定は拒否（IDOR）", async () => {
+      const t = convexTest(schema, modules);
+      const { staffId } = await setupShop(t);
+      const foreignShopId = await t.run(async (ctx) => await seedShop(ctx, "無関係店舗"));
+
+      await expect(
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.line.mutations.generateLinkToken, { staffId, shopId: foreignShopId }),
       ).rejects.toThrow("Not found");
     });
   });
@@ -266,6 +317,48 @@ describe("line/mutations", () => {
       );
       expect(oldManager?.isDeleted).toBe(true);
     });
+
+    it("別店舗で同じ lineUserId を連携しても、既存店舗のアカウントは残る（多店舗連携）", async () => {
+      const t = convexTest(schema, modules);
+      const { shopId: shopAId, staffId: staffAId } = await setupShop(t);
+      // 同一人物が店舗Aで既にLINE連携済み
+      await t.run(async (ctx) => {
+        await seedStaffLineAccount(ctx, { staffId: staffAId, shopId: shopAId, lineUserId: "U_multi", following: true });
+      });
+      // 店舗Bの別 staff レコード（同一人物）
+      const { shopBId, staffBId } = await t.run(async (ctx) => {
+        const shopBId = await seedShop(ctx, "店舗B");
+        const staffBId = await ctx.db.insert("staffs", {
+          shopId: shopBId,
+          name: "鈴木太郎",
+          email: "suzuki@example.com",
+          isDeleted: false,
+        });
+        return { shopBId, staffBId };
+      });
+      const { tokenDocId } = await seedLineLinkToken(t, {
+        staffId: staffBId,
+        shopId: shopBId,
+        token: "shopB-token",
+      });
+
+      const result = await t.mutation(internal.line.mutations.finalizeLinking, {
+        staffId: staffBId,
+        tokenDocId,
+        lineUserId: "U_multi",
+        lineFollowing: true,
+      });
+      expect(result.status).toBe("ok");
+
+      const accounts = await t.run(async (ctx) =>
+        ctx.db
+          .query("staffLineAccounts")
+          .withIndex("by_lineUserId_and_isDeleted", (q) => q.eq("lineUserId", "U_multi").eq("isDeleted", false))
+          .collect(),
+      );
+      expect(accounts).toHaveLength(2);
+      expect(accounts.map((a) => a.staffId).sort()).toEqual([staffAId, staffBId].sort());
+    });
   });
 
   describe("dispatchWebhookEvents", () => {
@@ -315,6 +408,55 @@ describe("line/mutations", () => {
           .first(),
       );
       expect(account?.following).toBe(false);
+    });
+
+    it("同じ lineUserId が複数店舗に紐づく場合、全アカウントの following を更新する", async () => {
+      const t = convexTest(schema, modules);
+      const { shopId: shopAId, staffId: staffAId } = await setupShop(t);
+      const { staffBId } = await t.run(async (ctx) => {
+        await seedStaffLineAccount(ctx, {
+          staffId: staffAId,
+          shopId: shopAId,
+          lineUserId: "U_multi",
+          following: false,
+        });
+        const shopBId = await seedShop(ctx, "店舗B");
+        const staffBId = await ctx.db.insert("staffs", {
+          shopId: shopBId,
+          name: "鈴木太郎",
+          email: "suzuki@example.com",
+          isDeleted: false,
+        });
+        await seedStaffLineAccount(ctx, {
+          staffId: staffBId,
+          shopId: shopBId,
+          lineUserId: "U_multi",
+          following: false,
+        });
+        return { staffBId };
+      });
+
+      await t.mutation(internal.line.mutations.dispatchWebhookEvents, {
+        events: [{ type: "follow", userId: "U_multi" }],
+      });
+
+      const accounts = await t.run(async (ctx) =>
+        ctx.db
+          .query("staffLineAccounts")
+          .withIndex("by_lineUserId_and_isDeleted", (q) => q.eq("lineUserId", "U_multi").eq("isDeleted", false))
+          .collect(),
+      );
+      expect(accounts).toHaveLength(2);
+      expect(accounts.every((a) => a.following)).toBe(true);
+
+      const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
+      for (const staffId of [staffAId, staffBId]) {
+        expect(
+          scheduled.some(
+            (job) => job.name === "legal/actions:sendStaffConsentLine" && job.args[0]?.staffId === staffId,
+          ),
+        ).toBe(true);
+      }
     });
 
     it("message イベントの replyToken が返る", async () => {

--- a/convex/line/mutations.ts
+++ b/convex/line/mutations.ts
@@ -7,7 +7,7 @@ import { buildLineAuthorizeUrl } from "../_lib/lineClient";
 import { rateLimit } from "../_lib/rateLimits";
 import { generateUUID } from "../_lib/uuid";
 import { LINE_LINK_TOKEN_TTL_MS } from "../constants";
-import { findStaffLineAccountByLineUserId, getStaffLineAccount, upsertStaffLineAccount } from "./service";
+import { findStaffLineAccountsByLineUserId, getStaffLineAccount, upsertStaffLineAccount } from "./service";
 
 /**
  * シフト担当者UI: 指定スタッフに紐づくLINE連携トークンを発行
@@ -111,11 +111,13 @@ export const finalizeLinking = internalMutation({
     if (!staff || staff.isDeleted) return { status: "expired" as const };
     const currentAccount = await getStaffLineAccount(ctx, args.staffId);
 
-    // 既に他スタッフに紐づいている lineUserId の場合は上書きせず置き換え
-    // （同じLINEアカウントを別スタッフが連携し直したケース）
-    const existing = await findStaffLineAccountByLineUserId(ctx, args.lineUserId);
-    if (existing && existing.staffId !== args.staffId) {
-      await ctx.db.patch(existing._id, { isDeleted: true, following: false });
+    // 同一店舗で別スタッフに同じ lineUserId が紐づいていた場合だけ付け替える
+    // （真の重複/担当替え）。別店舗のアカウントは残す（同一人物の多店舗連携を許可）。
+    const sameLineAccounts = await findStaffLineAccountsByLineUserId(ctx, args.lineUserId);
+    for (const acc of sameLineAccounts) {
+      if (acc.staffId !== args.staffId && acc.shopId === staff.shopId) {
+        await ctx.db.patch(acc._id, { isDeleted: true, following: false });
+      }
     }
 
     await upsertStaffLineAccount(ctx, {
@@ -202,11 +204,13 @@ export const dispatchWebhookEvents = internalMutation({
     }
 
     for (const [userId, following] of followingByUserId) {
-      const account = await findStaffLineAccountByLineUserId(ctx, userId);
-      const staff = account ? await ctx.db.get(account.staffId) : null;
-      if (staff && !staff.isDeleted) {
-        const wasFollowing = Boolean(account?.following);
-        if (account) await ctx.db.patch(account._id, { following, lastWebhookAt: Date.now() });
+      // 同じ lineUserId が複数店舗のスタッフに紐づく場合があるため、全アカウントへ反映する。
+      const accounts = await findStaffLineAccountsByLineUserId(ctx, userId);
+      for (const account of accounts) {
+        const staff = await ctx.db.get(account.staffId);
+        if (!staff || staff.isDeleted) continue;
+        const wasFollowing = Boolean(account.following);
+        await ctx.db.patch(account._id, { following, lastWebhookAt: Date.now() });
         if (following && !wasFollowing) {
           // ブロック解除などでfollow状態に戻った場合、未送達になっていた案内を補う。
           await ctx.scheduler.runAfter(0, internal.legal.actions.sendStaffConsentLine, {

--- a/convex/line/service.ts
+++ b/convex/line/service.ts
@@ -19,6 +19,17 @@ export async function findStaffLineAccountByLineUserId(ctx: DbCtx, lineUserId: s
   return account ?? null;
 }
 
+/**
+ * 同じ lineUserId に紐づくアクティブなアカウントを全件取得する。
+ * 同一人物が複数店舗にLINE連携しているケース（店舗ごとに別 staff レコード）を扱う。
+ */
+export async function findStaffLineAccountsByLineUserId(ctx: DbCtx, lineUserId: string) {
+  return await ctx.db
+    .query("staffLineAccounts")
+    .withIndex("by_lineUserId_and_isDeleted", (q) => q.eq("lineUserId", lineUserId).eq("isDeleted", false))
+    .collect();
+}
+
 export async function upsertStaffLineAccount(
   ctx: MutationCtx,
   args: {

--- a/doc/features/line-notification.md
+++ b/doc/features/line-notification.md
@@ -109,6 +109,14 @@ LINEメッセージ本文に載せるURLには `withOpenExternalBrowser()`（`co
 - 複数の対象募集がある場合は募集ごとに1通ずつ送る
 - スタッフ一覧の個別メニューから、募集通知と現在の確定シフト通知を手動再送できる。通常は募集作成時・シフト確定時に自動通知されるため、不達時だけ使う補助導線として扱う。操作後のUIでは「送りました」と案内する
 
+## 複数店舗での連携
+
+LINE連携は `staffLineAccounts`（`staffId` 単位、各 `staffs` は1店舗に属する）で管理する。同じ人が複数店舗に所属する場合は店舗ごとに別 `staffs` レコードがあるため、**同一 `lineUserId` を店舗ごとに同時連携できる**。
+
+- `finalizeLinking`: 同一 `lineUserId` の重複排除は**同一店舗内のみ**（同じ店舗で別スタッフに紐づいていた場合だけ旧アカウントを論理削除）。別店舗のアカウントは残す。
+- `dispatchWebhookEvents`（follow/unfollow）: 同一 `lineUserId` に紐づく**全店舗のアカウント**へ following 状態を反映し、初回follow時は店舗（staff）ごとに同意依頼・募集通知をスケジュールする。
+- 連携状況の引き当ては `getStaffLineAccount`（`staffId` 単位）で店舗ごとに独立して行う。
+
 ## 設計ドキュメント
 
 `doc/plans/2026-05-06_LINE通知連携設計.md`

--- a/doc/features/manager-shop-membership.md
+++ b/doc/features/manager-shop-membership.md
@@ -24,9 +24,20 @@
 | `api.dashboard.queries.getDashboardShop` | query | 現在店舗の基本情報を取得する |
 | `api.dashboard.queries.getDashboardRecruitments` | query | 現在店舗の募集一覧を取得する |
 | `api.dashboard.queries.getDashboardStaffs` | query | 現在店舗のスタッフ一覧を取得する |
+| `api.dashboard.queries.getMyShops` | query | ログインmanagerの全active所属店舗を返す（フロントの `selectedShopAtom` 初期化用） |
+
+## 現在店舗の解決（manager API）
+
+`managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）は optional 引数 `shopId` を受け取る。
+
+- `shopId` 指定あり: `shopMembers.by_userId_and_shopId_and_isDeleted` でactive所属を確認し、その店舗を `ctx.shop` にする。未所属なら query は `null`、mutation は `Not found`（IDOR・列挙対策）。
+- `shopId` 未指定: 先頭のactive所属店舗にフォールバック（後方互換）。
+
+フロント側は `selectedShopAtom`（localStorage永続化）に選択中店舗を保持し、`useShopMutation`（`src/hooks/useShopMutation.ts`）が manager 系 mutation へ `shopId` を自動注入する。`AuthGuard` が `getMyShops` で atom を初期化/整合する。
 
 ## 補足
 
-- 複数店舗切替UI、2店舗目作成、店舗招待は未実装。
-- 将来のmanager APIは、選択中 `shopId` を受け取り、`shopMembers.by_userId_and_shopId_and_isDeleted` でactive所属を確認してから各データの `shopId` と突合する。
+- **店舗切替UI（プルダウン等）は未実装**。`selectedShopAtom` は先頭店舗で初期化されるため、現状の挙動は実質これまでと同じ（送信経路だけ整備済み）。
+- ダッシュボードの読み取り（`getDashboardShop` 等）は `authenticatedQuery` + `getManagerShop`（先頭店舗）で、まだ `shopId` を受け取らない。完全な複数店舗読み取りは切替UI導入時に対応する。
+- 2店舗目作成、店舗招待は未実装。
 - managerの法務同意はuser単位で判定する。`legalConsentStates.shopId` は同意した店舗文脈の履歴として扱う。

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -13,6 +13,7 @@ import { Dialog, useDialog } from "@/src/components/ui/Dialog";
 import { StepperDialog } from "@/src/components/ui/StepperDialog";
 import { showErrorToast, toaster } from "@/src/components/ui/toaster";
 import { formatDateShort } from "@/src/domains/shift/date";
+import { useShopMutation } from "@/src/hooks/useShopMutation";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import { AddStaffForm } from "../AddStaffForm/index.tsx";
 import type { CreateRecruitmentData } from "../CreateRecruitmentForm/index";
@@ -185,24 +186,26 @@ export const DashboardContent = ({
   const visibleRecruitmentGroups =
     recruitmentGroups ?? buildDashboardRecruitmentGroups({ recruitments: recruitmentList }).groups;
 
+  // shop 未作成状態でも呼ぶため authenticatedMutation（shopId なし）
   const setupShopAndManager = useMutation(api.setup.mutations.setupShopAndManager);
-  const acceptManagerLegalConsent = useMutation(api.legal.mutations.acceptManagerLegalConsent);
-  const createRecruitment = useMutation(api.recruitment.mutations.createRecruitment);
-  const deleteRecruitmentMut = useMutation(api.recruitment.mutations.deleteRecruitment);
-  const addStaffs = useMutation(api.staff.mutations.addStaffs);
-  const editStaffMut = useMutation(api.staff.mutations.editStaff);
-  const deleteStaffMut = useMutation(api.staff.mutations.deleteStaff);
-  const updateShopSettings = useMutation(api.shop.mutations.updateShopSettings);
-  const generateLineLinkToken = useMutation(api.line.mutations.generateLinkToken);
-  const sendLineInvite = useMutation(api.line.mutations.sendInvite);
-  const sendOpenRecruitmentNotifications = useMutation(api.staff.mutations.sendOpenRecruitmentNotifications);
-  const sendCurrentShiftNotification = useMutation(api.staff.mutations.sendCurrentShiftNotification);
-  const ensureShopRegistrationLink = useMutation(api.staffRegistration.mutations.ensureShopRegistrationLink);
-  const approveStaffRequest = useMutation(api.staffRegistration.mutations.approveRequest);
-  const rejectStaffRequest = useMutation(api.staffRegistration.mutations.rejectRequest);
   const dismissOnboarding = useMutation(api.dashboard.mutations.dismissOnboarding);
-  const resendNotificationFailure = useMutation(api.notificationOutbox.mutations.resendFailure);
-  const resendOpenNotificationFailures = useMutation(api.notificationOutbox.mutations.resendOpenFailures);
+  // 以下は managerMutation。選択中店舗の shopId を自動注入する
+  const acceptManagerLegalConsent = useShopMutation(api.legal.mutations.acceptManagerLegalConsent);
+  const createRecruitment = useShopMutation(api.recruitment.mutations.createRecruitment);
+  const deleteRecruitmentMut = useShopMutation(api.recruitment.mutations.deleteRecruitment);
+  const addStaffs = useShopMutation(api.staff.mutations.addStaffs);
+  const editStaffMut = useShopMutation(api.staff.mutations.editStaff);
+  const deleteStaffMut = useShopMutation(api.staff.mutations.deleteStaff);
+  const updateShopSettings = useShopMutation(api.shop.mutations.updateShopSettings);
+  const generateLineLinkToken = useShopMutation(api.line.mutations.generateLinkToken);
+  const sendLineInvite = useShopMutation(api.line.mutations.sendInvite);
+  const sendOpenRecruitmentNotifications = useShopMutation(api.staff.mutations.sendOpenRecruitmentNotifications);
+  const sendCurrentShiftNotification = useShopMutation(api.staff.mutations.sendCurrentShiftNotification);
+  const ensureShopRegistrationLink = useShopMutation(api.staffRegistration.mutations.ensureShopRegistrationLink);
+  const approveStaffRequest = useShopMutation(api.staffRegistration.mutations.approveRequest);
+  const rejectStaffRequest = useShopMutation(api.staffRegistration.mutations.rejectRequest);
+  const resendNotificationFailure = useShopMutation(api.notificationOutbox.mutations.resendFailure);
+  const resendOpenNotificationFailures = useShopMutation(api.notificationOutbox.mutations.resendOpenFailures);
 
   useEffect(() => {
     if (pendingStaffRequests.length === 0 || isDashboardOnboardingDismissed || autoDismissedOnboarding) return;

--- a/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Icon, Text } from "@chakra-ui/react";
 import { Link, useBlocker } from "@tanstack/react-router";
-import { useMutation } from "convex/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { LuChevronLeft, LuCircleCheck } from "react-icons/lu";
 import { api } from "@/convex/_generated/api";
@@ -30,6 +29,7 @@ import { isAssignmentsEqual } from "@/src/domains/shift/isAssignmentsEqual";
 import { resolveDisplayShiftLine } from "@/src/domains/shift/resolveDisplayShiftLine";
 import { minutesToTime } from "@/src/domains/shift/time";
 import type { ShiftData, ShiftTimeRange, StaffType } from "@/src/domains/shift/types";
+import { useShopMutation } from "@/src/hooks/useShopMutation";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import { ConfirmShiftContent } from "../ConfirmShiftContent";
 import { RemindUnsubmittedContent } from "../RemindUnsubmittedContent";
@@ -241,8 +241,8 @@ type Props = {
 };
 
 export const ShiftBoardPage = ({ data, recruitmentId }: Props) => {
-  const saveShiftAssignments = useMutation(api.shiftBoard.mutations.saveShiftAssignments);
-  const confirmRecruitmentMutation = useMutation(api.shiftBoard.mutations.confirmRecruitment);
+  const saveShiftAssignments = useShopMutation(api.shiftBoard.mutations.saveShiftAssignments);
+  const confirmRecruitmentMutation = useShopMutation(api.shiftBoard.mutations.confirmRecruitment);
 
   const confirmedAt = data.recruitment.confirmedAt ? new Date(data.recruitment.confirmedAt) : null;
   const isConfirmed = data.recruitment.status === "confirmed";

--- a/src/components/features/auths/AuthGuard.tsx
+++ b/src/components/features/auths/AuthGuard.tsx
@@ -6,6 +6,7 @@ import { useEffect } from "react";
 import { api } from "@/convex/_generated/api";
 import { normalizeAuthRedirect } from "@/src/components/features/AuthPage/redirect";
 import { FullPageSpinner } from "@/src/components/ui/FullPageSpinner";
+import { selectedShopAtom } from "@/src/stores/shop";
 import { userAtom } from "@/src/stores/user";
 
 type Props = {
@@ -16,7 +17,9 @@ export const AuthGuard = ({ children }: Props) => {
   const { isSignedIn, userId, isLoaded } = useAuth();
   const location = useRouterState({ select: (state) => state.location });
   const [user, setUser] = useAtom(userAtom);
+  const [selectedShop, setSelectedShop] = useAtom(selectedShopAtom);
   const currentUser = useQuery(api.dashboard.queries.getCurrentUser, isSignedIn ? {} : "skip");
+  const myShops = useQuery(api.dashboard.queries.getMyShops, isSignedIn ? {} : "skip");
 
   useEffect(() => {
     if (userId && currentUser) {
@@ -27,6 +30,16 @@ export const AuthGuard = ({ children }: Props) => {
       });
     }
   }, [userId, currentUser, setUser]);
+
+  // 選択中店舗を初期化/整合する。未選択 or 保存値が所属一覧から消えた場合は先頭店舗にする。
+  // （店舗切替UIは未提供。ここで selectedShopAtom にセットした値が manager 系の shopId として送られる）
+  useEffect(() => {
+    if (!myShops || myShops.length === 0) return;
+    const stillValid = selectedShop && myShops.some((shop) => shop.shopId === selectedShop.shopId);
+    if (!stillValid) {
+      setSelectedShop({ shopId: myShops[0].shopId, shopName: myShops[0].shopName });
+    }
+  }, [myShops, selectedShop, setSelectedShop]);
 
   if (user.authId) {
     return children;

--- a/src/hooks/useShopMutation.ts
+++ b/src/hooks/useShopMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation } from "convex/react";
+import type { FunctionArgs, FunctionReference, FunctionReturnType } from "convex/server";
+import { useAtomValue } from "jotai";
+import { useCallback } from "react";
+import { selectedShopAtom } from "@/src/stores/shop";
+
+/**
+ * マネージャー系 mutation 用のラッパー。
+ * 選択中店舗（selectedShopAtom）の shopId を自動で引数に注入する。
+ *
+ * バックエンドの managerMutation は shopId を optional で受け取り、
+ * 未指定なら先頭の所属店舗にフォールバックする。複数店舗マネージャーが
+ * 操作対象店舗を明示できるようにするための入口。
+ */
+export function useShopMutation<M extends FunctionReference<"mutation">>(mutationRef: M) {
+  const mutate = useMutation(mutationRef);
+  const selectedShop = useAtomValue(selectedShopAtom);
+  const shopId = selectedShop?.shopId;
+
+  return useCallback(
+    (args: Omit<FunctionArgs<M>, "shopId">): Promise<FunctionReturnType<M>> => {
+      const merged = shopId ? { ...args, shopId } : args;
+      return mutate(merged as FunctionArgs<M>);
+    },
+    [mutate, shopId],
+  );
+}

--- a/src/pages/shift-board/index.tsx
+++ b/src/pages/shift-board/index.tsx
@@ -1,18 +1,22 @@
 import { useQuery } from "convex/react";
+import { useAtomValue } from "jotai";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { ShiftBoardPage } from "@/src/components/features/ShiftBoard/ShiftBoardPage";
 import { Animation } from "@/src/components/templates/Animation";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
+import { selectedShopAtom } from "@/src/stores/shop";
 
 type Props = {
   recruitmentId: string;
 };
 
 export function ShiftBoardRoutePage({ recruitmentId }: Props) {
+  const selectedShop = useAtomValue(selectedShopAtom);
   const data = useQuery(api.shiftBoard.queries.getShiftBoardData, {
     recruitmentId: recruitmentId as Id<"recruitments">,
+    ...(selectedShop?.shopId ? { shopId: selectedShop.shopId as Id<"shops"> } : {}),
   });
 
   if (data === undefined) {


### PR DESCRIPTION
同じ人(同じlineUserId)が複数店舗に所属する場合、LINE連携が直近に連携した
1店舗にしか有効に残らない問題を修正。

Phase 1 (LINE連携本体):
- finalizeLinking の重複排除を同一店舗内のみに限定し、別店舗の連携は残す
- follow/unfollow Webhook を同一lineUserIdの全店舗アカウントへ反映
- service に findStaffLineAccountsByLineUserId(複数取得)を追加

Phase 2 (マネージャー店舗コンテキスト):
- managerQuery/managerMutation に optional shopId を追加し shopMembers で所属検証
- getShopByUser 未指定時は先頭店舗にフォールバック(後方互換)
- getMyShops query を追加
- フロントは selectedShopAtom を AuthGuard で初期化し、useShopMutation で
  manager系 mutation へ shopId を自動注入(店舗切替UIは未実装)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014biNaJXvLSgQzrbw772iGx