### PR TITLE
feat(shop): 店舗ソフトデリート機能を追加

### DIFF
--- a/convex/shop/mutations.test.ts
+++ b/convex/shop/mutations.test.ts
@@ -405,4 +405,142 @@ describe("shop/mutations", () => {
       ).rejects.toThrow("勤務区分は4件まで登録できます");
     });
   });
+
+  describe("deleteShop", () => {
+    it("未認証の場合エラーをthrowする", async () => {
+      const t = convexTest(schema, modules);
+      await expect(t.mutation(api.shop.mutations.deleteShop, {})).rejects.toThrow();
+    });
+
+    it("店舗が存在しないマネージャーは Not found でエラー", async () => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        await seedUser(ctx, "user_no_shop", "noshop@example.com");
+      });
+      await expect(
+        t.withIdentity({ subject: "user_no_shop" }).mutation(api.shop.mutations.deleteShop, {}),
+      ).rejects.toThrow();
+    });
+
+    it("店舗・所属スタッフ・所属マネージャーを論理削除し、アクセス経路を無効化する", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const { userId, shopId } = await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        const recruitmentId = await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-05-01",
+          periodEnd: "2026-05-07",
+          deadline: "2026-04-28",
+          shopClosedDates: [],
+          status: "open",
+          isDeleted: false,
+          submissionPattern: { kind: "dateOnly" },
+        });
+        const staffId = await ctx.db.insert("staffs", {
+          shopId,
+          name: "佐藤",
+          email: "sato@example.com",
+          emailNormalized: "sato@example.com",
+          isDeleted: false,
+        });
+        const sessionId = await ctx.db.insert("sessions", {
+          sessionToken: "session-token",
+          staffId,
+          shopId,
+          recruitmentId,
+          expiresAt: Date.now() + 1000,
+        });
+        const magicLinkId = await ctx.db.insert("magicLinks", {
+          token: "magic-token",
+          staffId,
+          shopId,
+          recruitmentId,
+          expiresAt: Date.now() + 1000,
+        });
+        const lineLinkTokenId = await ctx.db.insert("lineLinkTokens", {
+          staffId,
+          shopId,
+          token: "line-token",
+          expiresAt: Date.now() + 1000,
+        });
+        const lineAccountId = await ctx.db.insert("staffLineAccounts", {
+          staffId,
+          shopId,
+          lineUserId: "U123",
+          linkedAt: Date.now(),
+          following: true,
+          isDeleted: false,
+        });
+        const registrationLinkId = await ctx.db.insert("shopRegistrationLinks", {
+          shopId,
+          token: "registration-token",
+          createdAt: Date.now(),
+        });
+        const membership = await ctx.db
+          .query("shopMembers")
+          .withIndex("by_userId_and_shopId", (q) => q.eq("userId", userId).eq("shopId", shopId))
+          .first();
+        return {
+          shopId,
+          staffId,
+          sessionId,
+          magicLinkId,
+          lineLinkTokenId,
+          lineAccountId,
+          registrationLinkId,
+          membershipId: membership?._id,
+        };
+      });
+
+      await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {});
+
+      await t.run(async (ctx) => {
+        expect((await ctx.db.get(ids.shopId))?.isDeleted).toBe(true);
+        expect((await ctx.db.get(ids.staffId))?.isDeleted).toBe(true);
+        expect(ids.membershipId && (await ctx.db.get(ids.membershipId))?.isDeleted).toBe(true);
+        expect((await ctx.db.get(ids.sessionId))?.revokedAt).toBeTypeOf("number");
+        expect((await ctx.db.get(ids.magicLinkId))?.revokedAt).toBeTypeOf("number");
+        expect((await ctx.db.get(ids.lineLinkTokenId))?.revokedAt).toBeTypeOf("number");
+        const lineAccount = await ctx.db.get(ids.lineAccountId);
+        expect(lineAccount?.isDeleted).toBe(true);
+        expect(lineAccount?.following).toBe(false);
+        expect((await ctx.db.get(ids.registrationLinkId))?.revokedAt).toBeTypeOf("number");
+      });
+    });
+
+    it("他店舗のデータは削除しない", async () => {
+      const t = convexTest(schema, modules);
+      const { otherShopId, otherStaffId } = await t.run(async (ctx) => {
+        await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        const other = await seedManagerShop(ctx, {
+          subject: "user_other",
+          email: "other@example.com",
+          shopName: "別店舗",
+        });
+        const otherStaffId = await ctx.db.insert("staffs", {
+          shopId: other.shopId,
+          name: "別スタッフ",
+          email: "other-staff@example.com",
+          emailNormalized: "other-staff@example.com",
+          isDeleted: false,
+        });
+        return { otherShopId: other.shopId, otherStaffId };
+      });
+
+      await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {});
+
+      await t.run(async (ctx) => {
+        expect((await ctx.db.get(otherShopId))?.isDeleted).toBe(false);
+        expect((await ctx.db.get(otherStaffId))?.isDeleted).toBe(false);
+      });
+    });
+  });
 });

