### PR TITLE
feat: スタッフのシフト確認で今日の日付を初期表示する

### DIFF
--- a/src/components/features/Shift/ShiftForm/hooks/useScrollDateIntoView.ts
+++ b/src/components/features/Shift/ShiftForm/hooks/useScrollDateIntoView.ts
@@ -1,0 +1,25 @@
+import { type RefObject, useEffect } from "react";
+
+// 選択日のチップ（data-date-chip="<iso>"）をコンテナ内で画面内へスクロールする。
+// 初期表示で今日が先頭以外のとき、レール／横チップが今日まで自動スクロールするために使う。
+export const useScrollDateIntoView = (
+  containerRef: RefObject<HTMLElement | null>,
+  selectedDate: string,
+  axis: "vertical" | "horizontal",
+) => {
+  useEffect(() => {
+    if (!selectedDate) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const target = container.querySelector<HTMLElement>(`[data-date-chip="${selectedDate}"]`);
+    if (!target) return;
+
+    const frame = requestAnimationFrame(() => {
+      target.scrollIntoView({
+        block: "nearest",
+        inline: axis === "horizontal" ? "center" : "nearest",
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [containerRef, selectedDate, axis]);
+};

--- a/src/components/features/Shift/ShiftForm/hooks/useShiftFormInit.ts
+++ b/src/components/features/Shift/ShiftForm/hooks/useShiftFormInit.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import type { AssignmentIssue } from "@/convex/shiftBoard/validation";
 import type { ShiftSubmissionPattern } from "@/convex/shop/schemas";
 import type { AssignmentWarning } from "@/src/domains/shift/assignmentWarnings";
+import { resolveInitialSelectedDate } from "@/src/domains/shift/date";
 import { indexShiftsByStaffId } from "@/src/domains/shift/shiftLookup";
 import { sortDailyStaffs } from "@/src/domains/shift/sortStaffs";
 import type {
@@ -39,6 +40,7 @@ type UseShiftFormInitParams = {
   requiredStaffing?: RequiredStaffingData[];
   submissionPattern?: ShiftSubmissionPattern;
   displayMode?: "request" | "confirmed";
+  defaultToToday?: boolean;
   initialViewMode?: ViewMode;
   initialSortMode?: SortMode;
   validationIssues?: AssignmentIssue[];
@@ -59,6 +61,7 @@ export const useShiftFormInit = ({
   requiredStaffing,
   submissionPattern,
   displayMode = "request",
+  defaultToToday = false,
   initialViewMode,
   initialSortMode,
   validationIssues,
@@ -80,7 +83,7 @@ export const useShiftFormInit = ({
     isInitialized.current = true;
 
     setShifts(initialShifts);
-    const initialDate = dates[0] ?? "";
+    const initialDate = resolveInitialSelectedDate(dates, defaultToToday);
     setSelectedDate(initialDate);
     if (initialDate && staffs.length > 0) {
       const shiftByStaffId = indexShiftsByStaffId(initialShifts.filter((shift) => shift.date === initialDate));
@@ -105,6 +108,7 @@ export const useShiftFormInit = ({
     dates,
     staffs,
     submissionPattern,
+    defaultToToday,
     setShifts,
     setSelectedDate,
     setLockedDailyStaffOrder,

--- a/src/components/features/Shift/ShiftForm/index.tsx
+++ b/src/components/features/Shift/ShiftForm/index.tsx
@@ -45,6 +45,7 @@ type ShiftFormProps = {
   requiredStaffing?: RequiredStaffingData[];
   submissionPattern?: ShiftSubmissionPattern;
   displayMode?: "request" | "confirmed";
+  defaultToToday?: boolean;
   initialViewMode?: ViewMode;
   initialSortMode?: SortMode;
   onShiftsChange?: (shifts: ShiftData[]) => void;
@@ -75,6 +76,7 @@ const ShiftFormInner = ({
   requiredStaffing,
   submissionPattern,
   displayMode,
+  defaultToToday,
   initialViewMode,
   initialSortMode,
   onShiftsChange,
@@ -104,6 +106,7 @@ const ShiftFormInner = ({
     requiredStaffing,
     submissionPattern,
     displayMode,
+    defaultToToday,
     initialViewMode,
     initialSortMode,
     validationIssues,

--- a/src/components/features/Shift/ShiftForm/pc/DailyView/DateRail.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/DailyView/DateRail.tsx
@@ -1,7 +1,9 @@
 import { Box, Flex, Stack } from "@chakra-ui/react";
 import dayjs from "dayjs";
+import { useRef } from "react";
 import { getWeekdayLabel } from "@/src/domains/shift/date";
 import { DateIssueBadge, dateIssueBorderColor } from "../../components";
+import { useScrollDateIntoView } from "../../hooks/useScrollDateIntoView";
 
 type Props = {
   dates: string[];
@@ -19,67 +21,74 @@ const dayColor = (dateStr: string): string => {
   return "#3f3f46";
 };
 
-export const DateRail = ({ dates, selectedDate, onSelect, holidays = [], issueCounts, warningCounts }: Props) => (
-  <Box
-    minH={0}
-    borderRightWidth="1px"
-    borderColor="gray.200"
-    bg="white"
-    py={2}
-    overflow="auto"
-    alignSelf="stretch"
-    role="tablist"
-    aria-label="日付選択"
-    data-tour="date-rail"
-  >
-    <Stack gap={1} px={2}>
-      {dates.map((iso) => {
-        const d = dayjs(iso);
-        const active = iso === selectedDate;
-        const isClosed = holidays.includes(iso);
-        const issueCount = issueCounts?.get(iso) ?? 0;
-        const warningCount = warningCounts?.get(iso) ?? 0;
-        const badgeBorderColor = dateIssueBorderColor({
-          active,
-          issueCount,
-          warningCount,
-          activeColor: "teal.300",
-          fallbackColor: "transparent",
-        });
-        return (
-          <Box
-            key={iso}
-            role="tab"
-            aria-selected={active}
-            onClick={() => onSelect(iso)}
-            cursor="pointer"
-            position="relative"
-            py="6px"
-            px="8px"
-            borderRadius="md"
-            borderWidth="1px"
-            borderColor={badgeBorderColor}
-            bg={active ? "teal.50" : isClosed ? "gray.50" : "transparent"}
-            transition="all 120ms"
-            _hover={{ bg: active ? "teal.50" : "gray.50" }}
-          >
-            <DateIssueBadge issueCount={issueCount} warningCount={warningCount} />
-            <Flex align="baseline" justify="center" gap="3px">
-              <Box textStyle="sm" fontWeight={700} color="gray.800" fontVariantNumeric="tabular-nums">
-                {d.date()}
-              </Box>
-              <Box textStyle="caption" fontWeight={600} style={{ color: dayColor(iso) }}>
-                ({getWeekdayLabel(iso)})
-              </Box>
-            </Flex>
-            {isClosed && (
-              <Box mt="2px" textStyle="2xs" fontWeight={700} color="gray.500" textAlign="center">
-                定休日
-              </Box>
-            )}
-          </Box>
-        );
-      })}
-    </Stack>
-  </Box>
-);
+export const DateRail = ({ dates, selectedDate, onSelect, holidays = [], issueCounts, warningCounts }: Props) => {
+  const railRef = useRef<HTMLDivElement>(null);
+  useScrollDateIntoView(railRef, selectedDate, "vertical");
+
+  return (
+    <Box
+      ref={railRef}
+      minH={0}
+      borderRightWidth="1px"
+      borderColor="gray.200"
+      bg="white"
+      py={2}
+      overflow="auto"
+      alignSelf="stretch"
+      role="tablist"
+      aria-label="日付選択"
+      data-tour="date-rail"
+    >
+      <Stack gap={1} px={2}>
+        {dates.map((iso) => {
+          const d = dayjs(iso);
+          const active = iso === selectedDate;
+          const isClosed = holidays.includes(iso);
+          const issueCount = issueCounts?.get(iso) ?? 0;
+          const warningCount = warningCounts?.get(iso) ?? 0;
+          const badgeBorderColor = dateIssueBorderColor({
+            active,
+            issueCount,
+            warningCount,
+            activeColor: "teal.300",
+            fallbackColor: "transparent",
+          });
+          return (
+            <Box
+              key={iso}
+              data-date-chip={iso}
+              role="tab"
+              aria-selected={active}
+              onClick={() => onSelect(iso)}
+              cursor="pointer"
+              position="relative"
+              py="6px"
+              px="8px"
+              borderRadius="md"
+              borderWidth="1px"
+              borderColor={badgeBorderColor}
+              bg={active ? "teal.50" : isClosed ? "gray.50" : "transparent"}
+              transition="all 120ms"
+              _hover={{ bg: active ? "teal.50" : "gray.50" }}
+            >
+              <DateIssueBadge issueCount={issueCount} warningCount={warningCount} />
+              <Flex align="baseline" justify="center" gap="3px">
+                <Box textStyle="sm" fontWeight={700} color="gray.800" fontVariantNumeric="tabular-nums">
+                  {d.date()}
+                </Box>
+                <Box textStyle="caption" fontWeight={600} style={{ color: dayColor(iso) }}>
+                  ({getWeekdayLabel(iso)})
+                </Box>
+              </Flex>
+              {isClosed && (
+                <Box mt="2px" textStyle="2xs" fontWeight={700} color="gray.500" textAlign="center">
+                  定休日
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+};

--- a/src/components/features/Shift/ShiftForm/pc/DateOnlyView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/pc/DateOnlyView/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Text } from "@chakra-ui/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getAssignmentWarningSettingText } from "@/src/domains/shift/assignmentWarningSummary";
 import {
   buildWeeklyGrid,
@@ -24,6 +24,7 @@ import {
   dailySortedStaffsAtom,
   issueCountByDateAtom,
   lockDailyStaffOrderAtom,
+  selectedDateAtom,
   shiftConfigAtom,
   shiftsAtom,
   validationWarningsAtom,
@@ -67,6 +68,17 @@ export const DateOnlyView = () => {
   const sortableDates = useMemo(() => getSortableDates(visibleDates, holidays), [visibleDates, holidays]);
   const defaultSortDate = sortableDates[0]?.iso ?? "";
   const [sortDate, setSortDate] = useState(defaultSortDate);
+  const selectedDate = useAtomValue(selectedDateAtom);
+  const didInitWeek = useRef(false);
+
+  // 初回1度だけ、選択日（スタッフ確認では今日）を含む週を開く。
+  // 通常の呼び出し元では selectedDate = 期間先頭日 = 1週目のため変更なし。
+  useEffect(() => {
+    if (didInitWeek.current || !selectedDate || weeks.length === 0) return;
+    didInitWeek.current = true;
+    const idx = weeks.findIndex((week) => week.dates.some((date) => date.inRange && date.iso === selectedDate));
+    if (idx > 0) setSelectedWeekIndex(idx);
+  }, [selectedDate, weeks]);
   const visibleInRangeDateKeys = useMemo(
     () => visibleDates.filter((date) => date.inRange).map((date) => date.iso),
     [visibleDates],

--- a/src/components/features/Shift/ShiftForm/sp/DailyView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/DailyView/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../components";
 import { BREAK_POSITION } from "../../constants";
 import { useLockedDailyStaffOrder } from "../../hooks/useLockedDailyStaffOrder";
+import { useScrollDateIntoView } from "../../hooks/useScrollDateIntoView";
 import {
   dailySortedStaffsAtom,
   issueCountByDateAtom,
@@ -82,6 +83,8 @@ export const SPDailyView = () => {
   const detailDialog = useDialog();
   const [selectedStaffId, setSelectedStaffId] = useState<string | null>(null);
   const touchStartX = useRef(0);
+  const dateStripRef = useRef<HTMLDivElement>(null);
+  useScrollDateIntoView(dateStripRef, selectedDate, "horizontal");
 
   const rows = useMemo(
     () =>
@@ -187,7 +190,7 @@ export const SPDailyView = () => {
         flexShrink={0}
         data-tour="date-rail"
       >
-        <Flex gap={2} overflow="auto" pt={2} pb={1}>
+        <Flex ref={dateStripRef} gap={2} overflow="auto" pt={2} pb={1}>
           {dates.map((iso) => {
             const d = dayjs(iso);
             const active = iso === selectedDate;
@@ -204,6 +207,7 @@ export const SPDailyView = () => {
             return (
               <Box
                 key={iso}
+                data-date-chip={iso}
                 onClick={() => selectDate(iso)}
                 position="relative"
                 flexShrink={0}

--- a/src/components/features/Shift/ShiftForm/sp/DateOnlyDailyView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/DateOnlyDailyView/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Stack, Text } from "@chakra-ui/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import type { ReactNode } from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import {
   formatDateShort,
   formatDateWithWeekday,
@@ -18,6 +18,7 @@ import {
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { Avatar, DateIssueBadge, dateIssueBorderColor, StaffWarningIcon } from "../../components";
 import { useLockedDailyStaffOrder } from "../../hooks/useLockedDailyStaffOrder";
+import { useScrollDateIntoView } from "../../hooks/useScrollDateIntoView";
 import {
   dailySortedStaffsAtom,
   issueCountByDateAtom,
@@ -204,80 +205,86 @@ const DateRail = ({
   issueCounts: ReadonlyMap<string, number>;
   warningCounts: ReadonlyMap<string, number>;
   onSelect: (iso: string) => void;
-}) => (
-  <Box
-    px={3}
-    pt={3}
-    pb={2}
-    bg="white"
-    borderBottomWidth="1px"
-    borderColor="gray.100"
-    flexShrink={0}
-    data-tour="date-rail"
-  >
-    <Flex gap={2} overflow="auto" pt={2} pb={1}>
-      {dates.map((date) => {
-        const active = date.iso === selectedDate;
-        const isClosed = date.inRange && holidays.includes(date.iso);
-        const issueCount = issueCounts.get(date.iso) ?? 0;
-        const warningCount = warningCounts.get(date.iso) ?? 0;
-        const chipBorderColor = dateIssueBorderColor({
-          active,
-          issueCount,
-          warningCount,
-          activeColor: "teal.500",
-          fallbackColor: "gray.200",
-        });
-        return (
-          <Box
-            as="button"
-            key={date.iso}
-            aria-label={`${formatDateWithWeekday(date.iso)}を表示`}
-            aria-pressed={active}
-            onClick={() => onSelect(date.iso)}
-            position="relative"
-            flexShrink={0}
-            w="56px"
-            minH="58px"
-            py="7px"
-            textAlign="center"
-            borderRadius="md"
-            borderWidth="1px"
-            borderColor={chipBorderColor}
-            bg={active ? "teal.50" : isClosed || !date.inRange ? "gray.50" : "white"}
-            color={!date.inRange || isClosed ? "gray.400" : "gray.800"}
-            cursor="pointer"
-            _focusVisible={{ outline: "2px solid", outlineColor: "teal.600", outlineOffset: "1px" }}
-          >
-            <DateIssueBadge issueCount={issueCount} warningCount={warningCount} />
-            <Text
-              textStyle="md"
-              fontWeight={700}
-              lineHeight="1.1"
-              color={active ? "teal.700" : undefined}
-              fontVariantNumeric="tabular-nums"
+}) => {
+  const stripRef = useRef<HTMLDivElement>(null);
+  useScrollDateIntoView(stripRef, selectedDate, "horizontal");
+
+  return (
+    <Box
+      px={3}
+      pt={3}
+      pb={2}
+      bg="white"
+      borderBottomWidth="1px"
+      borderColor="gray.100"
+      flexShrink={0}
+      data-tour="date-rail"
+    >
+      <Flex ref={stripRef} gap={2} overflow="auto" pt={2} pb={1}>
+        {dates.map((date) => {
+          const active = date.iso === selectedDate;
+          const isClosed = date.inRange && holidays.includes(date.iso);
+          const issueCount = issueCounts.get(date.iso) ?? 0;
+          const warningCount = warningCounts.get(date.iso) ?? 0;
+          const chipBorderColor = dateIssueBorderColor({
+            active,
+            issueCount,
+            warningCount,
+            activeColor: "teal.500",
+            fallbackColor: "gray.200",
+          });
+          return (
+            <Box
+              as="button"
+              key={date.iso}
+              data-date-chip={date.iso}
+              aria-label={`${formatDateWithWeekday(date.iso)}を表示`}
+              aria-pressed={active}
+              onClick={() => onSelect(date.iso)}
+              position="relative"
+              flexShrink={0}
+              w="56px"
+              minH="58px"
+              py="7px"
+              textAlign="center"
+              borderRadius="md"
+              borderWidth="1px"
+              borderColor={chipBorderColor}
+              bg={active ? "teal.50" : isClosed || !date.inRange ? "gray.50" : "white"}
+              color={!date.inRange || isClosed ? "gray.400" : "gray.800"}
+              cursor="pointer"
+              _focusVisible={{ outline: "2px solid", outlineColor: "teal.600", outlineOffset: "1px" }}
             >
-              {formatDateShort(date.iso)}
-            </Text>
-            <Text
-              textStyle="2xs"
-              mt="2px"
-              fontWeight={active ? 700 : 500}
-              color={!date.inRange || isClosed ? "gray.400" : dayColor(date.iso)}
-            >
-              {getWeekdayLabel(date.iso)}
-            </Text>
-            {(isClosed || !date.inRange) && (
-              <Text textStyle="2xs" mt="1px" fontWeight={700} color="gray.400">
-                {date.inRange ? "休" : "外"}
+              <DateIssueBadge issueCount={issueCount} warningCount={warningCount} />
+              <Text
+                textStyle="md"
+                fontWeight={700}
+                lineHeight="1.1"
+                color={active ? "teal.700" : undefined}
+                fontVariantNumeric="tabular-nums"
+              >
+                {formatDateShort(date.iso)}
               </Text>
-            )}
-          </Box>
-        );
-      })}
-    </Flex>
-  </Box>
-);
+              <Text
+                textStyle="2xs"
+                mt="2px"
+                fontWeight={active ? 700 : 500}
+                color={!date.inRange || isClosed ? "gray.400" : dayColor(date.iso)}
+              >
+                {getWeekdayLabel(date.iso)}
+              </Text>
+              {(isClosed || !date.inRange) && (
+                <Text textStyle="2xs" mt="1px" fontWeight={700} color="gray.400">
+                  {date.inRange ? "休" : "外"}
+                </Text>
+              )}
+            </Box>
+          );
+        })}
+      </Flex>
+    </Box>
+  );
+};
 
 const StaffToggleRow = ({
   row,

--- a/src/components/features/Shift/ShiftForm/sp/ShiftTypeDailyView/index.tsx
+++ b/src/components/features/Shift/ShiftForm/sp/ShiftTypeDailyView/index.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, SimpleGrid, Stack, Text } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { useAtomValue, useSetAtom } from "jotai";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { DEFAULT_POSITION } from "@/src/domains/shift/constants";
 import { getWeekdayLabel } from "@/src/domains/shift/date";
 import {
@@ -15,6 +15,7 @@ import {
 import type { ShiftData, StaffType } from "@/src/domains/shift/types";
 import { Avatar, DateIssueBadge, dateIssueBorderColor, StaffWarningIcon } from "../../components";
 import { useLockedDailyStaffOrder } from "../../hooks/useLockedDailyStaffOrder";
+import { useScrollDateIntoView } from "../../hooks/useScrollDateIntoView";
 import {
   getShiftTypeOptionColor,
   SHIFT_TYPE_REQUEST_STATUS_COLORS,
@@ -60,6 +61,8 @@ export const SPShiftTypeDailyView = () => {
   const fallbackPosition = config.positions[0] ?? DEFAULT_POSITION;
   const isShopClosedDate = holidays.includes(selectedDate);
   const selectedDay = selectedDate ? dayjs(selectedDate) : null;
+  const dateStripRef = useRef<HTMLDivElement>(null);
+  useScrollDateIntoView(dateStripRef, selectedDate, "horizontal");
   useLockedDailyStaffOrder(selectedDate);
 
   const counts = useMemo(
@@ -87,7 +90,7 @@ export const SPShiftTypeDailyView = () => {
   return (
     <Flex direction="column" flex={1} minH={0}>
       <Box px={3} pt={3} pb={2} bg="white" borderBottomWidth="1px" borderColor="gray.100" flexShrink={0}>
-        <Flex gap={2} overflow="auto" pt={2} pb={1}>
+        <Flex ref={dateStripRef} gap={2} overflow="auto" pt={2} pb={1}>
           {dates.map((iso) => {
             const date = dayjs(iso);
             const active = iso === selectedDate;
@@ -104,6 +107,7 @@ export const SPShiftTypeDailyView = () => {
             return (
               <Box
                 key={iso}
+                data-date-chip={iso}
                 onClick={() => selectDate(iso)}
                 position="relative"
                 flexShrink={0}

--- a/src/components/features/StaffView/ShiftViewPage/index.tsx
+++ b/src/components/features/StaffView/ShiftViewPage/index.tsx
@@ -149,6 +149,7 @@ export function ShiftViewPage({
           holidays={shopClosedDates}
           submissionPattern={submissionPattern}
           displayMode="confirmed"
+          defaultToToday
           isReadOnly
         />
       </Box>

--- a/src/domains/shift/date.test.ts
+++ b/src/domains/shift/date.test.ts
@@ -10,6 +10,7 @@ import {
   isDateInRange,
   isPastShiftPeriod,
   pruneDatesInRange,
+  resolveInitialSelectedDate,
   todayJST,
 } from "./date";
 
@@ -43,6 +44,27 @@ describe("date helpers", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test("defaultToTodayが有効で今日が期間内なら今日を初期選択日にする", () => {
+    const dates = ["2026-06-26", "2026-06-27", "2026-06-28", "2026-06-29"];
+    expect(resolveInitialSelectedDate(dates, true, "2026-06-28")).toBe("2026-06-28");
+  });
+
+  test("今日が期間外なら先頭日にフォールバックする", () => {
+    const past = ["2026-06-01", "2026-06-02", "2026-06-03"];
+    expect(resolveInitialSelectedDate(past, true, "2026-06-28")).toBe("2026-06-01");
+    const future = ["2026-07-01", "2026-07-02"];
+    expect(resolveInitialSelectedDate(future, true, "2026-06-28")).toBe("2026-07-01");
+  });
+
+  test("defaultToTodayが無効なら今日が期間内でも先頭日を返す", () => {
+    const dates = ["2026-06-26", "2026-06-27", "2026-06-28"];
+    expect(resolveInitialSelectedDate(dates, false, "2026-06-28")).toBe("2026-06-26");
+  });
+
+  test("日付が空なら空文字を返す", () => {
+    expect(resolveInitialSelectedDate([], true, "2026-06-28")).toBe("");
   });
 
   test("期間外の日付を除外してソートできる", () => {

--- a/src/domains/shift/date.ts
+++ b/src/domains/shift/date.ts
@@ -47,6 +47,17 @@ export const isPastShiftPeriod = (periodEnd: string, today = todayJST()): boolea
   return periodEnd < today;
 };
 
+// シフトの初期選択日を決める。
+// defaultToToday かつ今日が期間内なら今日を、そうでなければ期間の先頭日を返す。
+export const resolveInitialSelectedDate = (
+  dates: string[],
+  defaultToToday: boolean,
+  today: string = todayJST(),
+): string => {
+  if (defaultToToday && dates.includes(today)) return today;
+  return dates[0] ?? "";
+};
+
 export const pruneDatesInRange = (dates: string[], startDate: string, endDate: string): string[] => {
   if (!startDate || !endDate) return [];
   return dates.filter((date) => isDateInRange(date, startDate, endDate)).sort();


### PR DESCRIPTION
スタッフがマジックリンクからシフトを確認する際、日別ビューが常に
期間先頭日で開き、毎回今日のタブをタップする必要があった。
今日が期間内なら今日を初期選択日にし、日付レール/横チップを
その位置まで自動スクロールする。

- resolveInitialSelectedDate を date.ts に追加（今日が期間外なら先頭日にフォールバック）
- ShiftForm に opt-in prop defaultToToday を追加し ShiftViewPage のみ有効化
  （マネージャー割当・デモは従来どおり先頭日）
- useScrollDateIntoView で選択日チップを画面内へスクロール
  （PC DateRail / SP 各日別ビューに適用、提出方法 time/shiftType/dateOnly 対応）

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016bde3Rur1V98KKEz9MiGaj