### PR TITLE
feat(notification): LINE連携案内の不達を再通知可能にする

### DIFF
--- a/convex/notificationOutbox/failureResend.ts
+++ b/convex/notificationOutbox/failureResend.ts
@@ -2,6 +2,9 @@ export type NotificationFailureKind = "recruitment" | "reminder" | "confirmation
 
 export type NotificationFailureResendKind = "recruitment" | "reminder" | "confirmation" | "reissue";
 
+/** LINE連携案内メールの送信 context。再送時は新しいマジックリンク（連携トークン）を発行し直す。 */
+export const LINE_INVITE_NOTIFICATION_CONTEXT = "line.sendInviteEmail";
+
 export type NotificationFailureLogicalKind = NotificationFailureResendKind;
 
 const RECRUITMENT_CONTEXTS = new Set([
@@ -26,8 +29,17 @@ export function describeNotificationFailureContext(context: string): {
   if (CONFIRMATION_CONTEXTS.has(context) || context === "notification.sendReissueEmail") {
     return { kind: "confirmation", label: "確定シフト" };
   }
-  if (context === "line.sendInviteEmail") return { kind: "lineInvite", label: "LINE連携案内" };
+  if (isLineInviteResendContext(context)) return { kind: "lineInvite", label: "LINE連携案内" };
   return { kind: "other", label: "通知" };
+}
+
+/**
+ * LINE連携案内メールの不達かどうか。
+ * 募集に紐づかない（recruitmentId を持たない）ため通常の再送種別とは別経路で扱い、
+ * 再送時はスタッフIDから連携依頼メールを送り直す（=新しいマジックリンクを発行する）。
+ */
+export function isLineInviteResendContext(context: string): boolean {
+  return context === LINE_INVITE_NOTIFICATION_CONTEXT;
 }
 
 /**
@@ -48,7 +60,7 @@ export const ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS: readonly string[] = [
   "notification.sendReminderEmails",
   ...CONFIRMATION_CONTEXTS,
   "notification.sendReissueEmail",
-  "line.sendInviteEmail",
+  LINE_INVITE_NOTIFICATION_CONTEXT,
 ];
 
 export function getNotificationFailureResendKind(context: string): NotificationFailureResendKind | null {

--- a/convex/notificationOutbox/mutations.test.ts
+++ b/convex/notificationOutbox/mutations.test.ts
@@ -1349,6 +1349,45 @@ describe("notificationOutbox", () => {
     expect(state.scheduled.some((job) => job.name === "line/actions:sendInviteEmail")).toBe(false);
   });
 
+  it("resendOpenFailuresは同一スタッフのLINE連携案内をまとめて1回だけ予約する", async () => {
+    const { t, shopId, staffId } = await setupShop();
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      for (const suffix of ["a", "b"]) {
+        await ctx.db.insert("notificationFailureInbox", {
+          failureKey: `provider:resend:lineInvite-${suffix}`,
+          sourceType: "provider",
+          status: "open",
+          shopId,
+          staffId,
+          channel: "email",
+          dedupeKey: `email:lineInvite:${staffId}`,
+          notificationContext: "line.sendInviteEmail",
+          firstFailedAt: now,
+          lastFailedAt: now,
+          lastError: "bounced",
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    });
+
+    const result = await t
+      .withIdentity({ subject: "user_mgr" })
+      .mutation(api.notificationOutbox.mutations.resendOpenFailures, {});
+
+    expect(result.scheduledCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+    const scheduled = await t.run(async (ctx) =>
+      ctx.db.system
+        .query("_scheduled_functions")
+        .collect()
+        .then((jobs) => jobs.filter((job) => job.name === "line/actions:sendInviteEmail")),
+    );
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.args[0]?.staffId).toBe(staffId);
+  });
+
   it("resendOpenFailuresは現在店舗のopen失敗だけを一斉再通知する", async () => {
     const { t, shopId, staffId } = await setupShop();
     const ids = await t.run(async (ctx) => {

--- a/convex/notificationOutbox/mutations.test.ts
+++ b/convex/notificationOutbox/mutations.test.ts
@@ -1270,6 +1270,85 @@ describe("notificationOutbox", () => {
     expect(openPage.page).toHaveLength(0);
   });
 
+  it("resendFailureはLINE連携案内の不達を連携依頼メール再送に予約する（募集なしでも可）", async () => {
+    const { t, shopId, staffId } = await setupShop();
+    const failureId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert("notificationFailureInbox", {
+        failureKey: "provider:resend:lineInvite",
+        sourceType: "provider",
+        status: "open",
+        shopId,
+        staffId,
+        channel: "email",
+        dedupeKey: `email:lineInvite:${staffId}`,
+        notificationContext: "line.sendInviteEmail",
+        firstFailedAt: now,
+        lastFailedAt: now,
+        lastError: "bounced",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const result = await t
+      .withIdentity({ subject: "user_mgr" })
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+
+    expect(result).toEqual({ scheduled: true });
+    const state = await t.run(async (ctx) => ({
+      failure: await ctx.db.get(failureId),
+      scheduled: await ctx.db.system.query("_scheduled_functions").collect(),
+    }));
+    expect(state.failure).toMatchObject({ status: "retrying", retryRequestedByUserId: expect.any(String) });
+    expect(
+      state.scheduled.some((job) => job.name === "line/actions:sendInviteEmail" && job.args[0]?.staffId === staffId),
+    ).toBe(true);
+    const openPage = await t
+      .withIdentity({ subject: "user_mgr" })
+      .query(api.notificationOutbox.queries.listOpenFailures, {
+        paginationOpts: { numItems: 10, cursor: null },
+      });
+    expect(openPage.page).toHaveLength(0);
+  });
+
+  it("resendFailureはメール未登録スタッフのLINE連携案内を再送しない", async () => {
+    const { t, shopId } = await setupShop();
+    const staffWithoutEmailId = await t.run(async (ctx) => {
+      return await ctx.db.insert("staffs", { shopId, name: "メールなしスタッフ", email: "", isDeleted: false });
+    });
+    const failureId = await t.run(async (ctx) => {
+      const now = Date.now();
+      return await ctx.db.insert("notificationFailureInbox", {
+        failureKey: "provider:resend:lineInvite-noemail",
+        sourceType: "provider",
+        status: "open",
+        shopId,
+        staffId: staffWithoutEmailId,
+        channel: "email",
+        dedupeKey: `email:lineInvite:${staffWithoutEmailId}`,
+        notificationContext: "line.sendInviteEmail",
+        firstFailedAt: now,
+        lastFailedAt: now,
+        lastError: "bounced",
+        createdAt: now,
+        updatedAt: now,
+      });
+    });
+
+    const result = await t
+      .withIdentity({ subject: "user_mgr" })
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+
+    expect(result).toEqual({ scheduled: false, reason: "notRetryable" });
+    const state = await t.run(async (ctx) => ({
+      failure: await ctx.db.get(failureId),
+      scheduled: await ctx.db.system.query("_scheduled_functions").collect(),
+    }));
+    expect(state.failure?.status).toBe("open");
+    expect(state.scheduled.some((job) => job.name === "line/actions:sendInviteEmail")).toBe(false);
+  });
+
   it("resendOpenFailuresは現在店舗のopen失敗だけを一斉再通知する", async () => {
     const { t, shopId, staffId } = await setupShop();
     const ids = await t.run(async (ctx) => {

--- a/convex/notificationOutbox/mutations.ts
+++ b/convex/notificationOutbox/mutations.ts
@@ -527,14 +527,19 @@ async function requestLineInviteResend(
     return { scheduled: false, reason: "notRetryable" as const };
   }
 
-  const allowed = await allowFailureRetry(ctx, failure._id);
-  if (!allowed) return { scheduled: false, reason: "rateLimited" as const };
-
   const staff = await ctx.db.get(failure.staffId);
   // 連携依頼はメールで送るため、メール未登録のスタッフには再送できない。
   if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted || !staff.email) {
     return { scheduled: false, reason: "notRetryable" as const };
   }
+
+  // 通常の個別連携依頼（line.mutations.sendInvite）と同じスタッフ単位のレートリミットを使い、
+  // 一斉再通知で同一スタッフへ連携依頼メールが重複送信されるのを防ぐ。
+  const { ok } = await rateLimit(ctx, {
+    name: "lineInviteShort",
+    key: `${ctx.shop._id}:${failure.staffId}`,
+  });
+  if (!ok) return { scheduled: false, reason: "rateLimited" as const };
 
   // sendInviteEmail は呼ぶたびに新しい連携トークン（マジックリンク）を発行して送り直す。
   await ctx.scheduler.runAfter(0, internal.line.actions.sendInviteEmail, {
@@ -1051,5 +1056,12 @@ function sortFailureByRecencyDesc(a: Doc<"notificationFailureInbox">, b: Doc<"no
 }
 
 function resendBatchKey(failure: Doc<"notificationFailureInbox">) {
-  return getNotificationFailureIdentityForDoc(failure)?.failureKey ?? `failure:${failure._id}`;
+  const identityKey = getNotificationFailureIdentityForDoc(failure)?.failureKey;
+  if (identityKey) return identityKey;
+  // LINE連携案内は募集に紐づかず論理キーを持たないため、一斉再通知で同一スタッフの
+  // 複数行を1回にまとめられるようスタッフ単位のキーを返す。
+  if (isLineInviteResendContext(failure.notificationContext) && failure.staffId) {
+    return `lineInvite:${failure.shopId}:${failure.staffId}`;
+  }
+  return `failure:${failure._id}`;
 }

--- a/convex/notificationOutbox/mutations.ts
+++ b/convex/notificationOutbox/mutations.ts
@@ -21,7 +21,7 @@ import {
   getNotificationFailureIdentityForDoc,
   supersededFailureKey,
 } from "./failureIdentity";
-import { getNotificationFailureResendKind } from "./failureResend";
+import { getNotificationFailureResendKind, isLineInviteResendContext } from "./failureResend";
 import { shouldSuppressNotificationFailureInbox } from "./failureSuppress";
 import { type ResendProviderIssueEventType, resendProviderDeliveryStatus } from "./resendProviderEvents";
 import {
@@ -453,6 +453,12 @@ async function requestFailureResend(
   ctx: ManagerNotificationOutboxMutationCtx,
   failure: Doc<"notificationFailureInbox">,
 ) {
+  // LINE連携案内は sourceType を問わず、送信のたびに新しいマジックリンクを発行して送り直す。
+  // （既存 outbox を再実行すると古いトークンを使い回してしまうため別経路にする）
+  if (isLineInviteResendContext(failure.notificationContext)) {
+    return await requestLineInviteResend(ctx, failure);
+  }
+
   if (failure.sourceType === "outbox") {
     return await retryOutboxFailure(ctx, failure, { throwOnNotFound: false });
   }
@@ -510,6 +516,31 @@ async function requestFailureResend(
   }
 
   await markFailureRetrying(ctx, failure._id, now);
+  return { scheduled: true as const };
+}
+
+async function requestLineInviteResend(
+  ctx: ManagerNotificationOutboxMutationCtx,
+  failure: Doc<"notificationFailureInbox">,
+) {
+  if (failure.shopId !== ctx.shop._id || failure.status !== "open" || !failure.staffId) {
+    return { scheduled: false, reason: "notRetryable" as const };
+  }
+
+  const allowed = await allowFailureRetry(ctx, failure._id);
+  if (!allowed) return { scheduled: false, reason: "rateLimited" as const };
+
+  const staff = await ctx.db.get(failure.staffId);
+  // 連携依頼はメールで送るため、メール未登録のスタッフには再送できない。
+  if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted || !staff.email) {
+    return { scheduled: false, reason: "notRetryable" as const };
+  }
+
+  // sendInviteEmail は呼ぶたびに新しい連携トークン（マジックリンク）を発行して送り直す。
+  await ctx.scheduler.runAfter(0, internal.line.actions.sendInviteEmail, {
+    staffId: failure.staffId,
+  });
+  await markFailureRetrying(ctx, failure._id, Date.now());
   return { scheduled: true as const };
 }
 

--- a/convex/notificationOutbox/queries.ts
+++ b/convex/notificationOutbox/queries.ts
@@ -7,6 +7,7 @@ import {
   ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS,
   describeNotificationFailureContext,
   getNotificationFailureResendKind,
+  isLineInviteResendContext,
   isManagerActionableNotificationFailure,
 } from "./failureResend";
 
@@ -93,6 +94,8 @@ export const hasOpenFailures = managerQuery({
 });
 
 function canRetryFailure(failure: Doc<"notificationFailureInbox">) {
+  // LINE連携案内は募集に紐づかず、スタッフIDから連携依頼メールを送り直せる（新しいマジックリンクを発行）。
+  if (isLineInviteResendContext(failure.notificationContext)) return Boolean(failure.staffId);
   if (failure.sourceType === "outbox") return Boolean(failure.outboxId);
   return Boolean(
     failure.staffId && failure.recruitmentId && getNotificationFailureResendKind(failure.notificationContext),

--- a/doc/features/notification-failure-dashboard.md
+++ b/doc/features/notification-failure-dashboard.md
@@ -59,3 +59,5 @@
 - 非同期配送で再度失敗した場合は failure 記録により `open` として再表示される。
 - 初回失敗から30日を過ぎた不達通知は日次cronで `resolved/expired` になり、行は残したままDashboard表示と再通知対象から外れる。
 - 同じ通知種別・募集・スタッフの不達は最新1件だけを `open` として扱う。古い重複行は `resolved/superseded` になり、一覧や一斉再通知の対象にはしない。
+- `LINE連携案内`（context `line.sendInviteEmail`）の不達は募集に紐づかないため、PCテーブルの募集期間セルは `-`（ダッシュ）を表示し、SPカードでは募集期間行自体を出さない。
+- `LINE連携案内` の再通知は `sourceType` を問わず `internal.line.actions.sendInviteEmail` を予約し、**送信のたびに新しいマジックリンク（連携トークン）を発行して送り直す**（既存 outbox の再実行で古いトークンを使い回さない）。スタッフIDがあれば再通知可能だが、連携依頼はメールで送るためメール未登録（空文字）のスタッフには再送しない。判定は `isLineInviteResendContext`（`convex/notificationOutbox/failureResend.ts`）。

--- a/src/components/features/Dashboard/NotificationFailureDialog/index.tsx
+++ b/src/components/features/Dashboard/NotificationFailureDialog/index.tsx
@@ -120,7 +120,7 @@ export const NotificationFailureDialogContent = ({
                   <NotificationKindBadge failure={failure} />
                 </Table.Cell>
                 <Table.Cell color="gray.800" textAlign="center" verticalAlign="middle">
-                  {failure.periodLabel ?? "対象の募集なし"}
+                  {failure.periodLabel ?? "-"}
                 </Table.Cell>
                 <Table.Cell textAlign="center" verticalAlign="middle">
                   <ChannelText channel={failure.channel} />
@@ -153,9 +153,11 @@ export const NotificationFailureDialogContent = ({
                 <ChannelText channel={failure.channel} />
               </Flex>
 
-              <Text fontSize="sm" color="gray.700" lineHeight="short">
-                {failure.periodLabel ?? "対象の募集なし"}
-              </Text>
+              {failure.periodLabel && (
+                <Text fontSize="sm" color="gray.700" lineHeight="short">
+                  {failure.periodLabel}
+                </Text>
+              )}
 
               <HStack gap={2} wrap="wrap">
                 <NotificationKindBadge failure={failure} />


### PR DESCRIPTION
送れなかった通知ダイアログで LINE連携案内（line.sendInviteEmail）が
「再通知不可」になっていたのを再送できるようにする。再送時は
sendInviteEmail を予約し、毎回新しいマジックリンク（連携トークン）を
発行して送り直す。sourceType を問わず別経路で扱い、既存 outbox の
再実行で古いトークンを使い回さない。

- canRetryFailure: lineInvite はスタッフIDがあれば再通知可
- requestFailureResend: lineInvite を requestLineInviteResend に分岐
  （メール未登録スタッフは notRetryable）
- 募集に紐づかない行の表示: PCテーブルは「-」、SPは募集期間行を非表示

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ADxyux8jqbMFWJZzF8Hu4n