--- a/convex/shop/mutations.test.ts
+++ b/convex/shop/mutations.test.ts
@@ -2,7 +2,7 @@ import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
 import { describe, expect, it } from "vitest";
 import { api } from "../_generated/api";
-import { seedManagerShop, seedUser } from "../_test/seed";
+import { seedManagerShop, seedShop, seedUser } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 import { SHIFT_TYPE_NAME_MAX_LENGTH, SHOP_NAME_MAX_LENGTH } from "../constants";
 
@@ -409,17 +409,40 @@ describe("shop/mutations", () => {
   describe("deleteShop", () => {
     it("未認証の場合エラーをthrowする", async () => {
       const t = convexTest(schema, modules);
-      await expect(t.mutation(api.shop.mutations.deleteShop, {})).rejects.toThrow();
+      const shopId = await t.run(async (ctx) => seedShop(ctx));
+      await expect(t.mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId })).rejects.toThrow();
     });
 
     it("店舗が存在しないマネージャーは Not found でエラー", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         await seedUser(ctx, "user_no_shop", "noshop@example.com");
+        return seedShop(ctx);
       });
       await expect(
-        t.withIdentity({ subject: "user_no_shop" }).mutation(api.shop.mutations.deleteShop, {}),
+        t.withIdentity({ subject: "user_no_shop" }).mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId }),
       ).rejects.toThrow();
