### PR TITLE
refactor(convex): submissionPattern を Narrow し legacy 時間帯フィールドを撤去

### DIFF
--- a/convex/migrations/m001_recruitments_add_shift_times.ts
+++ b/convex/migrations/m001_recruitments_add_shift_times.ts
@@ -7,16 +7,25 @@ import { migrations } from "./index";
  * 狙い: 店舗設定変更後も、過去の募集の時間軸は作成時点のまま固定される。
  * 既存レコードには「作成時点の値」が残っていないため、移行時点の店舗値を
  * 近似値として採用する（移行以前の履歴はない前提）。
+ *
+ * NOTE: shiftStartTime/shiftEndTime は m007/m008 完走後に schema から削除済み。
+ *   本マイグレーションは実行完了済みの履歴で、runner は完了済みを再実行しないため、
+ *   削除済みフィールドへの参照は型ビュー経由で読み書きしてコンパイルのみ通す。
  */
+type LegacyShiftTimes = { shiftStartTime?: string; shiftEndTime?: string };
+
 export const migration = migrations.define({
   table: "recruitments",
   migrateOne: async (ctx, doc) => {
-    if (doc.shiftStartTime !== undefined && doc.shiftEndTime !== undefined) return;
+    const docLegacy = doc as typeof doc & LegacyShiftTimes;
+    if (docLegacy.shiftStartTime !== undefined && docLegacy.shiftEndTime !== undefined) return;
     const shop = await ctx.db.get(doc.shopId);
-    if (shop?.shiftStartTime === undefined || shop.shiftEndTime === undefined) return;
-    await ctx.db.patch(doc._id, {
-      shiftStartTime: shop.shiftStartTime,
-      shiftEndTime: shop.shiftEndTime,
-    });
+    const shopLegacy = shop as (typeof shop & LegacyShiftTimes) | null;
+    if (shopLegacy?.shiftStartTime === undefined || shopLegacy.shiftEndTime === undefined) return;
+    const update: LegacyShiftTimes = {
+      shiftStartTime: shopLegacy.shiftStartTime,
+      shiftEndTime: shopLegacy.shiftEndTime,
+    };
+    await ctx.db.patch(doc._id, update as Partial<typeof doc>);
   },
 });

--- a/convex/migrations/m002_shops_add_submission_pattern.ts
+++ b/convex/migrations/m002_shops_add_submission_pattern.ts
@@ -1,13 +1,18 @@
 import { DEFAULT_SUBMISSION_PATTERN } from "../_lib/submissionPattern";
 import { migrations } from "./index";
 
