### PR TITLE
refactor: ユーザー向け日本語コピーの冗長表現・表記ゆれを整理

### DIFF
--- a/convex/_lib/validation.ts
+++ b/convex/_lib/validation.ts
@@ -38,7 +38,7 @@ export const requiredEmailSchema = z
   .trim()
   .min(1, "メールアドレスを入力してください")
   .max(EMAIL_MAX_LENGTH, `メールアドレスは${EMAIL_MAX_LENGTH}文字以内で入力してください`)
-  .email("正しいメールアドレスを入力してください")
+  .email("メールアドレスの形式で入力してください")
   .refine((value) => !hasControlCharacter(value), {
     message: "メールアドレスに使用できない文字が含まれています",
   });
@@ -49,7 +49,7 @@ export const optionalEmail = (val: string, ctx: z.RefinementCtx) => {
   if (!result.success) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: result.error.issues[0]?.message ?? "正しいメールアドレスを入力してください",
+      message: result.error.issues[0]?.message ?? "メールアドレスの形式で入力してください",
     });
   }
 };

--- a/convex/setup/mutations.test.ts
+++ b/convex/setup/mutations.test.ts
@@ -61,7 +61,7 @@ describe("setup/mutations", () => {
           ...setupArgs,
           managerEmail: "not-email",
         }),
-      ).rejects.toThrow("正しいメールアドレスを入力してください");
+      ).rejects.toThrow("メールアドレスの形式で入力してください");
     });
 
     it("店舗・ユーザー・スタッフ・同意履歴をトランザクションで作成する", async () => {

--- a/convex/staff/mutations.test.ts
+++ b/convex/staff/mutations.test.ts
@@ -133,7 +133,7 @@ describe("staff/mutations", () => {
         asManager.mutation(api.staff.mutations.addStaffs, {
           entries: [{ name: "不正メール", email: "not-email" }],
         }),
-      ).rejects.toThrow("正しいメールアドレスを入力してください");
+      ).rejects.toThrow("メールアドレスの形式で入力してください");
     });
 
     it("既存メールアドレスの重複はエラーにしてスタッフを追加しない", async () => {
@@ -545,7 +545,7 @@ describe("staff/mutations", () => {
           name: "田中太郎",
           email: "not-email",
         }),
-      ).rejects.toThrow("正しいメールアドレスを入力してください");
+      ).rejects.toThrow("メールアドレスの形式で入力してください");
     });
 
     it("他店舗のスタッフは編集できない（IDOR）", async () => {

--- a/convex/staffRegistration/mutations.test.ts
+++ b/convex/staffRegistration/mutations.test.ts
@@ -64,7 +64,7 @@ describe("staffRegistration/mutations", () => {
         email: "not-email",
         acceptedLegal: true,
       }),
-    ).rejects.toThrow("正しいメールアドレスを入力してください");
+    ).rejects.toThrow("メールアドレスの形式で入力してください");
     await expect(
       t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
         token: link.token,

--- a/e2e/pages/StaffSubmitPage.ts
+++ b/e2e/pages/StaffSubmitPage.ts
@@ -45,16 +45,12 @@ export class StaffSubmitPage {
   }
 
   async expectLegalConsentVisible() {
-    await expect(
-      this.page.getByText(/初回の提出時、または利用規約・プライバシーポリシーに大きな変更があった場合のみ/),
-    ).toBeVisible();
+    await expect(this.page.getByText(/初めての提出時や、規約の大きな変更があったときのみ/)).toBeVisible();
     await expect(this.legalConsentCheckbox()).toBeVisible();
   }
 
   async expectLegalConsentNotVisible() {
-    await expect(
-      this.page.getByText(/初回の提出時、または利用規約・プライバシーポリシーに大きな変更があった場合のみ/),
-    ).not.toBeVisible();
+    await expect(this.page.getByText(/初めての提出時や、規約の大きな変更があったときのみ/)).not.toBeVisible();
     await expect(this.legalConsentCheckbox()).not.toBeVisible();
   }
 

--- a/src/components/features/Dashboard/AddStaffForm/index.test.ts
+++ b/src/components/features/Dashboard/AddStaffForm/index.test.ts
@@ -34,7 +34,7 @@ describe("staffEntrySchema", () => {
     const result = staffEntrySchema.safeParse({ name: "田中", email });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe("正しいメールアドレスを入力してください");
+      expect(result.error.issues[0].message).toBe("メールアドレスの形式で入力してください");
     }
   });
 

--- a/src/components/features/Dashboard/EditStaffForm/index.test.ts
+++ b/src/components/features/Dashboard/EditStaffForm/index.test.ts
@@ -57,7 +57,7 @@ describe("editStaffSchema", () => {
     const result = editStaffSchema.safeParse({ name: "田中", email });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe("正しいメールアドレスを入力してください");
+      expect(result.error.issues[0].message).toBe("メールアドレスの形式で入力してください");
     }
   });
 

--- a/src/components/features/Dashboard/SetupModal/SetupStep2/index.test.ts
+++ b/src/components/features/Dashboard/SetupModal/SetupStep2/index.test.ts
@@ -35,7 +35,7 @@ describe("step2Schema (managerProfile)", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const error = result.error.issues.find((i) => i.path.includes("email"));
-      expect(error?.message).toBe("正しいメールアドレスを入力してください");
+      expect(error?.message).toBe("メールアドレスの形式で入力してください");
     }
   });
 

