### PR TITLE
refactor(convex): submissionPattern を required に Narrow しフォールバックを撤去

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -55,6 +55,8 @@ import type * as migrations_m003_recruitments_add_submission_pattern from "../mi
 import type * as migrations_m004_notification_failure_inbox_backfill from "../migrations/m004_notification_failure_inbox_backfill.js";
 import type * as migrations_m005_shop_billing_states_backfill_free from "../migrations/m005_shop_billing_states_backfill_free.js";
 import type * as migrations_m006_notification_failure_inbox_collapse_duplicates from "../migrations/m006_notification_failure_inbox_collapse_duplicates.js";
+import type * as migrations_m007_shops_strip_legacy_shift_times from "../migrations/m007_shops_strip_legacy_shift_times.js";
+import type * as migrations_m008_recruitments_strip_legacy_shift_times from "../migrations/m008_recruitments_strip_legacy_shift_times.js";
 import type * as notification_actions from "../notification/actions.js";
 import type * as notification_confirmationSnapshots from "../notification/confirmationSnapshots.js";
 import type * as notification_failureRecording from "../notification/failureRecording.js";
@@ -152,6 +154,8 @@ declare const fullApi: ApiFromModules<{
   "migrations/m004_notification_failure_inbox_backfill": typeof migrations_m004_notification_failure_inbox_backfill;
   "migrations/m005_shop_billing_states_backfill_free": typeof migrations_m005_shop_billing_states_backfill_free;
   "migrations/m006_notification_failure_inbox_collapse_duplicates": typeof migrations_m006_notification_failure_inbox_collapse_duplicates;
+  "migrations/m007_shops_strip_legacy_shift_times": typeof migrations_m007_shops_strip_legacy_shift_times;
+  "migrations/m008_recruitments_strip_legacy_shift_times": typeof migrations_m008_recruitments_strip_legacy_shift_times;
   "notification/actions": typeof notification_actions;
   "notification/confirmationSnapshots": typeof notification_confirmationSnapshots;
   "notification/failureRecording": typeof notification_failureRecording;

--- a/convex/_lib/submissionPattern.ts
+++ b/convex/_lib/submissionPattern.ts
@@ -98,14 +98,3 @@ export function normalizeSubmissionPattern(pattern: ShiftSubmissionPattern | und
     options: normalized.sort(compareShiftTypeOptionsByTime).map((option, index) => ({ ...option, sortOrder: index })),
   };
 }
-
-export function getSubmissionPattern(
-  pattern?: ShiftSubmissionPattern,
-  legacyTimeRange?: { startTime?: string; endTime?: string },
-): ShiftSubmissionPattern {
-  if (pattern) return pattern;
-  if (legacyTimeRange?.startTime !== undefined && legacyTimeRange.endTime !== undefined) {
-    return { kind: "time", startTime: legacyTimeRange.startTime, endTime: legacyTimeRange.endTime };
-  }
-  return DEFAULT_SUBMISSION_PATTERN;
-}

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -4,7 +4,6 @@ import { ConvexError } from "convex/values";
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { todayJST } from "../_lib/dateFormat";
 import { authenticatedQuery } from "../_lib/functions";
-import { getSubmissionPattern } from "../_lib/submissionPattern";
 import {
   DASHBOARD_CURRENT_RECRUITMENT_SCAN_LIMIT,
   DASHBOARD_RECRUITMENT_CANDIDATE_GROUP_LIMIT,
@@ -141,10 +140,7 @@ export const getDashboardShop = authenticatedQuery({
     return {
       name: shop.name,
       regularClosedDays: shop.regularClosedDays,
-      submissionPattern: getSubmissionPattern(shop.submissionPattern, {
-        startTime: shop.shiftStartTime,
-        endTime: shop.shiftEndTime,
-      }),
+      submissionPattern: shop.submissionPattern,
     };
   },
 });

--- a/convex/migrations/index.ts
+++ b/convex/migrations/index.ts
@@ -22,4 +22,6 @@ export const run = migrations.runner([
   internal.migrations.m004_notification_failure_inbox_backfill.migration,
   internal.migrations.m005_shop_billing_states_backfill_free.migration,
   internal.migrations.m006_notification_failure_inbox_collapse_duplicates.migration,
+  internal.migrations.m007_shops_strip_legacy_shift_times.migration,
+  internal.migrations.m008_recruitments_strip_legacy_shift_times.migration,
 ]);