+    });
+
+    it("confirmShopId が解決された店舗と一致しない場合は削除しない", async () => {
+      const t = convexTest(schema, modules);
+      const { ownShopId, otherShopId } = await t.run(async (ctx) => {
+        const { shopId } = await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        return { ownShopId: shopId, otherShopId: await seedShop(ctx, "別店舗") };
+      });
+
+      await expect(
+        t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {
+          confirmShopId: otherShopId,
+        }),
+      ).rejects.toThrow();
+
+      const ownShop = await t.run(async (ctx) => ctx.db.get(ownShopId));
+      expect(ownShop?.isDeleted).toBe(false);
     });
 
     it("店舗・所属スタッフ・所属マネージャーを論理削除し、アクセス経路を無効化する", async () => {
@@ -496,7 +519,9 @@ describe("shop/mutations", () => {
         };
       });
 
-      await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {});
+      await t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId });
 
       await t.run(async (ctx) => {
         expect((await ctx.db.get(ids.shopId))?.isDeleted).toBe(true);
@@ -514,8 +539,8 @@ describe("shop/mutations", () => {
 
     it("他店舗のデータは削除しない", async () => {
       const t = convexTest(schema, modules);
-      const { otherShopId, otherStaffId } = await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const { ownShopId, otherShopId, otherStaffId } = await t.run(async (ctx) => {
+        const own = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
@@ -532,10 +557,12 @@ describe("shop/mutations", () => {
           emailNormalized: "other-staff@example.com",
           isDeleted: false,
         });
-        return { otherShopId: other.shopId, otherStaffId };
+        return { ownShopId: own.shopId, otherShopId: other.shopId, otherStaffId };
       });
 
-      await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {});
+      await t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ownShopId });
 
       await t.run(async (ctx) => {
         expect((await ctx.db.get(otherShopId))?.isDeleted).toBe(false);

--- a/convex/shop/mutations.test.ts
+++ b/convex/shop/mutations.test.ts
@@ -1,6 +1,6 @@
 import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../_generated/api";
 import { seedManagerShop, seedShop, seedUser } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
@@ -407,6 +407,11 @@ describe("shop/mutations", () => {
   });
 
   describe("deleteShop", () => {
+    // バックグラウンドの cleanupDeletedShop は runAfter(0) で自己再スケジュールするため、
+    // フェイクタイマー + finishAllScheduledFunctions で完了まで進める。
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
     it("未認証の場合エラーをthrowする", async () => {
       const t = convexTest(schema, modules);
       const shopId = await t.run(async (ctx) => seedShop(ctx));
@@ -522,6 +527,7 @@ describe("shop/mutations", () => {
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
         .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId });
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {
         expect((await ctx.db.get(ids.shopId))?.isDeleted).toBe(true);
@@ -563,10 +569,124 @@ describe("shop/mutations", () => {
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
         .mutation(api.shop.mutations.deleteShop, { confirmShopId: ownShopId });
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {
         expect((await ctx.db.get(otherShopId))?.isDeleted).toBe(false);
         expect((await ctx.db.get(otherStaffId))?.isDeleted).toBe(false);
+      });
+    });
+
+    it("配信予約済み（pending/processing）の通知をキャンセルし、送信済みは変更しない", async () => {
+      const t = convexTest(schema, modules);
+      const ids = await t.run(async (ctx) => {
+        const { shopId } = await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        const base = {
+          channel: "email" as const,
+          shopId,
+          payload: {
+            kind: "email" as const,
+            context: "test",
+            from: "noreply@example.com",
+            to: "sato@example.com",
+            subject: "件名",
+            html: "<p>body</p>",
+          },
+          attemptCount: 0,
+          nextRunAt: Date.now(),
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        };
+        const pendingId = await ctx.db.insert("notificationOutbox", {
+          ...base,
+          status: "pending",
+          dedupeKey: "dedupe-pending",
+        });
+        const processingId = await ctx.db.insert("notificationOutbox", {
+          ...base,
+          status: "processing",
+          dedupeKey: "dedupe-processing",
+        });
+        const sentId = await ctx.db.insert("notificationOutbox", {
+          ...base,
+          status: "sent",
+          dedupeKey: "dedupe-sent",
+          sentAt: Date.now(),
+        });
+        return { shopId, pendingId, processingId, sentId };
+      });
+
+      await t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId });
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+      await t.run(async (ctx) => {
+        expect((await ctx.db.get(ids.pendingId))?.status).toBe("failed");
+        expect((await ctx.db.get(ids.processingId))?.status).toBe("failed");
+        expect((await ctx.db.get(ids.sentId))?.status).toBe("sent");
+      });
+    });
+
+    it("バッチサイズを超える件数でも全件を後片付けできる", async () => {
+      const t = convexTest(schema, modules);
+      const COUNT = 150; // SHOP_CLEANUP_BATCH_SIZE(100) を跨いで再スケジュールされること
+      const { shopId, magicLinkIds } = await t.run(async (ctx) => {
+        const { shopId } = await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        const recruitmentId = await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-05-01",
+          periodEnd: "2026-05-07",
+          deadline: "2026-04-28",
+          shopClosedDates: [],
+          status: "open",
+          isDeleted: false,
+          submissionPattern: { kind: "dateOnly" },
+        });
+        const magicLinkIds = [];
+        for (let i = 0; i < COUNT; i++) {
+          const staffId = await ctx.db.insert("staffs", {
+            shopId,
+            name: `スタッフ${i}`,
+            email: `staff${i}@example.com`,
+            emailNormalized: `staff${i}@example.com`,
+            isDeleted: false,
+          });
+          magicLinkIds.push(
+            await ctx.db.insert("magicLinks", {
+              token: `magic-${i}`,
+              staffId,
+              shopId,
+              recruitmentId,
+              expiresAt: Date.now() + 1000,
+            }),
+          );
+        }
+        return { shopId, magicLinkIds };
+      });
+
+      await t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId });
+      await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+      await t.run(async (ctx) => {
+        const remainingStaff = await ctx.db
+          .query("staffs")
+          .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+          .collect();
+        expect(remainingStaff).toHaveLength(0);
+        for (const magicLinkId of magicLinkIds) {
+          expect((await ctx.db.get(magicLinkId))?.revokedAt).toBeTypeOf("number");
+        }
       });
     });
   });

--- a/convex/shop/mutations.ts
+++ b/convex/shop/mutations.ts
@@ -35,3 +35,67 @@ export const updateShopSettings = managerMutation({
     });
   },
 });
