### PR TITLE
fix(vrt): 締切超過ダイアログのStoryが閉じ切るまで待ちフレーキーを解消

### DIFF
--- a/src/components/features/StaffSubmit/SubmitFormView/index.stories.tsx
+++ b/src/components/features/StaffSubmit/SubmitFormView/index.stories.tsx
@@ -80,7 +80,10 @@ export const LateInitialInteractive: Story = {
 
     await userEvent.click(await canvas.findByRole("button", { name: "希望シフトを提出" }));
     await userEvent.click(await screen.findByRole("button", { name: "この内容で提出する" }));
-    await expect(lateInitialSubmitCount).toBe(1);
+    await waitFor(() => expect(lateInitialSubmitCount).toBe(1));
+    // 提出後はダイアログが閉じ切るまで待つ。非同期の submit→close を待たずに play を終えると
+    // VRT 撮影時にダイアログの開/閉状態がブレてフレーキーな差分になるため。
+    await waitFor(() => expect(screen.queryByText("提出締切を過ぎています")).not.toBeInTheDocument());
   },
 };
 


### PR DESCRIPTION
LateInitialInteractive の play は「この内容で提出する」クリック後、
非同期の onSubmit→ダイアログ close を待たずに終了していた。そのため
afterEach のスクリーンショット撮影時にダイアログの開/閉状態がブレ、
ベースラインと実測で画面全体がズレてVRTがフレーキーになっていた。
提出回数の確定とダイアログの非表示を waitFor で待ち、最終状態を
決定的にする。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TYZrSShTUmkspzm7CuUZEo