+// shiftStartTime/shiftEndTime は m007 完走後に schema から削除済み。
+// 本マイグレーションは実行完了済みの履歴で、削除済みフィールドは型ビュー経由で読む。
+type LegacyShiftTimes = { shiftStartTime?: string; shiftEndTime?: string };
+
 export const migration = migrations.define({
   table: "shops",
   migrateOne: async (_ctx, doc) => {
     if (doc.submissionPattern !== undefined) return;
-    if (doc.shiftStartTime !== undefined && doc.shiftEndTime !== undefined) {
+    const { shiftStartTime, shiftEndTime } = doc as typeof doc & LegacyShiftTimes;
+    if (shiftStartTime !== undefined && shiftEndTime !== undefined) {
       return {
-        submissionPattern: { kind: "time" as const, startTime: doc.shiftStartTime, endTime: doc.shiftEndTime },
+        submissionPattern: { kind: "time" as const, startTime: shiftStartTime, endTime: shiftEndTime },
       };
     }
     return { submissionPattern: DEFAULT_SUBMISSION_PATTERN };

--- a/convex/migrations/m003_recruitments_add_submission_pattern.ts
+++ b/convex/migrations/m003_recruitments_add_submission_pattern.ts
@@ -1,13 +1,22 @@
 import { DEFAULT_SUBMISSION_PATTERN } from "../_lib/submissionPattern";
 import { migrations } from "./index";
 
+// shiftStartTime/shiftEndTime は m007/m008 完走後に schema から削除済み。
+// 本マイグレーションは実行完了済みの履歴で、削除済みフィールドは型ビュー経由で読む。
+type LegacyShiftTimes = { shiftStartTime?: string; shiftEndTime?: string };
+
 export const migration = migrations.define({
   table: "recruitments",
   migrateOne: async (ctx, doc) => {
     if (doc.submissionPattern !== undefined) return;
-    if (doc.shiftStartTime !== undefined && doc.shiftEndTime !== undefined) {
+    const docLegacy = doc as typeof doc & LegacyShiftTimes;
+    if (docLegacy.shiftStartTime !== undefined && docLegacy.shiftEndTime !== undefined) {
       return {
-        submissionPattern: { kind: "time" as const, startTime: doc.shiftStartTime, endTime: doc.shiftEndTime },
+        submissionPattern: {
+          kind: "time" as const,
+          startTime: docLegacy.shiftStartTime,
+          endTime: docLegacy.shiftEndTime,
+        },
       };
     }
 
@@ -15,9 +24,14 @@ export const migration = migrations.define({
     if (shop?.submissionPattern !== undefined) {
       return { submissionPattern: shop.submissionPattern };
     }
-    if (shop?.shiftStartTime !== undefined && shop.shiftEndTime !== undefined) {
+    const shopLegacy = shop as (typeof shop & LegacyShiftTimes) | null;
+    if (shopLegacy?.shiftStartTime !== undefined && shopLegacy.shiftEndTime !== undefined) {
       return {
-        submissionPattern: { kind: "time" as const, startTime: shop.shiftStartTime, endTime: shop.shiftEndTime },
+        submissionPattern: {
+          kind: "time" as const,
+          startTime: shopLegacy.shiftStartTime,
+          endTime: shopLegacy.shiftEndTime,
+        },
       };
     }
 

--- a/convex/migrations/m007_shops_strip_legacy_shift_times.ts
+++ b/convex/migrations/m007_shops_strip_legacy_shift_times.ts
@@ -4,13 +4,20 @@ import { migrations } from "./index";
  * shops の legacy 時間帯フィールド shiftStartTime/shiftEndTime を削除する。
  *
  * submissionPattern への移行（m002）完走後、これらは読み取りに使われなくなった。
- * 本マイグレーションで全ドキュメントから値を unset し、後続 PR の schema narrow
+ * 本マイグレーションで全ドキュメントから値を unset し、schema narrow
  * （フィールド定義の削除）を安全にする。
+ *
+ * NOTE: 本 PR で schema から該当フィールドを削除済み。実行完了済みの履歴であり
+ *   runner は完了済みを再実行しないため、削除済みフィールドは型ビュー経由で扱う。
  */
+type LegacyShiftTimes = { shiftStartTime?: string; shiftEndTime?: string };
+
 export const migration = migrations.define({
   table: "shops",
-  migrateOne: async (_ctx, doc) => {
-    if (doc.shiftStartTime === undefined && doc.shiftEndTime === undefined) return;
-    return { shiftStartTime: undefined, shiftEndTime: undefined };
+  migrateOne: (_ctx, doc) => {
+    const { shiftStartTime, shiftEndTime } = doc as typeof doc & LegacyShiftTimes;
+    if (shiftStartTime === undefined && shiftEndTime === undefined) return;
+    const cleared: LegacyShiftTimes = { shiftStartTime: undefined, shiftEndTime: undefined };
+    return cleared as Partial<typeof doc>;
   },
 });

--- a/convex/migrations/m008_recruitments_strip_legacy_shift_times.ts
+++ b/convex/migrations/m008_recruitments_strip_legacy_shift_times.ts
@@ -4,13 +4,20 @@ import { migrations } from "./index";
  * recruitments の legacy 時間帯スナップショット shiftStartTime/shiftEndTime を削除する。
  *
  * submissionPattern への移行（m003）完走後、これらは読み取りに使われなくなった。
- * 本マイグレーションで全ドキュメントから値を unset し、後続 PR の schema narrow
+ * 本マイグレーションで全ドキュメントから値を unset し、schema narrow
  * （フィールド定義の削除）を安全にする。
+ *
+ * NOTE: 本 PR で schema から該当フィールドを削除済み。実行完了済みの履歴であり
+ *   runner は完了済みを再実行しないため、削除済みフィールドは型ビュー経由で扱う。
  */
+type LegacyShiftTimes = { shiftStartTime?: string; shiftEndTime?: string };
+
 export const migration = migrations.define({
   table: "recruitments",
-  migrateOne: async (_ctx, doc) => {
-    if (doc.shiftStartTime === undefined && doc.shiftEndTime === undefined) return;
-    return { shiftStartTime: undefined, shiftEndTime: undefined };
+  migrateOne: (_ctx, doc) => {
+    const { shiftStartTime, shiftEndTime } = doc as typeof doc & LegacyShiftTimes;
+    if (shiftStartTime === undefined && shiftEndTime === undefined) return;
+    const cleared: LegacyShiftTimes = { shiftStartTime: undefined, shiftEndTime: undefined };
+    return cleared as Partial<typeof doc>;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,9 +19,6 @@ const schema = defineSchema({
   // ========================================
   shops: defineTable({
     name: v.string(),
-    // submissionPattern 移行前の店舗時間帯（legacy）。m007_shops_strip_legacy_shift_times 完走後にフィールド削除する。
-    shiftStartTime: v.optional(v.string()),
-    shiftEndTime: v.optional(v.string()),
     regularClosedDays: v.array(
       v.union(
         v.literal("sun"),
@@ -169,9 +166,6 @@ const schema = defineSchema({
     status: v.union(v.literal("open"), v.literal("confirmed")),
     confirmedAt: v.optional(v.number()), // Unix ms
     isDeleted: v.boolean(),
-    // submissionPattern 移行前の募集作成時点スナップショット（legacy）。m008_recruitments_strip_legacy_shift_times 完走後にフィールド削除する。
-    shiftStartTime: v.optional(v.string()),
-    shiftEndTime: v.optional(v.string()),
     submissionPattern: submissionPatternValidator,
     // 未提出者への自動催促通知を予約した時刻。既存募集には付与せず、作成時に未来時刻のものだけ保存する。
     reminderScheduledAt: v.optional(v.number()),


### PR DESCRIPTION
## 概要

migration 完了後に不要になった optional chaining / フォールバックを整理し（Widen→Migrate→Narrow の Narrow）、legacy フィールドまで撤去します。phase1・phase2 を 1 ブランチに集約しています。

### phase1: submissionPattern の Narrow（デプロイ可能）
- `convex/schema.ts`: `shops` / `recruitments` の `submissionPattern` を `v.optional` → required
- `convex/_lib/submissionPattern.ts`: フォールバック解決関数 `getSubmissionPattern` を削除
- 読み取り 8 箇所 + seed を `X.submissionPattern` の直接参照へ置換
- 必須化で壊れるテスト修正、legacy フォールバック専用テストを削除
- `m007` / `m008`: 未使用化した legacy `shiftStartTime` / `shiftEndTime` を全ドキュメントから unset

### phase2: legacy フィールドの schema 削除
- `convex/schema.ts`: `shops` / `recruitments` から `shiftStartTime` / `shiftEndTime` を削除
- `m001`〜`m003` / `m007` / `m008`: 削除済みフィールドを参照する実行済み履歴 migration のため、型ビュー `LegacyShiftTimes` 経由で読み書きしコンパイルを通す（runner は完了済みを再実行しないため実行時には到達しない）

## 🚨 デプロイ順序（このまま 1 デプロイでマージすると失敗します）

`convex deploy` は**デプロイ時に既存ドキュメントを新スキーマで全件検証**し、その**後**に `migrations/index:run` が走ります。本ブランチは「m007/m008 の追加（migrate）」と「schema からのフィールド削除（narrow）」を同時に含むため、**1 回のデプロイでマージすると**、m007/m008 が未実行のうちにスキーマからフィールドが消え、フィールドが残る既存ドキュメントが検証で弾かれて**デプロイが失敗します**。

安全にデプロイするには **2 回に分ける**必要があります。いずれかで対応してください:

- **方法A（推奨・分割デプロイ）**: まず phase2 の schema 削除コミット（`d431a40`）を含まない状態（= phase1 まで）を先にデプロイ → `pnpm convex:migrate:status` で m007/m008 が `state: done` を確認 → その後 schema 削除コミットをデプロイ。
- **方法B**: 本ブランチを 2 PR に分け直す（phase1 を先にマージ→完走確認→phase2 をマージ）。

draft にしているのは、この順序管理を実施するまでマージしないためです。

## 検証

- `pnpm type-check` ✅ / `pnpm lint` ✅
- Convex tests 471 passed ✅ / logic tests 377 passed ✅
- `Doc` 型は `_generated/dataModel.d.ts` が `typeof schema` から導出するため、schema 編集が即型へ反映されることを確認（型チェックは stale ではない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNzLyC3RUAhY4QqEKEZhev)_