--- a/convex/migrations/m007_shops_strip_legacy_shift_times.ts
+++ b/convex/migrations/m007_shops_strip_legacy_shift_times.ts
@@ -1,0 +1,16 @@
+import { migrations } from "./index";
+
+/**
+ * shops の legacy 時間帯フィールド shiftStartTime/shiftEndTime を削除する。
+ *
+ * submissionPattern への移行（m002）完走後、これらは読み取りに使われなくなった。
+ * 本マイグレーションで全ドキュメントから値を unset し、後続 PR の schema narrow
+ * （フィールド定義の削除）を安全にする。
+ */
+export const migration = migrations.define({
+  table: "shops",
+  migrateOne: async (_ctx, doc) => {
+    if (doc.shiftStartTime === undefined && doc.shiftEndTime === undefined) return;
+    return { shiftStartTime: undefined, shiftEndTime: undefined };
+  },
+});

--- a/convex/migrations/m008_recruitments_strip_legacy_shift_times.ts
+++ b/convex/migrations/m008_recruitments_strip_legacy_shift_times.ts
@@ -1,0 +1,16 @@
+import { migrations } from "./index";
+
+/**
+ * recruitments の legacy 時間帯スナップショット shiftStartTime/shiftEndTime を削除する。
+ *
+ * submissionPattern への移行（m003）完走後、これらは読み取りに使われなくなった。
+ * 本マイグレーションで全ドキュメントから値を unset し、後続 PR の schema narrow
+ * （フィールド定義の削除）を安全にする。
+ */
+export const migration = migrations.define({
+  table: "recruitments",
+  migrateOne: async (_ctx, doc) => {
+    if (doc.shiftStartTime === undefined && doc.shiftEndTime === undefined) return;
+    return { shiftStartTime: undefined, shiftEndTime: undefined };
+  },
+});

--- a/convex/notification/actions.test.ts
+++ b/convex/notification/actions.test.ts
@@ -32,8 +32,7 @@ describe("notification/actions", () => {
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
-        shiftStartTime: "09:00",
-        shiftEndTime: "22:00",
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
     });
 

--- a/convex/notification/queries.ts
+++ b/convex/notification/queries.ts
@@ -10,7 +10,6 @@ import {
   getSubmitLinkCutoff,
   todayJST,
 } from "../_lib/dateFormat";
-import { getSubmissionPattern } from "../_lib/submissionPattern";
 import { buildShiftTimeLabel } from "../_lib/time";
 import { DASHBOARD_CURRENT_RECRUITMENT_SCAN_LIMIT, OPEN_RECRUITMENT_NOTIFICATION_LIMIT } from "../constants";
 import { getStaffLineAccount } from "../line/service";