--- a/src/components/features/Line/LineCallbackPage/index.tsx
+++ b/src/components/features/Line/LineCallbackPage/index.tsx
@@ -36,13 +36,13 @@ const COPY: Record<
     icon: LuClock,
     tone: "warning",
     title: "リンクの有効期限が切れています",
-    description: "シフト作成担当者にリンクをもう一度送ってもらってください。このリンクは72時間以内に1回だけ使えます。",
+    description: "シフト作成担当者に、リンクの再送をお願いしてください。このリンクは72時間以内に1回だけ使えます。",
   },
   rate_limited: {
     icon: LuCircleAlert,
     tone: "warning",
     title: "アクセスが集中しています",
-    description: "少し時間を空けてから再度お試しください。",
+    description: "少し時間をおいてから、もう一度お試しください。",
   },
   error: {
     icon: LuCircleAlert,

--- a/src/components/features/ShiftBoard/ConfirmShiftContent/index.tsx
+++ b/src/components/features/ShiftBoard/ConfirmShiftContent/index.tsx
@@ -21,9 +21,7 @@ export const ConfirmShiftContent = ({ staffCount, periodLabel, warnings = [], is
   return (
     <>
       <Text fontSize="sm" lineHeight="tall" mb={4}>
-        {isResend
-          ? "前回通知から変更があるスタッフだけに送ります。LINE連携済みのスタッフにはLINE、それ以外のスタッフにはメールで届きます。"
-          : "LINE連携済みのスタッフにはLINE、それ以外のスタッフにはメールで届きます。"}
+        {"LINE連携済みのスタッフにはLINE、それ以外にはメールで届きます。"}
       </Text>
       <Box bg="gray.50" borderRadius="md" p={4}>
         <Text fontSize="sm">対象: {isResend ? "前回通知から変更があるスタッフ" : `${staffCount}名`}</Text>

--- a/src/components/features/StaffSubmit/SubmitFormView/index.tsx
+++ b/src/components/features/StaffSubmit/SubmitFormView/index.tsx
@@ -417,7 +417,7 @@ export const SubmitFormView = ({ data, onSubmit }: Props) => {
           {data.legalConsentRequired && (
             <Box mb={4} p={4} bg="white" borderWidth={1} borderColor="border.default" borderRadius="md">
               <Text mb={3} fontSize="xs" color="fg.muted" lineHeight={1.7}>
-                初回の提出時、または利用規約・プライバシーポリシーに大きな変更があった場合のみ、確認をお願いしています。
+                初めての提出時や、規約の大きな変更があったときのみ確認をお願いしています。
               </Text>
               <Checkbox.Root
                 colorPalette="teal"

--- a/src/components/ui/ErrorBoundary/index.tsx
+++ b/src/components/ui/ErrorBoundary/index.tsx
@@ -4,8 +4,8 @@ import { LuTriangleAlert } from "react-icons/lu";
 import { Button } from "@/src/components/ui/Button";
 import { Empty } from "@/src/components/ui/Empty";
 
-const FALLBACK_DESCRIPTION = "一時的な問題が発生しました。ページを再読み込みして、もう一度お試しください。";
-const NETWORK_ERROR_DESCRIPTION = "通信が不安定な可能性があります。ページを再読み込みして、もう一度お試しください。";
+const FALLBACK_DESCRIPTION = "一時的な問題が発生しました。ページを再読み込みしてください。";
+const NETWORK_ERROR_DESCRIPTION = "通信が不安定なようです。ページを再読み込みしてください。";
 
 type DefaultErrorFallbackProps = {
   error: unknown;

--- a/src/pages/staff-shift-submit/index.tsx
+++ b/src/pages/staff-shift-submit/index.tsx
@@ -30,7 +30,7 @@ export function StaffShiftSubmitPage({ token }: Props) {
           <Empty
             icon={LuTriangleAlert}
             title="アクセスが集中しています"
-            description={"少し時間をおいて、\nもう一度開いてください。"}
+            description={"少し時間をおいて、\nもう一度お試しください。"}
             tone="warning"
           />
         </StaffCenteredContent>

--- a/src/pages/staff-shift-view/index.tsx
+++ b/src/pages/staff-shift-view/index.tsx
@@ -26,7 +26,7 @@ export function StaffShiftViewRoutePage({ token }: Props) {
           <Empty
             icon={LuTriangleAlert}
             title="アクセスが集中しています"
-            description={"少し時間をおいて、\nもう一度開いてください。"}
+            description={"少し時間をおいて、\nもう一度お試しください。"}
             tone="warning"
           />
         </StaffCenteredContent>


### PR DESCRIPTION
- ErrorBoundary: 再読み込み案内の重複表現を簡潔化
- ConfirmShiftContent: 本文と対象行の重複を解消、スタッフの反復を整理
- SubmitFormView: 法的同意の注記を簡潔化
- LineCallbackPage: リンク再送の二重依頼表現を修正、待機表現を統一
- staff-shift-submit/view: 再試行文言を「もう一度お試しください」に統一
- メールアドレス形式エラーをフロント表現に統一（テスト含む）

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019toqttR9a8k6uWQFyNQ3ZZ