### PR TITLE
feat(dashboard): 種別「通知」(other)の不達をダッシュボード・リマインダーから除外

### DIFF
--- a/convex/_scenario/notificationDelivery.test.ts
+++ b/convex/_scenario/notificationDelivery.test.ts
@@ -632,6 +632,19 @@ describe("通知配送outboxシナリオ", () => {
         kind: "line",
         toUserId: "U_failure",
         text: "hello",
+        // 実際のLINE通知は fallbackEmail を持ち、不達の通知種別はそのcontextで判定される。
+        // （通常の400失敗ではfallbackは送らないため配送挙動は変わらない）
+        fallbackEmail: {
+          dedupeKey: "email:recruitment:failure-inbox:scenario",
+          payload: {
+            kind: "email",
+            from: "シフトリ <noreply@example.com>",
+            to: "failure-staff@example.com",
+            subject: "シフト募集のお知らせ",
+            html: "<p>hello</p>",
+            context: "notification.sendRecruitmentNotificationEmails",
+          },
+        },
       },
     });
 
@@ -648,7 +661,7 @@ describe("通知配送outboxシナリオ", () => {
       status: "open",
       channel: "line",
       dedupeKey: "line:failure-inbox:scenario",
-      notificationContext: "line:failure-inbox",
+      notificationContext: "notification.sendRecruitmentNotificationEmails",
       canRetry: true,
     });
 

--- a/convex/notificationOutbox/failureReminderQueries.test.ts
+++ b/convex/notificationOutbox/failureReminderQueries.test.ts
@@ -14,6 +14,7 @@ async function insertFailure(
     status?: "open" | "retrying" | "resolved";
     lastFailedAt?: number;
     dedupeKey?: string;
+    notificationContext?: string;
   },
 ) {
   const now = Date.now();
@@ -24,7 +25,7 @@ async function insertFailure(
     status: args.status ?? "open",
     shopId: args.shopId,
     dedupeKey: args.dedupeKey ?? `email:test:${args.shopId}`,
-    notificationContext: "notification.sendRecruitmentNotificationEmails",
+    notificationContext: args.notificationContext ?? "notification.sendRecruitmentNotificationEmails",
     firstFailedAt: lastFailedAt,
     lastFailedAt,
     lastError: "boom",
@@ -84,6 +85,25 @@ describe("notificationOutbox/failureReminderQueries", () => {
 
       expect(result.page.map(String)).toEqual([ids.recentShopId]);
       expect(result.page.map(String)).not.toContain(ids.staleShopId);
+    });
+
+    it("種別「通知」(other) しかない店舗は返さない", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const actionable = await seedManagerShop(ctx, { subject: "actionable_shop", shopName: "Actionable" });
+        const otherKind = await seedManagerShop(ctx, { subject: "other_kind_shop", shopName: "OtherKind" });
+        await insertFailure(ctx, { shopId: actionable.shopId, status: "open" });
+        await insertFailure(ctx, { shopId: otherKind.shopId, status: "open", notificationContext: "test.email" });
+        return idsToStrings({ actionableShopId: actionable.shopId, otherKindShopId: otherKind.shopId });
+      });
+
+      const result = await t.query(
+        internal.notificationOutbox.failureReminderQueries.listShopIdsWithRecentOpenFailuresPage,
+        { paginationOpts: { numItems: 10, cursor: null } },
+      );
+
+      expect(result.page.map(String)).toEqual([ids.actionableShopId]);
+      expect(result.page.map(String)).not.toContain(ids.otherKindShopId);
     });
 
     it("古い失敗と3日以内の失敗が混在する店舗は返す（最新失敗基準）", async () => {
@@ -158,6 +178,21 @@ describe("notificationOutbox/failureReminderQueries", () => {
           expect.objectContaining({ email: "owner-email@example.com" }),
         ]),
       );
+    });
+
+    it("種別「通知」(other) しかない店舗は null を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { otherKindShopId } = await t.run(async (ctx) => {
+        const otherKind = await seedManagerShop(ctx, { subject: "other_kind_target" });
+        await insertFailure(ctx, { shopId: otherKind.shopId, status: "open", notificationContext: "test.email" });
+        return { otherKindShopId: otherKind.shopId };
+      });
+
+      await expect(
+        t.query(internal.notificationOutbox.failureReminderQueries.getFailureReminderTargetForShop, {
+          shopId: otherKindShopId,
+        }),
+      ).resolves.toBeNull();
     });
 
     it("open failure がない店舗・削除済み店舗は null を返す", async () => {

--- a/convex/notificationOutbox/failureReminderQueries.ts
+++ b/convex/notificationOutbox/failureReminderQueries.ts
@@ -1,27 +1,33 @@
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
+import { filter } from "convex-helpers/server/filter";
 import { internalQuery } from "../_generated/server";
 import { APP_URL } from "../_lib/config";
 import { loadShopManagerRecipients } from "../_lib/shopManagerRecipients";
 import { NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT, NOTIFICATION_FAILURE_REMINDER_WINDOW_MS } from "../constants";
-import { isManagerActionableNotificationFailure } from "./failureResend";
+import { ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS, isManagerActionableNotificationFailure } from "./failureResend";
 
 export const listShopIdsWithRecentOpenFailuresPage = internalQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, { paginationOpts }) => {
     // 最新の失敗から3日間だけ通知する。3日以内に失敗した open レコードがある店舗が対象。
     const windowStart = Date.now() - NOTIFICATION_FAILURE_REMINDER_WINDOW_MS;
+    // 種別「通知」(other) しかない店舗にはリマインダーを送らない（Dashboard に出ないため対応しようがない）。
+    // Convex の `.filter()` はページング読み取りに統合されるので、other がページを埋めて
+    // 対象店舗が空ページに押し出されるのを防げる。
     const result = await ctx.db
       .query("notificationFailureInbox")
       .withIndex("by_status_lastFailedAt", (q) => q.eq("status", "open").gte("lastFailedAt", windowStart))
+      .filter((q) =>
+        q.or(
+          ...ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS.map((context) => q.eq(q.field("notificationContext"), context)),
+        ),
+      )
       .paginate(paginationOpts);
 
     return {
       ...result,
-      // 種別「通知」(other) しかない店舗にはリマインダーを送らない（Dashboard に出ないため対応しようがない）。
-      page: result.page
-        .filter((failure) => isManagerActionableNotificationFailure(failure.notificationContext))
-        .map((failure) => failure.shopId),
+      page: result.page.map((failure) => failure.shopId),
     };
   },
 });