@@ -46,10 +45,7 @@ async function buildConfirmationStaffEntries(
 ): Promise<ConfirmationStaffEntry[]> {
   const dates = generateDateRange(recruitment.periodStart, recruitment.periodEnd);
   const shopClosedDateSet = new Set(recruitment.shopClosedDates ?? []);
-  const submissionPattern = getSubmissionPattern(recruitment.submissionPattern, {
-    startTime: recruitment.shiftStartTime,
-    endTime: recruitment.shiftEndTime,
-  });
+  const submissionPattern = recruitment.submissionPattern;
 
   return Promise.all(
     staffs.map(async (staff) => {

--- a/convex/notificationOutbox/mutations.test.ts
+++ b/convex/notificationOutbox/mutations.test.ts
@@ -896,6 +896,7 @@ describe("notificationOutbox", () => {
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
     });
     const failureId = await t.run(async (ctx) => {
@@ -978,6 +979,7 @@ describe("notificationOutbox", () => {
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
       const now = Date.now();
       const currentFailureId = await ctx.db.insert("notificationFailureInbox", {
@@ -1010,6 +1012,7 @@ describe("notificationOutbox", () => {
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
       const otherFailureId = await ctx.db.insert("notificationFailureInbox", {
         failureKey: "enqueue_preparation:test:bulk-other",

--- a/convex/notificationOutbox/queries.test.ts
+++ b/convex/notificationOutbox/queries.test.ts
@@ -40,6 +40,7 @@ describe("notificationOutbox/queries", () => {
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
       const oldFailureId = await insertFailure(ctx, {
         shopId: primary.shopId,

--- a/convex/recruitment/mutations.ts
+++ b/convex/recruitment/mutations.ts
@@ -2,7 +2,6 @@ import { ConvexError, v } from "convex/values";
 import { internal } from "../_generated/api";
 import { generateDateRange, getReminderScheduledAt, todayJST } from "../_lib/dateFormat";
 import { managerMutation } from "../_lib/functions";
-import { getSubmissionPattern } from "../_lib/submissionPattern";
 import { isValidIsoDateString } from "../_lib/validation";
 import { RECRUITMENT_DUPLICATE_SCAN_LIMIT } from "../constants";
 import { createRecruitmentSchema } from "./schemas";
@@ -87,10 +86,7 @@ export const createRecruitment = managerMutation({
       status: "open",
       isDeleted: false,
       // 作成時点の店舗シフト時間帯をスナップショットとして保存
-      submissionPattern: getSubmissionPattern(ctx.shop.submissionPattern, {
-        startTime: ctx.shop.shiftStartTime,
-        endTime: ctx.shop.shiftEndTime,
-      }),
+      submissionPattern: ctx.shop.submissionPattern,
       ...(shouldScheduleReminder ? { reminderScheduledAt } : {}),
     });
     const activeStaffs = await ctx.db

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,7 +19,7 @@ const schema = defineSchema({
   // ========================================
   shops: defineTable({
     name: v.string(),
-    // submissionPattern 移行前の店舗時間帯。全環境で移行完了するまで optional で受ける。
+    // submissionPattern 移行前の店舗時間帯（legacy）。m007_shops_strip_legacy_shift_times 完走後にフィールド削除する。
     shiftStartTime: v.optional(v.string()),
     shiftEndTime: v.optional(v.string()),
     regularClosedDays: v.array(
@@ -33,7 +33,7 @@ const schema = defineSchema({
         v.literal("sat"),
       ),
     ),
-    submissionPattern: v.optional(submissionPatternValidator),
+    submissionPattern: submissionPatternValidator,
     isDeleted: v.boolean(),
   }),
 
@@ -169,10 +169,10 @@ const schema = defineSchema({
     status: v.union(v.literal("open"), v.literal("confirmed")),
     confirmedAt: v.optional(v.number()), // Unix ms
     isDeleted: v.boolean(),
-    // submissionPattern 移行前の募集作成時点スナップショット。全環境で移行完了するまで optional で受ける。
+    // submissionPattern 移行前の募集作成時点スナップショット（legacy）。m008_recruitments_strip_legacy_shift_times 完走後にフィールド削除する。
     shiftStartTime: v.optional(v.string()),
     shiftEndTime: v.optional(v.string()),
-    submissionPattern: v.optional(submissionPatternValidator),
+    submissionPattern: submissionPatternValidator,
     // 未提出者への自動催促通知を予約した時刻。既存募集には付与せず、作成時に未来時刻のものだけ保存する。
     reminderScheduledAt: v.optional(v.number()),
     // 未提出者への自動催促通知を実際に送信した時刻（UI表示・二重送信防止用）

--- a/convex/shiftBoard/mutations.ts
+++ b/convex/shiftBoard/mutations.ts
@@ -2,7 +2,6 @@ import { ConvexError, v } from "convex/values";
 import { internal } from "../_generated/api";
 import { isPastShiftPeriod } from "../_lib/dateFormat";
 import { managerMutation } from "../_lib/functions";
-import { getSubmissionPattern } from "../_lib/submissionPattern";
 import { SHIFT_ASSIGNMENT_LIMIT, SHIFT_BOARD_STAFF_LIMIT } from "../constants";
 import { buildConfirmationSnapshotsForStaffs } from "../notification/confirmationSnapshots";
 import { ensureDefaultPosition } from "../position/service";
@@ -34,10 +33,7 @@ export const saveShiftAssignments = managerMutation({
       throw new ConvexError(PAST_SHIFT_SAVE_ERROR);
     }
 
-    const submissionPattern = getSubmissionPattern(recruitment.submissionPattern, {
-      startTime: recruitment.shiftStartTime,
-      endTime: recruitment.shiftEndTime,
-    });
+    const submissionPattern = recruitment.submissionPattern;
     // 違反は全件収集して構造化エラーで返し、フロントのエラー一覧UIにマップする
     const issues = validateShiftAssignments({
       assignments: args.assignments,

--- a/convex/shiftBoard/queries.test.ts
+++ b/convex/shiftBoard/queries.test.ts
@@ -326,34 +326,6 @@ describe("shiftBoard/queries", () => {
     });
   });
 
-  it("migration前の募集時間スナップショットをsubmissionPatternの代わりに読める", async () => {
-    const t = convexTest(schema, modules);
-    const recruitmentId = await t.run(async (ctx) => {
-      const { shopId } = await seedManagerShop(ctx, {
-        subject: "manager_legacy_time_snapshot",
-        shopName: "テスト店舗",
-      });
-      return await ctx.db.insert("recruitments", {
-        shopId,
-        periodStart: "2026-04-01",
-        periodEnd: "2026-04-07",
-        deadline: "2026-03-28",
-        shopClosedDates: [],
-        status: "open",
-        isDeleted: false,
-        shiftStartTime: "06:30",
-        shiftEndTime: "21:30",
-      });
-    });
-
-    const result = await t
-      .withIdentity({ subject: "manager_legacy_time_snapshot" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
-
-    expect(result?.timeRange.editableStartMinutes).toBe(390);
-    expect(result?.timeRange.editableEndMinutes).toBe(1290);
-  });
-
   it("募集スナップショットの時間指定を店舗設定より優先する", async () => {
     const t = convexTest(schema, modules);
     const recruitmentId = await t.run(async (ctx) => {

--- a/convex/shiftBoard/queries.ts
+++ b/convex/shiftBoard/queries.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { managerQuery } from "../_lib/functions";
-import { getSubmissionPattern, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import {
   SHIFT_ASSIGNMENT_LIMIT,
@@ -69,10 +69,7 @@ export const getShiftBoardData = managerQuery({
       (shiftAssignments.length > 0 ? Math.max(...shiftAssignments.map((a) => a._creationTime)) : null);
 
     // TimeRange.start/end は「時」の数値を期待（9, 22 等）
-    const submissionPattern = getSubmissionPattern(recruitment.submissionPattern, {
-      startTime: recruitment.shiftStartTime,
-      endTime: recruitment.shiftEndTime,
-    });
+    const submissionPattern = recruitment.submissionPattern;
     const { startTime: startTimeStr, endTime: endTimeStr } = getBoardTimeRange(submissionPattern);
     const editableStartMinutes = timeToMinutes(startTimeStr);
     const editableEndMinutes = timeToMinutes(endTimeStr);

--- a/convex/shiftSubmission/mutations.test.ts
+++ b/convex/shiftSubmission/mutations.test.ts
@@ -39,7 +39,7 @@ async function setupTestData(
       shopClosedDates: options?.shopClosedDates ?? [],
       status: "open",
       isDeleted: false,
-      submissionPattern: options?.submissionPattern,
+      submissionPattern: options?.submissionPattern ?? { kind: "time", startTime: "09:00", endTime: "22:00" },
     });
     const sessionToken = "test-session-token";
     await ctx.db.insert("sessions", {
@@ -111,6 +111,7 @@ describe("shiftSubmission/mutations", () => {
           shopClosedDates: [],
           status: "open",
           isDeleted: false,
+          submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         }),
       );
 

--- a/convex/shiftSubmission/mutations.ts
+++ b/convex/shiftSubmission/mutations.ts
@@ -3,7 +3,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import { getDeadlineCutoff, getSubmitLinkCutoff } from "../_lib/dateFormat";
 import { staffSessionMutation } from "../_lib/functions";
 import { rateLimit } from "../_lib/rateLimits";
-import { getSubmissionPattern, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { hasCurrentStaffLegalConsent, recordStaffLegalConsent } from "../legal/service";
 import { type SubmitShiftSelection, submitShiftRequestsSchema, submitShiftSelectionSchema } from "./schemas";
@@ -175,10 +175,7 @@ export const submitShiftRequests = staffSessionMutation({
       throw new ConvexError("Deadline passed");
     }
 
-    const pattern = getSubmissionPattern(recruitment.submissionPattern, {
-      startTime: recruitment.shiftStartTime,
-      endTime: recruitment.shiftEndTime,
-    });
+    const pattern = recruitment.submissionPattern;
     const rawSubmission = args.submission ?? { kind: "time", requests: args.requests ?? [] };
     const parsed = submitShiftSelectionSchema.safeParse(rawSubmission);
     if (!parsed.success) {

--- a/convex/shiftSubmission/queries.test.ts
+++ b/convex/shiftSubmission/queries.test.ts
@@ -38,7 +38,7 @@ async function setupSubmissionPageData(
       shopClosedDates: [],
       status: "open",
       isDeleted: false,
-      submissionPattern: options?.submissionPattern,
+      submissionPattern: options?.submissionPattern ?? { kind: "time", startTime: "09:00", endTime: "22:00" },
     });
     const sessionToken = "query-history-session";
     await ctx.db.insert("sessions", {

--- a/convex/shiftSubmission/queries.ts
+++ b/convex/shiftSubmission/queries.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { getDeadlineCutoff, getSubmitLinkCutoff } from "../_lib/dateFormat";
 import { staffSessionQuery } from "../_lib/functions";
 import { getPreviousDateOnlyPattern, getPreviousWeeklyPattern } from "../_lib/previousWeeklyPattern";
-import { getSubmissionPattern, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { getLegalDocumentsForAudience } from "../legal/documents";
 import { hasCurrentStaffLegalConsent } from "../legal/service";
@@ -82,10 +82,7 @@ export const getSubmissionPageData = staffSessionQuery({
     }
 
     const isBeforeDeadline = now < getDeadlineCutoff(recruitment.deadline);
-    const submissionPattern = getSubmissionPattern(recruitment.submissionPattern, {
-      startTime: recruitment.shiftStartTime,
-      endTime: recruitment.shiftEndTime,
-    });
+    const submissionPattern = recruitment.submissionPattern;
 
     const staffId = ctx.staff._id;
     const [submission, slots] = await Promise.all([

--- a/convex/shiftView/queries.ts
+++ b/convex/shiftView/queries.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { formatPeriodLabel } from "../_lib/dateFormat";
 import { staffSessionQuery } from "../_lib/functions";
-import { getSubmissionPattern, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { SHIFT_ASSIGNMENT_LIMIT, SHIFT_BOARD_STAFF_LIMIT, SHIFT_BOARD_TIME_UNIT_MINUTES } from "../constants";
 
@@ -50,10 +50,7 @@ export const getShiftViewData = staffSessionQuery({
         .take(50),
     ]);
 
-    const submissionPattern = getSubmissionPattern(recruitment.submissionPattern, {
-      startTime: recruitment.shiftStartTime,
-      endTime: recruitment.shiftEndTime,
-    });
+    const submissionPattern = recruitment.submissionPattern;
     const { startTime: startTimeStr, endTime: endTimeStr } = getViewTimeRange(submissionPattern);
     const editableStartMinutes = timeToMinutes(startTimeStr);
     const editableEndMinutes = timeToMinutes(endTimeStr);

--- a/convex/testing.ts
+++ b/convex/testing.ts
@@ -5,7 +5,7 @@ import { internalMutation, internalQuery, type MutationCtx, type QueryCtx } from
 import { APP_URL } from "./_lib/config";
 import { getReminderScheduledAt, getSubmitLinkCutoff } from "./_lib/dateFormat";
 import { buildLineAuthorizeUrl } from "./_lib/lineClient";
-import { getSubmissionPattern, normalizeSubmissionPattern, submissionPatternValidator } from "./_lib/submissionPattern";
+import { normalizeSubmissionPattern, submissionPatternValidator } from "./_lib/submissionPattern";
 import { generateUUID } from "./_lib/uuid";
 import { LEGAL_CONSENT_TOKEN_TTL_MS, LINE_LINK_TOKEN_TTL_MS, MAGIC_LINK_DEFAULT_TTL_MS } from "./constants";
 import { getLegalConsentVersions, type LegalAudience } from "./legal/documents";
@@ -602,10 +602,7 @@ export const seedPaginationTestData = internalMutation({
         shopClosedDates: [],
         status: "open",
         isDeleted: false,
-        submissionPattern: getSubmissionPattern(shop.submissionPattern, {
-          startTime: shop.shiftStartTime,
-          endTime: shop.shiftEndTime,
-        }),
+        submissionPattern: shop.submissionPattern,
       });
     }
 


### PR DESCRIPTION
m002/m003 のバックフィル完走により submissionPattern は全 shop/recruitment に
必ず存在するため、Widen フェーズの名残だった getSubmissionPattern() の
legacy 時間帯フォールバックは実行時デッドコードになっていた。

- schema: shops/recruitments の submissionPattern を v.optional から required へ
- _lib/submissionPattern: getSubmissionPattern を削除（DEFAULT/normalize は残置）
- 全読み取り箇所を recruitment/shop.submissionPattern の直接参照へ置換
- submissionPattern 必須化で壊れるテストを修正、legacy フォールバック専用テストを削除

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SNzLyC3RUAhY4QqEKEZhev