### PR TITLE
fix: 通知不達リマインダーの失敗ログを保持

### DIFF
--- a/convex/notification/actions.test.ts
+++ b/convex/notification/actions.test.ts
@@ -5,7 +5,10 @@ import { seedManagerShop } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
 describe("notification/actions", () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T00:00:00+09:00"));
+  });
   afterEach(() => vi.useRealTimers());
 
   it("100人分の募集開始通知をoutboxにenqueueする", async () => {

--- a/convex/notificationOutbox/actions.ts
+++ b/convex/notificationOutbox/actions.ts
@@ -44,8 +44,7 @@ export const processPending = internalAction({
             ...(errorName(e) ? { errorName: errorName(e) } : {}),
           });
         } else {
-          const suppressFailureInbox =
-            lastError === LINE_QUOTA_FALLBACK_ENQUEUED_MESSAGE || job.payload.suppressFailureInbox === true;
+          const suppressFailureInbox = lastError === LINE_QUOTA_FALLBACK_ENQUEUED_MESSAGE;
           await ctx.runMutation(internal.notificationOutbox.mutations.markFailed, {
             outboxId: job._id,
             lastError,

--- a/convex/notificationOutbox/enqueue.test.ts
+++ b/convex/notificationOutbox/enqueue.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { emailPayload, enqueueEmail } from "./enqueue";
+import { NOTIFICATION_FAILURE_REMINDER_CONTEXT } from "./failureSuppress";
+
+describe("notificationOutbox/enqueue", () => {
+  it("suppressFailureInboxつきpayloadでもenqueue失敗イベントを記録する", async () => {
+    const shopId = "shop_test" as Id<"shops">;
+    const userId = "user_test" as Id<"users">;
+    const dedupeKey = "email:notificationFailureReminder:shop_test:user_test";
+    const runMutation = vi.fn().mockRejectedValueOnce(new Error("enqueue failed")).mockResolvedValueOnce(null);
+
+    const result = await enqueueEmail({ runMutation } as unknown as Parameters<typeof enqueueEmail>[0], {
+      shopId,
+      userId,
+      dedupeKey,
+      payload: emailPayload({
+        from: "シフトリ <noreply@example.com>",
+        to: "manager@example.com",
+        subject: "通知エラーがあります",
+        html: "<p>test</p>",
+        context: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+        suppressDelivery: true,
+        suppressFailureInbox: true,
+      }),
+    });
+
+    expect(result).toBeNull();
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runMutation).toHaveBeenNthCalledWith(2, internal.notificationOutbox.mutations.recordDeliveryEvent, {
+      eventType: "enqueue_failed",
+      shopId,
+      userId,
+      channel: "email",
+      dedupeKey,
+      notificationContext: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+      errorMessage: "enqueue failed",
+      errorName: "Error",
+    });
+  });
+});

--- a/convex/notificationOutbox/enqueue.ts
+++ b/convex/notificationOutbox/enqueue.ts
@@ -46,8 +46,6 @@ async function enqueueNotification(ctx: EnqueueCtx, input: EnqueueNotificationIn
 }
 
 async function recordEnqueueFailure(ctx: EnqueueCtx, input: EnqueueNotificationInput, e: unknown) {
-  // 失敗リマインダー等のメタ通知は、enqueue失敗時もInboxに記録しない
-  if (input.payload.suppressFailureInbox) return;
   try {
     await ctx.runMutation(internal.notificationOutbox.mutations.recordDeliveryEvent, {
       eventType: "enqueue_failed",

--- a/convex/notificationOutbox/failureReminderActions.ts
+++ b/convex/notificationOutbox/failureReminderActions.ts
@@ -14,8 +14,7 @@ import {
   NOTIFICATION_FAILURE_REMINDER_SUBJECT,
 } from "../notification/templates";
 import { emailPayload, enqueueEmail, enqueueLine, linePayload } from "./enqueue";
-
-const NOTIFICATION_CONTEXT = "notificationOutbox.sendFailureReminderDigest";
+import { NOTIFICATION_FAILURE_REMINDER_CONTEXT } from "./failureSuppress";
 
 type ShopIdsPage = {
   page: Id<"shops">[];
@@ -78,7 +77,6 @@ async function sendFailureReminderForShop(ctx: ActionCtx, shopId: Id<"shops">) {
           toUserId: recipient.lineUserId,
           text: buildNotificationFailureReminderLineText({ dashboardUrl: data.dashboardUrl }),
           suppressDelivery,
-          suppressFailureInbox: true,
           fallbackEmail: {
             dedupeKey: `email:notificationFailureReminder:${data.shopId}:${recipient.userId}`,
             payload: emailPayload({
@@ -89,9 +87,8 @@ async function sendFailureReminderForShop(ctx: ActionCtx, shopId: Id<"shops">) {
                 managerName: recipient.name,
                 dashboardUrl: data.dashboardUrl,
               }),
-              context: NOTIFICATION_CONTEXT,
+              context: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
               suppressDelivery,
-              suppressFailureInbox: true,
             }),
           },
         }),
@@ -111,9 +108,8 @@ async function sendFailureReminderForShop(ctx: ActionCtx, shopId: Id<"shops">) {
           managerName: recipient.name,
           dashboardUrl: data.dashboardUrl,
         }),
-        context: NOTIFICATION_CONTEXT,
+        context: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
         suppressDelivery,
-        suppressFailureInbox: true,
       }),
     });
   }