@@ -32,16 +38,13 @@ export const getFailureReminderTargetForShop = internalQuery({
     const shop = await ctx.db.get(shopId);
     if (!shop || shop.isDeleted) return null;
 
-    let hasActionableFailure = false;
-    for await (const failure of ctx.db
-      .query("notificationFailureInbox")
-      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shopId).eq("status", "open"))) {
-      if (isManagerActionableNotificationFailure(failure.notificationContext)) {
-        hasActionableFailure = true;
-        break;
-      }
-    }
-    if (!hasActionableFailure) return null;
+    const openFailure = await filter(
+      ctx.db
+        .query("notificationFailureInbox")
+        .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shopId).eq("status", "open")),
+      (failure) => isManagerActionableNotificationFailure(failure.notificationContext),
+    ).first();
+    if (!openFailure) return null;
 
     const recipients = await loadShopManagerRecipients(ctx, shopId, NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT);
     if (recipients.length === 0) return null;

--- a/convex/notificationOutbox/failureReminderQueries.ts
+++ b/convex/notificationOutbox/failureReminderQueries.ts
@@ -4,6 +4,7 @@ import { internalQuery } from "../_generated/server";
 import { APP_URL } from "../_lib/config";
 import { loadShopManagerRecipients } from "../_lib/shopManagerRecipients";
 import { NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT, NOTIFICATION_FAILURE_REMINDER_WINDOW_MS } from "../constants";
+import { isManagerActionableNotificationFailure } from "./failureResend";
 
 export const listShopIdsWithRecentOpenFailuresPage = internalQuery({
   args: { paginationOpts: paginationOptsValidator },
@@ -17,7 +18,10 @@ export const listShopIdsWithRecentOpenFailuresPage = internalQuery({
 
     return {
       ...result,
-      page: result.page.map((failure) => failure.shopId),
+      // 種別「通知」(other) しかない店舗にはリマインダーを送らない（Dashboard に出ないため対応しようがない）。
+      page: result.page
+        .filter((failure) => isManagerActionableNotificationFailure(failure.notificationContext))
+        .map((failure) => failure.shopId),
     };
   },
 });
@@ -28,11 +32,16 @@ export const getFailureReminderTargetForShop = internalQuery({
     const shop = await ctx.db.get(shopId);
     if (!shop || shop.isDeleted) return null;
 
-    const openFailure = await ctx.db
+    let hasActionableFailure = false;
+    for await (const failure of ctx.db
       .query("notificationFailureInbox")
-      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shopId).eq("status", "open"))
-      .first();
-    if (!openFailure) return null;
+      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shopId).eq("status", "open"))) {
+      if (isManagerActionableNotificationFailure(failure.notificationContext)) {
+        hasActionableFailure = true;
+        break;
+      }
+    }
+    if (!hasActionableFailure) return null;
 
     const recipients = await loadShopManagerRecipients(ctx, shopId, NOTIFICATION_FAILURE_REMINDER_MANAGER_LIMIT);
     if (recipients.length === 0) return null;