+
+/**
+ * 店舗を論理削除する。
+ *
+ * 店舗本体だけでなく「所属する人」も同時に論理削除する:
+ * - staffs（スタッフ。manager 本人の staff レコードも含む）
+ * - shopMembers（マネージャーの所属。users 自体は他店舗に所属しうるので消さない）
+ *
+ * さらに、削除済み店舗へアクセスする経路を塞ぐため、スタッフのセッション/トークン/
+ * LINE 連携と、店舗への新規登録リンクを無効化する（deleteStaff と同じ方針）。
+ * 物理削除はしない（論理削除パターン）。
+ */
+export const deleteShop = managerMutation({
+  args: {},
+  handler: async (ctx) => {
+    const shopId = ctx.shop._id;
+    const now = Date.now();
+
+    await ctx.db.patch(shopId, { isDeleted: true });
+
+    const [staffs, members, sessions, magicLinks, lineLinkTokens, lineAccounts, registrationLinks] = await Promise.all([
+      ctx.db
+        .query("staffs")
+        .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+        .collect(),
+      ctx.db
+        .query("shopMembers")
+        .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+        .collect(),
+      ctx.db
+        .query("sessions")
+        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+        .collect(),
+      ctx.db
+        .query("magicLinks")
+        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+        .collect(),
+      ctx.db
+        .query("lineLinkTokens")
+        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+        .collect(),
+      ctx.db
+        .query("staffLineAccounts")
+        .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+        .collect(),
+      ctx.db
+        .query("shopRegistrationLinks")
+        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+        .collect(),
+    ]);
+
+    await Promise.all([
+      ...staffs.map((staff) => ctx.db.patch(staff._id, { isDeleted: true })),
+      ...members.map((member) => ctx.db.patch(member._id, { isDeleted: true })),
+      ...sessions
+        .filter((session) => !session.revokedAt)
+        .map((session) => ctx.db.patch(session._id, { revokedAt: now })),
+      ...magicLinks.filter((token) => !token.revokedAt).map((token) => ctx.db.patch(token._id, { revokedAt: now })),
+      ...lineLinkTokens.filter((token) => !token.revokedAt).map((token) => ctx.db.patch(token._id, { revokedAt: now })),
+      ...lineAccounts.map((account) => ctx.db.patch(account._id, { isDeleted: true, following: false })),
+      ...registrationLinks.filter((link) => !link.revokedAt).map((link) => ctx.db.patch(link._id, { revokedAt: now })),
+    ]);
+  },
+});