--- a/convex/notificationOutbox/failureSuppress.ts
+++ b/convex/notificationOutbox/failureSuppress.ts
@@ -5,8 +5,15 @@
 
 /** マネージャー向けシフト確定催促リマインダーの通知 context。 */
 export const SHIFT_CONFIRMATION_REMINDER_CONTEXT = "shiftConfirmationReminder.sendManagerConfirmationReminder";
+/** 通知不達の管理者向けリマインダー通知 context。 */
+export const NOTIFICATION_FAILURE_REMINDER_CONTEXT = "notificationOutbox.sendFailureReminderDigest";
+const NOTIFICATION_FAILURE_REMINDER_LINE_DEDUPE_CONTEXT = "line:notificationFailureReminder";
 
-const SUPPRESS_FAILURE_INBOX_CONTEXTS = new Set<string>([SHIFT_CONFIRMATION_REMINDER_CONTEXT]);
+const SUPPRESS_FAILURE_INBOX_CONTEXTS = new Set<string>([
+  SHIFT_CONFIRMATION_REMINDER_CONTEXT,
+  NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+  NOTIFICATION_FAILURE_REMINDER_LINE_DEDUPE_CONTEXT,
+]);
 
 /** この context の通知は failureInbox への登録をスキップするか。 */
 export function shouldSuppressNotificationFailureInbox(context: string): boolean {

--- a/convex/notificationOutbox/mutations.test.ts
+++ b/convex/notificationOutbox/mutations.test.ts
@@ -11,6 +11,7 @@ import {
   NOTIFICATION_FAILURE_INBOX_RETENTION_MS,
   NOTIFICATION_OUTBOX_ENQUEUE_DELAY_MS,
 } from "../constants";
+import { NOTIFICATION_FAILURE_REMINDER_CONTEXT } from "./failureSuppress";
 
 const emailPayload = {
   kind: "email" as const,
@@ -450,6 +451,32 @@ describe("notificationOutbox", () => {
       expect(failures[0].lastFailedAt).toBeGreaterThan(firstFailure.lastFailedAt);
     });
 
+    it("markFailedは抑止対象contextでも配送イベントを残し、要対応Inbox化しない", async () => {
+      const { t, shopId } = await setupShop();
+      const dedupeKey = "email:notificationFailureReminder:shop_test:user_test";
+      const outboxId = await insertProcessingJob(t, {
+        shopId,
+        channel: "email",
+        dedupeKey,
+        context: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+      });
+
+      await t.mutation(internal.notificationOutbox.mutations.markFailed, { outboxId, lastError: "reminder failed" });
+
+      const events = await t.run(async (ctx) => await ctx.db.query("notificationDeliveryEvents").collect());
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        eventType: "final_failed",
+        shopId,
+        outboxId,
+        channel: "email",
+        dedupeKey,
+        notificationContext: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+        errorMessage: "reminder failed",
+      });
+      expect(await collectFailureInbox(t)).toEqual([]);
+    });
+
     it("同じ通知種別・募集・スタッフの異なるoutbox失敗は最新1件の要対応Inboxに更新する", async () => {
       const { t, shopId, staffId } = await setupShop();
       const recruitmentId = await t.run(async (ctx) => {
@@ -782,6 +809,60 @@ describe("notificationOutbox", () => {
       recruitmentId,
       errorMessage: "preparation failed",
     });
+  });
+
+  it("recordDeliveryEventは抑止対象contextでも配送イベントを残し、要対応Inbox化しない", async () => {
+    const { t, shopId, staffId } = await setupShop();
+    const dedupeKey = "email:notificationFailureReminder:shop_test:user_test";
+
+    await t.mutation(internal.notificationOutbox.mutations.recordDeliveryEvent, {
+      eventType: "enqueue_failed",
+      shopId,
+      staffId,
+      channel: "email",
+      dedupeKey,
+      notificationContext: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+      errorMessage: "enqueue failed",
+    });
+
+    const events = await t.run(async (ctx) => await ctx.db.query("notificationDeliveryEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: "enqueue_failed",
+      shopId,
+      staffId,
+      channel: "email",
+      dedupeKey,
+      notificationContext: NOTIFICATION_FAILURE_REMINDER_CONTEXT,
+      errorMessage: "enqueue failed",
+    });
+    expect(await collectFailureInbox(t)).toEqual([]);
+  });
+
+  it("recordDeliveryEventは通知不達リマインダーLINEのdedupe由来contextでも要対応Inbox化しない", async () => {
+    const { t, shopId, staffId } = await setupShop();
+    const dedupeKey = "line:notificationFailureReminder:shop_test:user_test";
+
+    await t.mutation(internal.notificationOutbox.mutations.recordDeliveryEvent, {
+      eventType: "enqueue_failed",
+      shopId,
+      staffId,
+      channel: "line",
+      dedupeKey,
+      errorMessage: "line enqueue failed",
+    });
+
+    const events = await t.run(async (ctx) => await ctx.db.query("notificationDeliveryEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: "enqueue_failed",
+      shopId,
+      staffId,
+      channel: "line",
+      dedupeKey,
+      errorMessage: "line enqueue failed",
+    });
+    expect(await collectFailureInbox(t)).toEqual([]);
   });
 
   it("recordDeliveryEventは解決済みの投入準備失敗を再発時にopenへ戻す", async () => {

--- a/convex/notificationOutbox/types.ts
+++ b/convex/notificationOutbox/types.ts
@@ -8,7 +8,7 @@ export type NotificationEmailPayload = {
   html: string;
   context: string;
   suppressDelivery?: boolean;
-  // 配送失敗時に notificationFailureInbox へ記録しない（失敗リマインダー等のメタ通知用）
+  // 互換用。新規のInbox抑止は notification context を failureSuppress.ts に追加する。
   suppressFailureInbox?: boolean;
 };
 
@@ -17,7 +17,7 @@ export type NotificationLinePayload = {
   toUserId: string;
   text: string;
   suppressDelivery?: boolean;
-  // 配送失敗時に notificationFailureInbox へ記録しない（失敗リマインダー等のメタ通知用）
+  // 互換用。新規のInbox抑止は notification context を failureSuppress.ts に追加する。
   suppressFailureInbox?: boolean;
   fallbackEmail?: {
     dedupeKey: string;


### PR DESCRIPTION
## Summary
通知不達リマインダーの enqueue 失敗で配送イベントログまで落ちてしまう経路を修正し、イベントは記録しつつ failureInbox への表示だけを context ベースで抑止するようにしました。
あわせて、現在日付に依存して落ちていた Convex 通知 action テストの時刻を固定しています。

## Design

### データフロー
```mermaid
sequenceDiagram
    participant Action as Notification action
    participant Outbox as notificationOutbox
    participant Event as notificationDeliveryEvents
    participant Inbox as notificationFailureInbox

    Action->>Outbox: enqueue
    Outbox-->>Action: enqueue failure
    Action->>Event: recordDeliveryEvent
    Event->>Inbox: contextを確認
    Inbox-->>Event: 抑止対象ならInbox化しない
```

## Changes
- **enqueue失敗ログの保持**: suppressFailureInbox による早期 return をやめ、enqueue_failed event を常に記録
- **Inbox抑止の統一**: 通知不達リマインダーの context を failureSuppress に追加し、メール/LINE/fallback の抑止を共有経路へ統一
- **回帰テスト追加**: enqueue helper、recordDeliveryEvent、markFailed の各経路で「イベントは残すが Inbox 化しない」ことを検証
- **テスト安定化**: 募集通知 action テストの現在時刻を固定し、締切日を越えた実行日でも落ちないように修正

## Verification
- pnpm vitest run --project='convex(logic)' convex/notificationOutbox/enqueue.test.ts convex/notificationOutbox/mutations.test.ts convex/notificationOutbox/actions.test.ts
- pnpm test:convex
- pnpm type-check
- pnpm lint
- git diff --check