--- a/convex/notificationOutbox/failureResend.test.ts
+++ b/convex/notificationOutbox/failureResend.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS,
+  describeNotificationFailureContext,
+  isManagerActionableNotificationFailure,
+} from "./failureResend";
+
+describe("describeNotificationFailureContext", () => {
+  it("LINE連携案内メールは other ではなく lineInvite 種別として扱う", () => {
+    expect(describeNotificationFailureContext("line.sendInviteEmail")).toEqual({
+      kind: "lineInvite",
+      label: "LINE連携案内",
+    });
+    expect(isManagerActionableNotificationFailure("line.sendInviteEmail")).toBe(true);
+    expect(ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS).toContain("line.sendInviteEmail");
+  });
+
+  it("未マッピングの context は other（ラベル「通知」）として扱う", () => {
+    expect(describeNotificationFailureContext("test.unknown")).toEqual({ kind: "other", label: "通知" });
+    expect(isManagerActionableNotificationFailure("test.unknown")).toBe(false);
+  });
+
+  it("ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS と isManagerActionableNotificationFailure は整合する", () => {
+    for (const context of ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS) {
+      expect(describeNotificationFailureContext(context).kind).not.toBe("other");
+      expect(isManagerActionableNotificationFailure(context)).toBe(true);
+    }
+  });
+});

--- a/convex/notificationOutbox/failureResend.ts
+++ b/convex/notificationOutbox/failureResend.ts
@@ -1,4 +1,4 @@
-export type NotificationFailureKind = "recruitment" | "reminder" | "confirmation" | "other";
+export type NotificationFailureKind = "recruitment" | "reminder" | "confirmation" | "lineInvite" | "other";
 
 export type NotificationFailureResendKind = "recruitment" | "reminder" | "confirmation" | "reissue";
 
@@ -26,6 +26,7 @@ export function describeNotificationFailureContext(context: string): {
   if (CONFIRMATION_CONTEXTS.has(context) || context === "notification.sendReissueEmail") {
     return { kind: "confirmation", label: "確定シフト" };
   }
+  if (context === "line.sendInviteEmail") return { kind: "lineInvite", label: "LINE連携案内" };
   return { kind: "other", label: "通知" };
 }
 
@@ -47,6 +48,7 @@ export const ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS: readonly string[] = [
   "notification.sendReminderEmails",
   ...CONFIRMATION_CONTEXTS,
   "notification.sendReissueEmail",
+  "line.sendInviteEmail",
 ];
 
 export function getNotificationFailureResendKind(context: string): NotificationFailureResendKind | null {

--- a/convex/notificationOutbox/failureResend.ts
+++ b/convex/notificationOutbox/failureResend.ts
@@ -37,6 +37,18 @@ export function isManagerActionableNotificationFailure(context: string): boolean
   return describeNotificationFailureContext(context).kind !== "other";
 }
 