--- a/convex/shop/mutations.ts
+++ b/convex/shop/mutations.ts
@@ -1,9 +1,48 @@
 import { ConvexError, v } from "convex/values";
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { internalMutation, type MutationCtx } from "../_generated/server";
 import { managerMutation } from "../_lib/functions";
 import { normalizeSubmissionPattern, submissionPatternValidator } from "../_lib/submissionPattern";
 import { updateShopSettingsSchema } from "./schemas";
 
 const WEEKDAY_ORDER = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+// 削除済み店舗の後片付け 1 バッチあたりの処理件数。Convex のトランザクション
+// 読み書き上限に収まるよう控えめに設定し、超過分は runAfter で次バッチへ送る。
+const SHOP_CLEANUP_BATCH_SIZE = 100;
+
+// 後片付けの実行順。前から順に 1 フェーズずつ処理し、各フェーズを完了してから次へ進む。
+const SHOP_CLEANUP_PHASES = [
+  "outboxPending",
+  "outboxProcessing",
+  "staffs",
+  "members",
+  "lineAccounts",
+  "sessions",
+  "magicLinks",
+  "lineLinkTokens",
+  "registrationLinks",
+] as const;
+type ShopCleanupPhase = (typeof SHOP_CLEANUP_PHASES)[number];
+
+const shopCleanupPhaseValidator = v.union(
+  v.literal("outboxPending"),
+  v.literal("outboxProcessing"),
+  v.literal("staffs"),
+  v.literal("members"),
+  v.literal("lineAccounts"),
+  v.literal("sessions"),
+  v.literal("magicLinks"),
+  v.literal("lineLinkTokens"),
+  v.literal("registrationLinks"),
+);
+
+function nextShopCleanupPhase(phase: ShopCleanupPhase): ShopCleanupPhase | null {
+  return SHOP_CLEANUP_PHASES[SHOP_CLEANUP_PHASES.indexOf(phase) + 1] ?? null;
+}
+
+type ShopCleanupStep = { phase: ShopCleanupPhase; cursor: string | null } | null;
 
 export const updateShopSettings = managerMutation({
   args: {
@@ -39,13 +78,13 @@ export const updateShopSettings = managerMutation({
 /**
  * 店舗を論理削除する。
  *
- * 店舗本体だけでなく「所属する人」も同時に論理削除する:
- * - staffs（スタッフ。manager 本人の staff レコードも含む）
- * - shopMembers（マネージャーの所属。users 自体は他店舗に所属しうるので消さない）
+ * 店舗本体を即座に論理削除し、残りの後片付けはバックグラウンドのバッチ処理
+ * （cleanupDeletedShop）へ委譲する。
  *
- * さらに、削除済み店舗へアクセスする経路を塞ぐため、スタッフのセッション/トークン/
- * LINE 連携と、店舗への新規登録リンクを無効化する（deleteStaff と同じ方針）。
- * 物理削除はしない（論理削除パターン）。
+ * shop.isDeleted を立てた時点で manager / staff 双方の認証ラッパーが弾くため、
+ * 対話的なアクセスはこの mutation 内で即座に遮断される。所属する人の論理削除や
+ * トークン無効化、配信予約済み通知のキャンセルは、大規模店舗でもトランザクション
+ * 上限を超えないよう分割実行する（unbounded な collect を避ける）。
  *
  * managerMutation は shopId 省略時に「先頭の所属店舗」へフォールバックするため、
  * 複数店舗マネージャーがうっかり別テナントを消す事故が起きうる。破壊的操作なので
@@ -60,52 +99,224 @@ export const deleteShop = managerMutation({
     if (args.confirmShopId !== ctx.shop._id) {
       throw new ConvexError("Not found");
     }
-    const shopId = ctx.shop._id;
-    const now = Date.now();
-
-    await ctx.db.patch(shopId, { isDeleted: true });
-
-    const [staffs, members, sessions, magicLinks, lineLinkTokens, lineAccounts, registrationLinks] = await Promise.all([
-      ctx.db
-        .query("staffs")
-        .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
-        .collect(),
-      ctx.db
-        .query("shopMembers")
-        .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
-        .collect(),
-      ctx.db
-        .query("sessions")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
-        .collect(),
-      ctx.db
-        .query("magicLinks")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
-        .collect(),
-      ctx.db
-        .query("lineLinkTokens")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
-        .collect(),
-      ctx.db
-        .query("staffLineAccounts")
-        .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
-        .collect(),
-      ctx.db
-        .query("shopRegistrationLinks")
-        .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
-        .collect(),
-    ]);
-
-    await Promise.all([
-      ...staffs.map((staff) => ctx.db.patch(staff._id, { isDeleted: true })),
-      ...members.map((member) => ctx.db.patch(member._id, { isDeleted: true })),
-      ...sessions
-        .filter((session) => !session.revokedAt)
-        .map((session) => ctx.db.patch(session._id, { revokedAt: now })),
-      ...magicLinks.filter((token) => !token.revokedAt).map((token) => ctx.db.patch(token._id, { revokedAt: now })),
-      ...lineLinkTokens.filter((token) => !token.revokedAt).map((token) => ctx.db.patch(token._id, { revokedAt: now })),
-      ...lineAccounts.map((account) => ctx.db.patch(account._id, { isDeleted: true, following: false })),
-      ...registrationLinks.filter((link) => !link.revokedAt).map((link) => ctx.db.patch(link._id, { revokedAt: now })),
-    ]);
+    // shop.isDeleted を立てるだけで全認証ラッパーが弾くため、ここでアクセスは遮断される。
+    await ctx.db.patch(ctx.shop._id, { isDeleted: true });
+    await ctx.scheduler.runAfter(0, internal.shop.mutations.cleanupDeletedShop, { shopId: ctx.shop._id });
   },
 });
+
+/**
+ * 削除済み店舗に紐づくデータをバッチで後片付けする internal mutation。
+ *
+ * 1 回の実行で 1 フェーズ・最大 SHOP_CLEANUP_BATCH_SIZE 件を処理し、続きがあれば
+ * runAfter(0) で自分自身を再スケジュールする（pruneExpiredEvents と同じ方針）。
+ * これにより、何年分ものセッション/マジックリンクを抱える店舗でも 1 トランザクション
+ * の読み書き上限を超えずに完了できる。
+ *
+ * 対象と単調性の担保:
+ * - 通知 outbox（pending/processing → failed）: worker は shop を再読込せず配信するため、
+ *   削除後に予約済みシフト/登録通知が飛ばないようキャンセルする。status をインデックスに
+ *   含む by_shopId_status を patch で抜けるので take + 再スケジュールで前進する。
+ * - staffs / shopMembers / staffLineAccounts（isDeleted → true）: isDeleted をインデックスに
+ *   含むため同様に take で前進する。
+ * - sessions / magicLinks / lineLinkTokens / shopRegistrationLinks（revokedAt 付与）: revokedAt は
+ *   インデックス外なので paginate のカーソルで前進する（patch しても shopId 順は不変）。
+ */
+export const cleanupDeletedShop = internalMutation({
+  args: {
+    shopId: v.id("shops"),
+    phase: v.optional(shopCleanupPhaseValidator),
+    cursor: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const phase = args.phase ?? SHOP_CLEANUP_PHASES[0];
+    const next = await runShopCleanupPhase(ctx, args.shopId, phase, args.cursor ?? null);
+    if (next) {
+      await ctx.scheduler.runAfter(0, internal.shop.mutations.cleanupDeletedShop, {
+        shopId: args.shopId,
+        phase: next.phase,
+        cursor: next.cursor,
+      });
+    }
+  },
+});
+
+async function runShopCleanupPhase(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+  cursor: string | null,
+): Promise<ShopCleanupStep> {
+  switch (phase) {
+    case "outboxPending":
+      return await cancelOutboxBatch(ctx, shopId, "pending", phase);
+    case "outboxProcessing":
+      return await cancelOutboxBatch(ctx, shopId, "processing", phase);
+    case "staffs":
+      return await softDeleteStaffsBatch(ctx, shopId, phase);
+    case "members":
+      return await softDeleteMembersBatch(ctx, shopId, phase);
+    case "lineAccounts":
+      return await softDeleteLineAccountsBatch(ctx, shopId, phase);
+    case "sessions":
+      return await revokeSessionsBatch(ctx, shopId, phase, cursor);
+    case "magicLinks":
+      return await revokeMagicLinksBatch(ctx, shopId, phase, cursor);
+    case "lineLinkTokens":
+      return await revokeLineLinkTokensBatch(ctx, shopId, phase, cursor);
+    case "registrationLinks":
+      return await revokeRegistrationLinksBatch(ctx, shopId, phase, cursor);
+  }
+}
+
+// take 件数が満杯なら同フェーズを継続、そうでなければ次フェーズへ進む（カーソル不要）。
+function advanceAfterTakeBatch(phase: ShopCleanupPhase, processed: number): ShopCleanupStep {
+  if (processed === SHOP_CLEANUP_BATCH_SIZE) return { phase, cursor: null };
+  const next = nextShopCleanupPhase(phase);
+  return next ? { phase: next, cursor: null } : null;
+}
+
+// paginate の続きがあれば同フェーズ＋カーソルを継続、なければ次フェーズへ進む。
+function advanceAfterPaginatedBatch(
+  phase: ShopCleanupPhase,
+  page: { isDone: boolean; continueCursor: string },
+): ShopCleanupStep {
+  if (!page.isDone) return { phase, cursor: page.continueCursor };
+  const next = nextShopCleanupPhase(phase);
+  return next ? { phase: next, cursor: null } : null;
+}
+
+async function cancelOutboxBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  status: "pending" | "processing",
+  phase: ShopCleanupPhase,
+): Promise<ShopCleanupStep> {
+  const jobs = await ctx.db
+    .query("notificationOutbox")
+    .withIndex("by_shopId_status", (q) => q.eq("shopId", shopId).eq("status", status))
+    .take(SHOP_CLEANUP_BATCH_SIZE);
+  const now = Date.now();
+  for (const job of jobs) {
+    await ctx.db.patch(job._id, {
+      status: "failed",
+      failedAt: now,
+      updatedAt: now,
+      lastError: "shop deleted",
+    });
+  }
+  return advanceAfterTakeBatch(phase, jobs.length);
+}
+
+async function softDeleteStaffsBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+): Promise<ShopCleanupStep> {
+  const staffs = await ctx.db
+    .query("staffs")
+    .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+    .take(SHOP_CLEANUP_BATCH_SIZE);
+  for (const staff of staffs) {
+    await ctx.db.patch(staff._id, { isDeleted: true });
+  }
+  return advanceAfterTakeBatch(phase, staffs.length);
+}
+
+async function softDeleteMembersBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+): Promise<ShopCleanupStep> {
+  const members = await ctx.db
+    .query("shopMembers")
+    .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+    .take(SHOP_CLEANUP_BATCH_SIZE);
+  for (const member of members) {
+    await ctx.db.patch(member._id, { isDeleted: true });
+  }
+  return advanceAfterTakeBatch(phase, members.length);
+}
+
+async function softDeleteLineAccountsBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+): Promise<ShopCleanupStep> {
+  const accounts = await ctx.db
+    .query("staffLineAccounts")
+    .withIndex("by_shopId_and_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
+    .take(SHOP_CLEANUP_BATCH_SIZE);
+  for (const account of accounts) {
+    await ctx.db.patch(account._id, { isDeleted: true, following: false });
+  }
+  return advanceAfterTakeBatch(phase, accounts.length);
+}
+
+async function revokeSessionsBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+  cursor: string | null,
+): Promise<ShopCleanupStep> {
+  const now = Date.now();
+  const page = await ctx.db
+    .query("sessions")
+    .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+    .paginate({ cursor, numItems: SHOP_CLEANUP_BATCH_SIZE });
+  for (const session of page.page) {
+    if (!session.revokedAt) await ctx.db.patch(session._id, { revokedAt: now });
+  }
+  return advanceAfterPaginatedBatch(phase, page);
+}
+
+async function revokeMagicLinksBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+  cursor: string | null,
+): Promise<ShopCleanupStep> {
+  const now = Date.now();
+  const page = await ctx.db
+    .query("magicLinks")
+    .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+    .paginate({ cursor, numItems: SHOP_CLEANUP_BATCH_SIZE });
+  for (const token of page.page) {
+    if (!token.revokedAt) await ctx.db.patch(token._id, { revokedAt: now });
+  }
+  return advanceAfterPaginatedBatch(phase, page);
+}
+
+async function revokeLineLinkTokensBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+  cursor: string | null,
+): Promise<ShopCleanupStep> {
+  const now = Date.now();
+  const page = await ctx.db
+    .query("lineLinkTokens")
+    .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+    .paginate({ cursor, numItems: SHOP_CLEANUP_BATCH_SIZE });
+  for (const token of page.page) {
+    if (!token.revokedAt) await ctx.db.patch(token._id, { revokedAt: now });
+  }
+  return advanceAfterPaginatedBatch(phase, page);
+}
+
+async function revokeRegistrationLinksBatch(
+  ctx: MutationCtx,
+  shopId: Id<"shops">,
+  phase: ShopCleanupPhase,
+  cursor: string | null,
+): Promise<ShopCleanupStep> {
+  const now = Date.now();
+  const page = await ctx.db
+    .query("shopRegistrationLinks")
+    .withIndex("by_shopId", (q) => q.eq("shopId", shopId))
+    .paginate({ cursor, numItems: SHOP_CLEANUP_BATCH_SIZE });
+  for (const link of page.page) {
+    if (!link.revokedAt) await ctx.db.patch(link._id, { revokedAt: now });
+  }
+  return advanceAfterPaginatedBatch(phase, page);
+}

