### PR TITLE
feat(notification): 通知失敗の日次リマインダーをmanagerへ送る

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -68,6 +68,8 @@ import type * as notification_templates from "../notification/templates.js";
 import type * as notificationOutbox_actions from "../notificationOutbox/actions.js";
 import type * as notificationOutbox_enqueue from "../notificationOutbox/enqueue.js";
 import type * as notificationOutbox_failureIdentity from "../notificationOutbox/failureIdentity.js";
+import type * as notificationOutbox_failureReminderActions from "../notificationOutbox/failureReminderActions.js";
+import type * as notificationOutbox_failureReminderQueries from "../notificationOutbox/failureReminderQueries.js";
 import type * as notificationOutbox_failureResend from "../notificationOutbox/failureResend.js";
 import type * as notificationOutbox_mutations from "../notificationOutbox/mutations.js";
 import type * as notificationOutbox_queries from "../notificationOutbox/queries.js";
@@ -167,6 +169,8 @@ declare const fullApi: ApiFromModules<{
   "notificationOutbox/actions": typeof notificationOutbox_actions;
   "notificationOutbox/enqueue": typeof notificationOutbox_enqueue;
   "notificationOutbox/failureIdentity": typeof notificationOutbox_failureIdentity;
+  "notificationOutbox/failureReminderActions": typeof notificationOutbox_failureReminderActions;
+  "notificationOutbox/failureReminderQueries": typeof notificationOutbox_failureReminderQueries;
   "notificationOutbox/failureResend": typeof notificationOutbox_failureResend;
   "notificationOutbox/mutations": typeof notificationOutbox_mutations;
   "notificationOutbox/queries": typeof notificationOutbox_queries;

--- a/convex/_lib/shopManagerRecipients.ts
+++ b/convex/_lib/shopManagerRecipients.ts
@@ -1,0 +1,62 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { SHIFT_BOARD_STAFF_LIMIT } from "../constants";
+import { getStaffLineAccount } from "../line/service";
+
+type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
+
+export type ShopManagerRecipient = {
+  userId: Id<"users">;
+  name: string;
+  email: string;
+  lineUserId: string | undefined;
+  lineFollowing: boolean | undefined;
+};
+
+/**
+ * 店舗のマネージャー（shopMembers）を通知受信者として組み立てる。
+ * 論理削除・メール未設定のユーザーは除外し、マネージャー本人がスタッフとして
+ * LINE連携済みなら lineUserId / lineFollowing を付与する。
+ * マネージャー宛の日次ダイジェスト系通知（承認依頼・失敗リマインダー等）で共有する。
+ */
+export async function loadShopManagerRecipients(
+  ctx: DbCtx,
+  shopId: Id<"shops">,
+  managerLimit: number,
+): Promise<ShopManagerRecipient[]> {
+  const [members, activeStaffs] = await Promise.all([
+    ctx.db
+      .query("shopMembers")
+      .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+      .take(managerLimit),
+    ctx.db
+      .query("staffs")
+      .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+      .take(SHIFT_BOARD_STAFF_LIMIT),
+  ]);
+
+  const staffByUserId = new Map<Id<"users">, (typeof activeStaffs)[number]>();
+  for (const staff of activeStaffs) {
+    if (staff.userId) staffByUserId.set(staff.userId, staff);
+  }
+
+  const recipients = await Promise.all(
+    members.map(async (member) => {
+      const user = await ctx.db.get(member.userId);
+      if (!user || user.isDeleted || !user.email) return null;
+
+      const managerStaff = staffByUserId.get(user._id);
+      const lineAccount = managerStaff ? await getStaffLineAccount(ctx, managerStaff._id) : null;
+
+      return {
+        userId: user._id,
+        name: user.name,
+        email: user.email,
+        lineUserId: lineAccount?.lineUserId,
+        lineFollowing: lineAccount?.following,
+      };
+    }),
+  );
+
+  return recipients.filter((recipient): recipient is ShopManagerRecipient => recipient !== null);
+}

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -43,5 +43,10 @@ export const RECRUITMENT_PERIOD_DAYS_MAX = 62;
 // 承認依頼digestの通知期間。最新依頼からこの期間を過ぎたら通知しない（日次cronで最大3回）
 export const STAFF_REGISTRATION_DIGEST_WINDOW_MS = 3 * DAY_MS;
 
+// 失敗通知リマインダーの通知期間。最新の失敗からこの期間を過ぎたら通知しない（日次cronで最大3回）
+export const NOTIFICATION_FAILURE_REMINDER_WINDOW_MS = 3 * DAY_MS;
+export const NOTIFICATION_FAILURE_REMINDER_PENDING_PAGE_SIZE = 100;
+export const NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT = 20;
+
 export const DEFAULT_POSITION_NAME = "シフト";
 export const DEFAULT_POSITION_COLOR = "#3b82f6";

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -26,4 +26,11 @@ crons.cron(
   internal.staffRegistration.actions.sendOwnerDailyDigest,
 );
 
+// 通知失敗の再通知リマインダー（JST 17:00 = UTC 08:00）
+crons.cron(
+  "notification-failure-reminder-digest",
+  "0 8 * * *",
+  internal.notificationOutbox.failureReminderActions.sendFailureReminderDigest,
+);
+
 export default crons;

--- a/convex/notification/templates.ts
+++ b/convex/notification/templates.ts
@@ -434,6 +434,54 @@ export function buildStaffRegistrationOwnerDigestEmailHtml(
 </html>`;
 }
 
+export const NOTIFICATION_FAILURE_REMINDER_SUBJECT = "通知の送信に失敗しています";
+
+type NotificationFailureReminderParams = {
+  dashboardUrl: string;
+};
+
+export function buildNotificationFailureReminderLineText(params: NotificationFailureReminderParams): string {
+  return [
+    "通知の送信に失敗したスタッフがいます。",
+    "シフトリのダッシュボードを開いて、再通知してください。",
+    "",
+    withOpenExternalBrowser(params.dashboardUrl),
+  ].join("\n");
+}
+
+export function buildNotificationFailureReminderEmailHtml(
+  params: NotificationFailureReminderParams & { managerName: string },
+): string {
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"></head>
+<body style="margin:0;padding:0;background-color:#f7fafc;font-family:'Helvetica Neue',Arial,'Hiragino Kaku Gothic ProN',sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f7fafc;padding:24px 0;">
+    <tr><td align="center">
+      <table width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background-color:#ffffff;border-radius:8px;overflow:hidden;">
+        <tr><td style="background-color:#319795;padding:16px 24px;">
+          <span style="color:#ffffff;font-size:16px;font-weight:700;">シフトリ</span>
+        </td></tr>
+        <tr><td style="padding:32px 24px;">
+          <p style="margin:0 0 24px;font-size:15px;color:#1a202c;">${params.managerName}さん</p>
+          <p style="margin:0 0 24px;font-size:15px;color:#1a202c;">通知の送信に失敗したスタッフがいます。<br/>シフトリのダッシュボードを開いて、再通知してください。</p>
+
+          <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
+            <tr><td align="center">
+              <a href="${params.dashboardUrl}" style="display:inline-block;padding:12px 32px;background-color:#319795;color:#ffffff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;" rel="noreferrer">ダッシュボードを確認する</a>
+            </td></tr>
+          </table>
+
+          <hr style="border:none;border-top:1px solid #e2e8f0;margin:24px 0;" />
+          <p style="margin:0;font-size:12px;color:#a0aec0;">※ このメールに返信しても届きません。</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
 type StaffLegalConsentEmailParams = {
   staffName: string;
   shopName: string;

--- a/convex/notificationOutbox/actions.ts
+++ b/convex/notificationOutbox/actions.ts
@@ -44,10 +44,12 @@ export const processPending = internalAction({
             ...(errorName(e) ? { errorName: errorName(e) } : {}),
           });
         } else {
+          const suppressFailureInbox =
+            lastError === LINE_QUOTA_FALLBACK_ENQUEUED_MESSAGE || job.payload.suppressFailureInbox === true;
           await ctx.runMutation(internal.notificationOutbox.mutations.markFailed, {
             outboxId: job._id,
             lastError,
-            ...(lastError === LINE_QUOTA_FALLBACK_ENQUEUED_MESSAGE ? { suppressFailureInbox: true } : {}),
+            ...(suppressFailureInbox ? { suppressFailureInbox: true } : {}),
             ...(errorName(e) ? { errorName: errorName(e) } : {}),
           });
         }

--- a/convex/notificationOutbox/enqueue.ts
+++ b/convex/notificationOutbox/enqueue.ts
@@ -46,6 +46,8 @@ async function enqueueNotification(ctx: EnqueueCtx, input: EnqueueNotificationIn
 }
 
 async function recordEnqueueFailure(ctx: EnqueueCtx, input: EnqueueNotificationInput, e: unknown) {
+  // 失敗リマインダー等のメタ通知は、enqueue失敗時もInboxに記録しない
+  if (input.payload.suppressFailureInbox) return;
   try {
     await ctx.runMutation(internal.notificationOutbox.mutations.recordDeliveryEvent, {
       eventType: "enqueue_failed",

--- a/convex/notificationOutbox/failureReminderActions.ts
+++ b/convex/notificationOutbox/failureReminderActions.ts
@@ -1,0 +1,120 @@
+"use node";
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { ActionCtx } from "../_generated/server";
+import { internalAction } from "../_generated/server";
+import { RESEND_FROM_EMAIL } from "../_lib/config";
+import { formatResendFrom, formatResendSubject } from "../_lib/emailFormat";
+import { selectChannel } from "../_lib/notification";
+import { NOTIFICATION_FAILURE_REMINDER_PENDING_PAGE_SIZE } from "../constants";
+import {
+  buildNotificationFailureReminderEmailHtml,
+  buildNotificationFailureReminderLineText,
+  NOTIFICATION_FAILURE_REMINDER_SUBJECT,
+} from "../notification/templates";
+import { emailPayload, enqueueEmail, enqueueLine, linePayload } from "./enqueue";
+
+const NOTIFICATION_CONTEXT = "notificationOutbox.sendFailureReminderDigest";
+
+type ShopIdsPage = {
+  page: Id<"shops">[];
+  continueCursor: string;
+  isDone: boolean;
+};
+
+export const sendFailureReminderDigest = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const notifiedShopIds = new Set<string>();
+    let cursor: string | null = null;
+    let isDone = false;
+
+    while (!isDone) {
+      const result: ShopIdsPage = await ctx.runQuery(
+        internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage,
+        {
+          paginationOpts: {
+            numItems: NOTIFICATION_FAILURE_REMINDER_PENDING_PAGE_SIZE,
+            cursor,
+          },
+        },
+      );
+
+      for (const shopId of result.page) {
+        if (notifiedShopIds.has(shopId)) continue;
+        notifiedShopIds.add(shopId);
+        await sendFailureReminderForShop(ctx, shopId);
+      }
+
+      cursor = result.continueCursor;
+      isDone = result.isDone;
+    }
+  },
+});
+
+async function sendFailureReminderForShop(ctx: ActionCtx, shopId: Id<"shops">) {
+  const data = await ctx.runQuery(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+    shopId,
+  });
+  if (!data) return;
+
+  const [quota, suppressDelivery] = await Promise.all([
+    ctx.runQuery(internal.line.queries.getQuotaStatusInternal, {}),
+    ctx.runQuery(internal._lib.notificationDeliveryQueries.isNotificationDeliverySuppressedForShop, {
+      shopId: data.shopId,
+    }),
+  ]);
+
+  for (const recipient of data.recipients) {
+    const channel = selectChannel({ lineUserId: recipient.lineUserId, lineFollowing: recipient.lineFollowing }, quota);
+
+    if (channel === "line" && recipient.lineUserId) {
+      await enqueueLine(ctx, {
+        shopId: data.shopId,
+        userId: recipient.userId,
+        dedupeKey: `line:notificationFailureReminder:${data.shopId}:${recipient.userId}`,
+        payload: linePayload({
+          toUserId: recipient.lineUserId,
+          text: buildNotificationFailureReminderLineText({ dashboardUrl: data.dashboardUrl }),
+          suppressDelivery,
+          suppressFailureInbox: true,
+          fallbackEmail: {
+            dedupeKey: `email:notificationFailureReminder:${data.shopId}:${recipient.userId}`,
+            payload: emailPayload({
+              from: formatResendFrom(data.shopName, RESEND_FROM_EMAIL),
+              to: recipient.email,
+              subject: formatResendSubject(data.shopName, NOTIFICATION_FAILURE_REMINDER_SUBJECT),
+              html: buildNotificationFailureReminderEmailHtml({
+                managerName: recipient.name,
+                dashboardUrl: data.dashboardUrl,
+              }),
+              context: NOTIFICATION_CONTEXT,
+              suppressDelivery,
+              suppressFailureInbox: true,
+            }),
+          },
+        }),
+      });
+      continue;
+    }
+
+    await enqueueEmail(ctx, {
+      shopId: data.shopId,
+      userId: recipient.userId,
+      dedupeKey: `email:notificationFailureReminder:${data.shopId}:${recipient.userId}`,
+      payload: emailPayload({
+        from: formatResendFrom(data.shopName, RESEND_FROM_EMAIL),
+        to: recipient.email,
+        subject: formatResendSubject(data.shopName, NOTIFICATION_FAILURE_REMINDER_SUBJECT),
+        html: buildNotificationFailureReminderEmailHtml({
+          managerName: recipient.name,
+          dashboardUrl: data.dashboardUrl,
+        }),
+        context: NOTIFICATION_CONTEXT,
+        suppressDelivery,
+        suppressFailureInbox: true,
+      }),
+    });
+  }
+}

--- a/convex/notificationOutbox/failureReminderQueries.test.ts
+++ b/convex/notificationOutbox/failureReminderQueries.test.ts
@@ -1,0 +1,204 @@
+import { convexTest } from "convex-test";
+import { describe, expect, it } from "vitest";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+import { seedManagerShop, seedShopMembership, seedStaffLineAccount, seedUser } from "../_test/seed";
+import { modules, schema } from "../_test/setup.test-helper";
+import { HOUR_MS, NOTIFICATION_FAILURE_REMINDER_WINDOW_MS } from "../constants";
+
+async function insertFailure(
+  ctx: MutationCtx,
+  args: {
+    shopId: Id<"shops">;
+    status?: "open" | "retrying" | "resolved";
+    lastFailedAt?: number;
+    dedupeKey?: string;
+  },
+) {
+  const now = Date.now();
+  const lastFailedAt = args.lastFailedAt ?? now;
+  return await ctx.db.insert("notificationFailureInbox", {
+    failureKey: `test:${args.dedupeKey ?? `${args.shopId}:${lastFailedAt}`}`,
+    sourceType: "outbox",
+    status: args.status ?? "open",
+    shopId: args.shopId,
+    dedupeKey: args.dedupeKey ?? `email:test:${args.shopId}`,
+    notificationContext: "notification.sendRecruitmentNotificationEmails",
+    firstFailedAt: lastFailedAt,
+    lastFailedAt,
+    lastError: "boom",
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+describe("notificationOutbox/failureReminderQueries", () => {
+  describe("listShopIdsWithRecentOpenFailuresPage", () => {
+    it("open failure がある店舗だけを返す（retrying/resolved は除外）", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const open = await seedManagerShop(ctx, { subject: "open_shop", shopName: "Open" });
+        const retrying = await seedManagerShop(ctx, { subject: "retrying_shop", shopName: "Retrying" });
+        const resolved = await seedManagerShop(ctx, { subject: "resolved_shop", shopName: "Resolved" });
+        await insertFailure(ctx, { shopId: open.shopId, status: "open" });
+        await insertFailure(ctx, { shopId: retrying.shopId, status: "retrying" });
+        await insertFailure(ctx, { shopId: resolved.shopId, status: "resolved" });
+        return idsToStrings({
+          openShopId: open.shopId,
+          retryingShopId: retrying.shopId,
+          resolvedShopId: resolved.shopId,
+        });
+      });
+
+      const result = await t.query(
+        internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage,
+        { paginationOpts: { numItems: 10, cursor: null } },
+      );
+
+      expect(result.page.map(String)).toEqual([ids.openShopId]);
+      expect(result.page.map(String)).not.toContain(ids.retryingShopId);
+      expect(result.page.map(String)).not.toContain(ids.resolvedShopId);
+    });
+
+    it("最新の失敗が3日を超えた店舗は返さない", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const recent = await seedManagerShop(ctx, { subject: "recent_shop", shopName: "Recent" });
+        const stale = await seedManagerShop(ctx, { subject: "stale_shop", shopName: "Stale" });
+        await insertFailure(ctx, {
+          shopId: recent.shopId,
+          lastFailedAt: Date.now() - NOTIFICATION_FAILURE_REMINDER_WINDOW_MS + HOUR_MS,
+        });
+        await insertFailure(ctx, {
+          shopId: stale.shopId,
+          lastFailedAt: Date.now() - NOTIFICATION_FAILURE_REMINDER_WINDOW_MS - HOUR_MS,
+        });
+        return idsToStrings({ recentShopId: recent.shopId, staleShopId: stale.shopId });
+      });
+
+      const result = await t.query(
+        internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage,
+        { paginationOpts: { numItems: 10, cursor: null } },
+      );
+
+      expect(result.page.map(String)).toEqual([ids.recentShopId]);
+      expect(result.page.map(String)).not.toContain(ids.staleShopId);
+    });
+
+    it("古い失敗と3日以内の失敗が混在する店舗は返す（最新失敗基準）", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const mixed = await seedManagerShop(ctx, { subject: "mixed_shop", shopName: "Mixed" });
+        await insertFailure(ctx, {
+          shopId: mixed.shopId,
+          dedupeKey: "old",
+          lastFailedAt: Date.now() - NOTIFICATION_FAILURE_REMINDER_WINDOW_MS - HOUR_MS,
+        });
+        await insertFailure(ctx, {
+          shopId: mixed.shopId,
+          dedupeKey: "new",
+          lastFailedAt: Date.now() - HOUR_MS,
+        });
+        return idsToStrings({ mixedShopId: mixed.shopId });
+      });
+
+      const result = await t.query(
+        internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage,
+        { paginationOpts: { numItems: 10, cursor: null } },
+      );
+
+      expect(result.page.map(String)).toContain(ids.mixedShopId);
+    });
+  });
+
+  describe("getFailureReminderTargetForShop", () => {
+    it("open failure があると manager 受信者を返し、manager staff の LINE 連携を付与する", async () => {
+      const t = convexTest(schema, modules);
+      const { shopId } = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "owner_line",
+          email: "owner-line@example.com",
+          shopName: "通知店舗",
+        });
+        const managerStaffId = await ctx.db.insert("staffs", {
+          shopId: seeded.shopId,
+          userId: seeded.userId,
+          name: "管理スタッフ",
+          email: "owner-line@example.com",
+          emailNormalized: "owner-line@example.com",
+          isDeleted: false,
+        });
+        await seedStaffLineAccount(ctx, {
+          shopId: seeded.shopId,
+          staffId: managerStaffId,
+          lineUserId: "U_owner_line",
+          following: true,
+        });
+
+        const secondUserId = await seedUser(ctx, "owner_email", "owner-email@example.com");
+        await seedShopMembership(ctx, { shopId: seeded.shopId, userId: secondUserId });
+        await insertFailure(ctx, { shopId: seeded.shopId, status: "open" });
+        return { shopId: seeded.shopId };
+      });
+
+      const result = await t.query(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+        shopId,
+      });
+
+      expect(result).toMatchObject({ shopId, shopName: "通知店舗" });
+      expect(result?.dashboardUrl).toMatch(/\/dashboard$/);
+      expect(result?.recipients).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            email: "owner-line@example.com",
+            lineUserId: "U_owner_line",
+            lineFollowing: true,
+          }),
+          expect.objectContaining({ email: "owner-email@example.com" }),
+        ]),
+      );
+    });
+
+    it("open failure がない店舗・削除済み店舗は null を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { noFailureShopId, resolvedOnlyShopId, deletedShopId } = await t.run(async (ctx) => {
+        const noFailure = await seedManagerShop(ctx, { subject: "no_failure" });
+
+        const resolvedOnly = await seedManagerShop(ctx, { subject: "resolved_only" });
+        await insertFailure(ctx, { shopId: resolvedOnly.shopId, status: "resolved" });
+
+        const deleted = await seedManagerShop(ctx, { subject: "deleted_shop", shopDeleted: true });
+        await insertFailure(ctx, { shopId: deleted.shopId, status: "open" });
+
+        return {
+          noFailureShopId: noFailure.shopId,
+          resolvedOnlyShopId: resolvedOnly.shopId,
+          deletedShopId: deleted.shopId,
+        };
+      });
+
+      await expect(
+        t.query(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+          shopId: noFailureShopId,
+        }),
+      ).resolves.toBeNull();
+      await expect(
+        t.query(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+          shopId: resolvedOnlyShopId,
+        }),
+      ).resolves.toBeNull();
+      await expect(
+        t.query(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+          shopId: deletedShopId,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
+});
+
+function idsToStrings<T extends Record<string, unknown>>(ids: T) {
+  return Object.fromEntries(Object.entries(ids).map(([key, value]) => [key, String(value)])) as {
+    [K in keyof T]: string;
+  };
+}

--- a/convex/notificationOutbox/failureReminderQueries.ts
+++ b/convex/notificationOutbox/failureReminderQueries.ts
@@ -1,0 +1,47 @@
+import { paginationOptsValidator } from "convex/server";
+import { v } from "convex/values";
+import { internalQuery } from "../_generated/server";
+import { APP_URL } from "../_lib/config";
+import { loadShopManagerRecipients } from "../_lib/shopManagerRecipients";
+import { NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT, NOTIFICATION_FAILURE_REMINDER_WINDOW_MS } from "../constants";
+
+export const listShopIdsWithRecentOpenFailuresPage = internalQuery({
+  args: { paginationOpts: paginationOptsValidator },
+  handler: async (ctx, { paginationOpts }) => {
+    // 最新の失敗から3日間だけ通知する。3日以内に失敗した open レコードがある店舗が対象。
+    const windowStart = Date.now() - NOTIFICATION_FAILURE_REMINDER_WINDOW_MS;
+    const result = await ctx.db
+      .query("notificationFailureInbox")
+      .withIndex("by_status_lastFailedAt", (q) => q.eq("status", "open").gte("lastFailedAt", windowStart))
+      .paginate(paginationOpts);
+
+    return {
+      ...result,
+      page: result.page.map((failure) => failure.shopId),
+    };
+  },
+});
+
+export const getFailureReminderTargetForShop = internalQuery({
+  args: { shopId: v.id("shops") },
+  handler: async (ctx, { shopId }) => {
+    const shop = await ctx.db.get(shopId);
+    if (!shop || shop.isDeleted) return null;
+
+    const openFailure = await ctx.db
+      .query("notificationFailureInbox")
+      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shopId).eq("status", "open"))
+      .first();
+    if (!openFailure) return null;
+
+    const recipients = await loadShopManagerRecipients(ctx, shopId, NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT);
+    if (recipients.length === 0) return null;
+
+    return {
+      shopId,
+      shopName: shop.name,
+      dashboardUrl: `${APP_URL}/dashboard`,
+      recipients,
+    };
+  },
+});

--- a/convex/notificationOutbox/schemas.ts
+++ b/convex/notificationOutbox/schemas.ts
@@ -45,6 +45,7 @@ export const notificationEmailPayloadValidator = v.object({
   html: v.string(),
   context: v.string(),
   suppressDelivery: v.optional(v.boolean()),
+  suppressFailureInbox: v.optional(v.boolean()),
 });
 
 export const notificationLinePayloadValidator = v.object({
@@ -52,6 +53,7 @@ export const notificationLinePayloadValidator = v.object({
   toUserId: v.string(),
   text: v.string(),
   suppressDelivery: v.optional(v.boolean()),
+  suppressFailureInbox: v.optional(v.boolean()),
   fallbackEmail: v.optional(
     v.object({
       dedupeKey: v.string(),

--- a/convex/notificationOutbox/types.ts
+++ b/convex/notificationOutbox/types.ts
@@ -8,6 +8,8 @@ export type NotificationEmailPayload = {
   html: string;
   context: string;
   suppressDelivery?: boolean;
+  // 配送失敗時に notificationFailureInbox へ記録しない（失敗リマインダー等のメタ通知用）
+  suppressFailureInbox?: boolean;
 };
 
 export type NotificationLinePayload = {
@@ -15,6 +17,8 @@ export type NotificationLinePayload = {
   toUserId: string;
   text: string;
   suppressDelivery?: boolean;
+  // 配送失敗時に notificationFailureInbox へ記録しない（失敗リマインダー等のメタ通知用）
+  suppressFailureInbox?: boolean;
   fallbackEmail?: {
     dedupeKey: string;
     payload: NotificationEmailPayload;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -419,6 +419,7 @@ const schema = defineSchema({
   })
     .index("by_failureKey", ["failureKey"])
     .index("by_status_firstFailedAt", ["status", "firstFailedAt"])
+    .index("by_status_lastFailedAt", ["status", "lastFailedAt"])
     .index("by_shopId_status_lastFailedAt", ["shopId", "status", "lastFailedAt"])
     .index("by_outboxId", ["outboxId"])
     .index("by_staffId_status_lastFailedAt", ["staffId", "status", "lastFailedAt"]),

--- a/convex/staffRegistration/notificationQueries.ts
+++ b/convex/staffRegistration/notificationQueries.ts
@@ -1,14 +1,9 @@
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
 import { internalQuery } from "../_generated/server";
 import { APP_URL } from "../_lib/config";
-import {
-  SHIFT_BOARD_STAFF_LIMIT,
-  STAFF_REGISTRATION_DAILY_DIGEST_MANAGER_LIMIT,
-  STAFF_REGISTRATION_DIGEST_WINDOW_MS,
-} from "../constants";
-import { getStaffLineAccount } from "../line/service";
+import { loadShopManagerRecipients } from "../_lib/shopManagerRecipients";
+import { STAFF_REGISTRATION_DAILY_DIGEST_MANAGER_LIMIT, STAFF_REGISTRATION_DIGEST_WINDOW_MS } from "../constants";
 
 export const listPendingRequestShopIdsPage = internalQuery({
   args: { paginationOpts: paginationOptsValidator },
@@ -39,42 +34,7 @@ export const getOwnerDigestTargetForShop = internalQuery({
       .first();
     if (!pendingRequest) return null;
 
-    const [members, activeStaffs] = await Promise.all([
-      ctx.db
-        .query("shopMembers")
-        .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
-        .take(STAFF_REGISTRATION_DAILY_DIGEST_MANAGER_LIMIT),
-      ctx.db
-        .query("staffs")
-        .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
-        .take(SHIFT_BOARD_STAFF_LIMIT),
-    ]);
-
-    const staffByUserId = new Map<Id<"users">, (typeof activeStaffs)[number]>();
-    for (const staff of activeStaffs) {
-      if (staff.userId) staffByUserId.set(staff.userId, staff);
-    }
-
-    const recipients = (
-      await Promise.all(
-        members.map(async (member) => {
-          const user = await ctx.db.get(member.userId);
-          if (!user || user.isDeleted || !user.email) return null;
-
-          const managerStaff = staffByUserId.get(user._id);
-          const lineAccount = managerStaff ? await getStaffLineAccount(ctx, managerStaff._id) : null;
-
-          return {
-            userId: user._id,
-            name: user.name,
-            email: user.email,
-            lineUserId: lineAccount?.lineUserId,
-            lineFollowing: lineAccount?.following,
-          };
-        }),
-      )
-    ).filter((recipient) => recipient !== null);
-
+    const recipients = await loadShopManagerRecipients(ctx, shopId, STAFF_REGISTRATION_DAILY_DIGEST_MANAGER_LIMIT);
     if (recipients.length === 0) return null;
 
     return {

--- a/doc/features/notification-failure-dashboard.md
+++ b/doc/features/notification-failure-dashboard.md
@@ -2,6 +2,8 @@
 
 送信できなかった通知を `notificationFailureInbox` から店舗単位で読み取り、Dashboard の「今やること」から再通知を受け付ける機能。再通知は配送完了ではなく、Outbox または再通知 action に載った時点で受付済みとして扱う。
 
+マネージャーがDashboardを開かないと不達に気づけないため、open 不達通知がある店舗のmanager usersへ、毎日 JST 17:00 に「Dashboardから再通知してください」というリマインダー（日次ダイジェスト）を送る。
+
 ## 関連ファイル
 
 ### フロントエンド（`src/`）
@@ -16,6 +18,15 @@
 - `convex/notificationOutbox/queries.ts` — `notificationFailureInbox` の open 件をUI向けDTOで返す
 - `convex/notificationOutbox/mutations.ts` — 個別/一斉再通知を受け付け、対象 failure を `retrying` にする
 - `convex/notification/actions.ts` / `convex/notification/reminderActions.ts` — enqueue/preparation 失敗の再通知を1スタッフ・1募集単位でOutboxに載せる
+- `convex/notificationOutbox/failureReminderActions.ts` / `failureReminderQueries.ts` — open 不達通知がある店舗のmanagerへ日次リマインダーを送る（cron `notification-failure-reminder-digest`）
+- `convex/_lib/shopManagerRecipients.ts` — 店舗のmanager usersを通知受信者として組み立てる共通ヘルパー（承認依頼ダイジェストと共有）
+
+## リマインダー（日次ダイジェスト）
+
+- cron `notification-failure-reminder-digest`（JST 17:00 = UTC 08:00）が `internal.notificationOutbox.failureReminderActions.sendFailureReminderDigest` を起動する。
+- `status = open` かつ最新失敗（`lastFailedAt`）が直近3日以内（`NOTIFICATION_FAILURE_REMINDER_WINDOW_MS`）の不達通知がある店舗だけを対象にする。失敗が再発するたびに窓がリセットされ、無ければ最大3回で打ち切られる。
+- 配信先は店舗のmanager users全員。LINE連携済みなら LINE（emailフォールバック付き）、それ以外はメール。
+- このリマインダー通知自体の配送が失敗しても `notificationFailureInbox` には記録しない（payloadの `suppressFailureInbox` で抑止。メタ失敗でInboxを汚さないため）。
 
 ## 画面一覧
 
@@ -31,6 +42,9 @@
 | `api.notificationOutbox.queries.listOpenFailures` | query | 現在店舗の open 不達通知をUI表示用に返す |
 | `api.notificationOutbox.mutations.resendFailure` | mutation | 1件の不達通知を再通知受付し、`retrying` にする |
 | `api.notificationOutbox.mutations.resendOpenFailures` | mutation | 現在店舗の open 不達通知をまとめて再通知受付する |
+| `internal.notificationOutbox.failureReminderActions.sendFailureReminderDigest` | internalAction | 毎日17:00 JSTに open 不達通知がある店舗のmanagerへリマインダーを送る |
+| `internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage` | internalQuery | 直近3日以内に失敗した open 不達通知がある店舗IDをページングで返す |
+| `internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop` | internalQuery | 店舗名、ダッシュボードURL、通知対象manager users、LINE連携状態を返す |
 
 ## 表示ルール
 


### PR DESCRIPTION
open不達通知がある店舗のmanager全員へ、毎日JST 17:00に
「Dashboardから再通知してください」というリマインダーを送る。
- 直近の失敗(lastFailedAt)から3日間だけ送る（承認依頼ダイジェストと同じ運用）
- payloadにsuppressFailureInboxを追加し、このリマインダー自体の
  配送失敗はnotificationFailureInboxに記録しない
- manager受信者の組み立てをloadShopManagerRecipientsに共通化し
  承認依頼ダイジェストと共有

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AG3LwW3y5gXDSs5X6igRoN