+/**
+ * 種別「通知」(other) 以外（= 対応可能）の通知 context の列挙。
+ * ページング前に Convex の `.filter()` で絞り込むために使う（other がページを埋めて
+ * 対応可能な失敗がカーソルの後ろに押し出されるのを防ぐ）。
+ */
+export const ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS: readonly string[] = [
+  ...RECRUITMENT_CONTEXTS,
+  "notification.sendReminderEmails",
+  ...CONFIRMATION_CONTEXTS,
+  "notification.sendReissueEmail",
+];
+
 export function getNotificationFailureResendKind(context: string): NotificationFailureResendKind | null {
   if (RECRUITMENT_CONTEXTS.has(context)) return "recruitment";
   if (context === "notification.sendReminderEmails") return "reminder";

--- a/convex/notificationOutbox/failureResend.ts
+++ b/convex/notificationOutbox/failureResend.ts
@@ -29,6 +29,14 @@ export function describeNotificationFailureContext(context: string): {
   return { kind: "other", label: "通知" };
 }
 
+/**
+ * 種別が "other"（ラベル「通知」）の不達は、再通知できずマネージャーが対応しようがないため、
+ * Dashboard 一覧・要対応有無・日次リマインダーのいずれにも出さない。
+ */
+export function isManagerActionableNotificationFailure(context: string): boolean {
+  return describeNotificationFailureContext(context).kind !== "other";
+}
+
 export function getNotificationFailureResendKind(context: string): NotificationFailureResendKind | null {
   if (RECRUITMENT_CONTEXTS.has(context)) return "recruitment";
   if (context === "notification.sendReminderEmails") return "reminder";

--- a/convex/notificationOutbox/queries.test.ts
+++ b/convex/notificationOutbox/queries.test.ts
@@ -113,6 +113,47 @@ describe("notificationOutbox/queries", () => {
     expect(page.page[0]).not.toHaveProperty("lastError");
   });
 
+  it("listOpenFailuresは新しいother失敗がページを埋めても対応可能な失敗を初回ページで返す", async () => {
+    const t = convexTest(schema, modules);
+    const actionableId = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, {
+        subject: "manager_pagination",
+        email: "pagination@example.com",
+        shopName: "ページング店舗",
+      });
+      // 対応可能な失敗（古い）
+      const id = await insertFailure(ctx, {
+        shopId,
+        failureKey: "outbox:actionable",
+        status: "open",
+        dedupeKey: "email:test:actionable",
+        lastFailedAt: Date.now() - 10_000,
+        notificationContext: "notification.sendRecruitmentNotificationEmails",
+      });
+      // other失敗（新しい）でページ先頭を埋める
+      for (let i = 0; i < 3; i++) {
+        await insertFailure(ctx, {
+          shopId,
+          failureKey: `outbox:other-${i}`,
+          status: "open",
+          dedupeKey: `email:test:other-${i}`,
+          lastFailedAt: Date.now() + i,
+          notificationContext: "test.email",
+        });
+      }
+      return id;
+    });
+
+    // ページング後フィルタだと初回ページが空になるが、前段フィルタなら対応可能な失敗を返す
+    const page = await t
+      .withIdentity({ subject: "manager_pagination" })
+      .query(api.notificationOutbox.queries.listOpenFailures, {
+        paginationOpts: { numItems: 1, cursor: null },
+      });
+
+    expect(page.page.map((failure) => failure._id)).toEqual([actionableId]);
+  });
+
   it("hasOpenFailuresは現在店舗のopen失敗の有無だけを返す", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/convex/notificationOutbox/queries.test.ts
+++ b/convex/notificationOutbox/queries.test.ts
@@ -48,6 +48,16 @@ describe("notificationOutbox/queries", () => {
         status: "open",
         dedupeKey: "email:test:old",
         lastFailedAt: Date.now() - 1000,
+        notificationContext: "notification.sendReminderEmails",
+      });
+      // 種別「通知」(other) は一覧から除外される（最新だが表示されない）
+      await insertFailure(ctx, {
+        shopId: primary.shopId,
+        failureKey: "outbox:other-kind",
+        status: "open",
+        dedupeKey: "email:test:other-kind",
+        lastFailedAt: Date.now() + 1000,
+        notificationContext: "test.email",
       });
       const newFailureId = await insertFailure(ctx, {
         shopId: primary.shopId,
@@ -116,11 +126,25 @@ describe("notificationOutbox/queries", () => {
         email: "empty@example.com",
         shopName: "失敗なし店舗",
       });
+      const otherKindOnly = await seedManagerShop(ctx, {
+        subject: "manager_other_kind",
+        email: "other-kind@example.com",
+        shopName: "通知種別のみ店舗",
+      });
       await insertFailure(ctx, {
         shopId: active.shopId,
         failureKey: "outbox:active",
         status: "open",
         dedupeKey: "email:test:active",
+        notificationContext: "notification.sendRecruitmentNotificationEmails",
+      });
+      // 種別「通知」(other) しかない店舗は要対応なし扱い
+      await insertFailure(ctx, {
+        shopId: otherKindOnly.shopId,
+        failureKey: "outbox:other-kind-only",
+        status: "open",
+        dedupeKey: "email:test:other-kind-only",
+        notificationContext: "test.email",
       });
     });
 
@@ -129,6 +153,9 @@ describe("notificationOutbox/queries", () => {
     ).resolves.toBe(true);
     await expect(
       t.withIdentity({ subject: "manager_empty" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+    ).resolves.toBe(false);
+    await expect(
+      t.withIdentity({ subject: "manager_other_kind" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
     ).resolves.toBe(false);
   });
 });

--- a/convex/notificationOutbox/queries.ts
+++ b/convex/notificationOutbox/queries.ts
@@ -1,8 +1,10 @@
 import { paginationOptsValidator } from "convex/server";
+import { filter } from "convex-helpers/server/filter";
 import type { Doc } from "../_generated/dataModel";
 import { formatPeriodLabel } from "../_lib/dateFormat";
 import { managerQuery } from "../_lib/functions";
 import {
+  ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS,
   describeNotificationFailureContext,
   getNotificationFailureResendKind,
   isManagerActionableNotificationFailure,
@@ -20,19 +22,23 @@ export const listOpenFailures = managerQuery({
     if (!ctx.shop) return EMPTY_PAGE;
     const shop = ctx.shop;
 
+    // 種別「通知」(other) は再通知できずマネージャーが対応しようがないため一覧に出さない。
+    // ページング前に除外しないと、新しい other がページを埋めて対応可能な失敗がカーソルの後ろに
+    // 押し出され、初回ページが空になり得る（HeroSummaryカードも出なくなる）。
+    // Convex の `.filter()` はページング読み取りに統合されるため、前段で other を落とせる。
     const result = await ctx.db
       .query("notificationFailureInbox")
       .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shop._id).eq("status", "open"))
       .order("desc")
+      .filter((q) =>
+        q.or(
+          ...ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS.map((context) => q.eq(q.field("notificationContext"), context)),
+        ),
+      )
       .paginate(paginationOpts);
 
-    // 種別「通知」(other) は再通知できずマネージャーが対応しようがないため、一覧にも要対応バッジにも出さない。
-    const actionableFailures = result.page.filter((failure) =>
-      isManagerActionableNotificationFailure(failure.notificationContext),
-    );
-
     const page = await Promise.all(
-      actionableFailures.map(async (failure) => {
+      result.page.map(async (failure) => {
         const [staff, recruitment] = await Promise.all([
           failure.staffId ? ctx.db.get(failure.staffId) : null,
           failure.recruitmentId ? ctx.db.get(failure.recruitmentId) : null,
@@ -76,12 +82,13 @@ export const hasOpenFailures = managerQuery({
     if (!ctx.shop) return false;
     const shop = ctx.shop;
     // 種別「通知」(other) は要対応の対象外。対応可能な open 失敗が1件でもあるかだけを返す。
-    for await (const failure of ctx.db
-      .query("notificationFailureInbox")
-      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shop._id).eq("status", "open"))) {
-      if (isManagerActionableNotificationFailure(failure.notificationContext)) return true;
-    }
-    return false;
+    const actionableFailure = await filter(
+      ctx.db
+        .query("notificationFailureInbox")
+        .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shop._id).eq("status", "open")),
+      (failure) => isManagerActionableNotificationFailure(failure.notificationContext),
+    ).first();
+    return actionableFailure !== null;
   },
 });
 

--- a/convex/notificationOutbox/queries.ts
+++ b/convex/notificationOutbox/queries.ts
@@ -2,7 +2,11 @@ import { paginationOptsValidator } from "convex/server";
 import type { Doc } from "../_generated/dataModel";
 import { formatPeriodLabel } from "../_lib/dateFormat";
 import { managerQuery } from "../_lib/functions";
-import { describeNotificationFailureContext, getNotificationFailureResendKind } from "./failureResend";
+import {
+  describeNotificationFailureContext,
+  getNotificationFailureResendKind,
+  isManagerActionableNotificationFailure,
+} from "./failureResend";
 
 const EMPTY_PAGE = { page: [], isDone: true, continueCursor: "" } as {
   page: never[];
@@ -22,8 +26,13 @@ export const listOpenFailures = managerQuery({
       .order("desc")
       .paginate(paginationOpts);
 
+    // 種別「通知」(other) は再通知できずマネージャーが対応しようがないため、一覧にも要対応バッジにも出さない。
+    const actionableFailures = result.page.filter((failure) =>
+      isManagerActionableNotificationFailure(failure.notificationContext),
+    );
+
     const page = await Promise.all(
-      result.page.map(async (failure) => {
+      actionableFailures.map(async (failure) => {
         const [staff, recruitment] = await Promise.all([
           failure.staffId ? ctx.db.get(failure.staffId) : null,
           failure.recruitmentId ? ctx.db.get(failure.recruitmentId) : null,
@@ -66,11 +75,13 @@ export const hasOpenFailures = managerQuery({
   handler: async (ctx) => {
     if (!ctx.shop) return false;
     const shop = ctx.shop;
-    const failures = await ctx.db
+    // 種別「通知」(other) は要対応の対象外。対応可能な open 失敗が1件でもあるかだけを返す。
+    for await (const failure of ctx.db
       .query("notificationFailureInbox")
-      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shop._id).eq("status", "open"))
-      .take(1);
-    return failures.length > 0;
+      .withIndex("by_shopId_status_lastFailedAt", (q) => q.eq("shopId", shop._id).eq("status", "open"))) {
+      if (isManagerActionableNotificationFailure(failure.notificationContext)) return true;
+    }
+    return false;
   },
 });
 

--- a/doc/features/notification-failure-dashboard.md
+++ b/doc/features/notification-failure-dashboard.md
@@ -50,6 +50,7 @@
 
 ## 表示ルール
 
+- 通知種別が `通知`（`other` = どの通知種別にもマッピングされない context）の不達は、再通知できずマネージャーが対応しようがないため、一覧・要対応有無（HeroSummaryの「不達通知があります」カード）・日次リマインダーのいずれにも出さない。判定は `isManagerActionableNotificationFailure`（`convex/notificationOutbox/failureResend.ts`）。記録自体は `notificationFailureInbox` に残す（配送ログ・Resend webhook突合のため）。
 - エラー理由、スタッフID、解決済み操作は表示しない。
 - メール channel の不達が含まれる場合は「メールが届かない場合は、メールアドレスに誤りがないか確認ください。それでも失敗する場合は、スタッフ行のメニューからLINE連携リンクを案内できます。」と補足する。
 - Resend provider 由来の遅延・失敗・拒否・抑止は、既存行と同じ `送れなかった通知` として表示する。細かい provider 状態ラベルは出さない。

--- a/src/components/features/Dashboard/NotificationFailureDialog/index.stories.tsx
+++ b/src/components/features/Dashboard/NotificationFailureDialog/index.stories.tsx
@@ -49,6 +49,16 @@ const failures: DashboardNotificationFailure[] = [
     lastFailedAt: new Date("2026-06-22T03:11:00.000Z").getTime(),
     canRetry: true,
   },
+  {
+    _id: id("failure-4"),
+    staffName: "田中 一郎",
+    notificationKind: "lineInvite",
+    notificationKindLabel: "LINE連携案内",
+    periodLabel: null,
+    channel: "email",
+    lastFailedAt: new Date("2026-06-22T02:40:00.000Z").getTime(),
+    canRetry: true,
+  },
 ];
 
 export const Normal: Story = {

--- a/src/components/features/Dashboard/NotificationFailureDialog/index.tsx
+++ b/src/components/features/Dashboard/NotificationFailureDialog/index.tsx
@@ -7,7 +7,7 @@ import { formatDateTime } from "@/src/domains/shift/date";
 export type DashboardNotificationFailure = {
   _id: Id<"notificationFailureInbox">;
   staffName: string;
-  notificationKind: "recruitment" | "reminder" | "confirmation" | "other";
+  notificationKind: "recruitment" | "reminder" | "confirmation" | "lineInvite" | "other";
   notificationKindLabel: string;
   periodLabel: string | null;
   channel?: "email" | "line";
@@ -281,6 +281,8 @@ function kindPalette(kind: DashboardNotificationFailure["notificationKind"]) {
       return "orange";
     case "confirmation":
       return "blue";
+    case "lineInvite":
+      return "green";
     case "other":
       return "gray";
   }


### PR DESCRIPTION
再通知できずマネージャーが対応しようがない種別「通知」(other =
どの通知種別にもマッピングされない context)の不達通知を、不達通知一覧・
HeroSummaryの「不達通知があります」カード・日次リマインダーのいずれにも
出さないようにした。判定は isManagerActionableNotificationFailure に集約。

記録自体は notificationFailureInbox に残す(配送ログ・Resend webhook突合のため)。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jk9DCmosUKUUbVT2w2iDvM