### PR TITLE
feat(staff-submit): シフト提出完了画面に提出画面へ戻るボタンを追加

### DIFF
--- a/src/pages/staff-shift-submit-completed/index.tsx
+++ b/src/pages/staff-shift-submit-completed/index.tsx
@@ -1,5 +1,7 @@
-import { LuCheck } from "react-icons/lu";
+import { useCanGoBack, useRouter } from "@tanstack/react-router";
+import { LuArrowLeft, LuCheck } from "react-icons/lu";
 import { StaffCenteredContent, StaffLayout } from "@/src/components/templates/StaffLayout";
+import { Button } from "@/src/components/ui/Button";
 import { Empty } from "@/src/components/ui/Empty";
 
 type Props = {
@@ -7,6 +9,9 @@ type Props = {
 };
 
 export function StaffShiftSubmitCompletedPage({ shopName = "シフト提出" }: Props) {
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+
   return (
     <StaffLayout shopName={shopName}>
       <StaffCenteredContent>
@@ -19,6 +24,21 @@ export function StaffShiftSubmitCompletedPage({ shopName = "シフト提出" }: 
           size="lg"
           bg="white"
           px={4}
+          action={
+            canGoBack ? (
+              <Button
+                variant="outline"
+                colorPalette="teal"
+                size="md"
+                borderRadius="lg"
+                px={6}
+                onClick={() => router.history.back()}
+              >
+                <LuArrowLeft />
+                シフト提出画面に戻る
+              </Button>
+            ) : undefined
+          }
         />
       </StaffCenteredContent>
     </StaffLayout>


### PR DESCRIPTION
提出完了後、入力内容を修正したいスタッフが1つ前のシフト提出画面に
戻れるよう、Empty の action にブラウザバックボタンを配置。
履歴がない場合（直接アクセス/リロード）は useCanGoBack で非表示にする。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WEZeoGYzfT2DyEJxNDQGZ6