--- a/convex/shop/mutations.ts
+++ b/convex/shop/mutations.ts
@@ -46,10 +46,20 @@ export const updateShopSettings = managerMutation({
  * さらに、削除済み店舗へアクセスする経路を塞ぐため、スタッフのセッション/トークン/
  * LINE 連携と、店舗への新規登録リンクを無効化する（deleteStaff と同じ方針）。
  * 物理削除はしない（論理削除パターン）。
+ *
+ * managerMutation は shopId 省略時に「先頭の所属店舗」へフォールバックするため、
+ * 複数店舗マネージャーがうっかり別テナントを消す事故が起きうる。破壊的操作なので
+ * 削除対象を `confirmShopId` で明示させ、解決された店舗（ctx.shop）と一致しない限り
+ * 実行しない（不一致は列挙対策のため "Not found" で区別しない）。
  */
 export const deleteShop = managerMutation({
-  args: {},
-  handler: async (ctx) => {
+  args: {
+    confirmShopId: v.id("shops"),
+  },
+  handler: async (ctx, args) => {
+    if (args.confirmShopId !== ctx.shop._id) {
+      throw new ConvexError("Not found");
+    }
     const shopId = ctx.shop._id;
     const now = Date.now();
 


### PR DESCRIPTION
deleteShop mutation を追加。店舗本体に加えて、所属する人（staffs・
shopMembers）も論理削除する。削除済み店舗へのアクセス経路を塞ぐため、
スタッフのセッション/マジックリンク/LINE連携トークン・LINE連携と、
店舗への新規登録リンクも無効化する（deleteStaff と同じ方針）。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XB6CHaABAciow8yhqHeJGV