### PR TITLE
feat: スタッフをシフト対象外にできるようにする

### DIFF
--- a/convex/_lib/functions.ts
+++ b/convex/_lib/functions.ts
@@ -3,6 +3,7 @@ import { ConvexError, v } from "convex/values";
 import { customMutation, customQuery } from "convex-helpers/server/customFunctions";
 import type { Doc, Id } from "../_generated/dataModel";
 import { type MutationCtx, mutation, type QueryCtx, query } from "../_generated/server";
+import { isShiftTargetStaff } from "../staff/service";
 import { sessionMatchesAccessKind, staffAccessKindValidator } from "./staffAccess";
 
 type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
@@ -176,7 +177,8 @@ export const staffSessionQuery = customQuery(query, {
       return { ctx: { staff: null, shop: null, session: null }, args: {} };
     }
     const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
-    if (!staff || staff.isDeleted || !shop || shop.isDeleted) {
+    // シフト対象外スタッフはシフト画面へアクセスさせない（削除同様に境界で弾く）。
+    if (!staff || !isShiftTargetStaff(staff) || !shop || shop.isDeleted) {
       return { ctx: { staff: null, shop: null, session: null }, args: {} };
     }
     return { ctx: { staff, shop, session }, args: {} };
@@ -213,7 +215,8 @@ export const staffSessionMutation = customMutation(mutation, {
       throw new ConvexError("Session expired");
     }
     const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
-    if (!staff || staff.isDeleted || !shop || shop.isDeleted) {
+    // シフト対象外スタッフはシフト希望提出等をさせない。
+    if (!staff || !isShiftTargetStaff(staff) || !shop || shop.isDeleted) {
       throw new ConvexError("Not found");
     }
     return { ctx: { staff, shop, session }, args: {} };

--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -766,6 +766,7 @@ describe("dashboard/queries", () => {
       expect(Object.keys(result.page[0]).sort()).toEqual([
         "_id",
         "email",
+        "excludedFromShift",
         "isLineFollowing",
         "isLineLinked",
         "isManager",

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -39,7 +39,8 @@ async function getTotalStaffCount(ctx: { db: GenericDatabaseReader<DataModel> },
     .query("staffs")
     .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shopId).eq("isDeleted", false))
     .collect();
-  return activeStaffs.length;
+  // シフト対象外スタッフは提出率の母数に含めない。
+  return activeStaffs.filter((s) => !s.excludedFromShift).length;
 }
 
 async function toDashboardRecruitment(
@@ -296,6 +297,7 @@ export const getDashboardStaffs = authenticatedQuery({
           isManager: s.userId === ctx.user?._id,
           isLineLinked: Boolean(lineAccount?.lineUserId),
           isLineFollowing: Boolean(lineAccount?.following),
+          excludedFromShift: s.excludedFromShift ?? false,
         };
       }),
     );

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -69,7 +69,9 @@ async function toDashboardRecruitment(
     shopClosedDates: recruitment.shopClosedDates ?? [],
     status: recruitment.status,
     confirmedAt: recruitment.confirmedAt ?? null,
-    responseCount: stats?.submittedCount ?? submissions.length,
+    // 提出数は対象外スタッフの提出も含みうるため、母数（対象外を除いた総数）を上限にクランプし、
+    // 「3/2人」のような不可能な比率が表示されないようにする。
+    responseCount: Math.min(stats?.submittedCount ?? submissions.length, totalStaffCount),
     totalStaffCount,
   };
 }

--- a/convex/notification/queries.test.ts
+++ b/convex/notification/queries.test.ts
@@ -63,6 +63,71 @@ describe("notification/queries", () => {
         ids.futureOpenRecruitmentId,
       ]);
     });
+
+    it("シフト対象外スタッフには募集通知データを返さない", async () => {
+      const t = convexTest(schema, modules);
+      const staffId = await t.run(async (ctx) => {
+        const shopId = await seedShop(ctx, "募集通知店舗");
+        const staffId = await ctx.db.insert("staffs", {
+          shopId,
+          name: "対象外スタッフ",
+          email: "excluded@example.com",
+          excludedFromShift: true,
+          isDeleted: false,
+        });
+        await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-01-25",
+          periodEnd: "2026-01-28",
+          deadline: "2026-01-23",
+          shopClosedDates: [],
+          status: "open",
+          isDeleted: false,
+          submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
+        });
+        return staffId;
+      });
+
+      const result = await t.query(internal.notification.queries.getOpenRecruitmentNotificationDataForStaff, {
+        staffId,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getRecruitmentEmailData（シフト対象外の除外）", () => {
+    it("シフト対象外スタッフを募集メールの宛先から除外する", async () => {
+      const t = convexTest(schema, modules);
+      const recruitmentId = await t.run(async (ctx) => {
+        const shopId = await seedShop(ctx, "募集メール店舗");
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "通常スタッフ",
+          email: "normal@example.com",
+          isDeleted: false,
+        });
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "対象外スタッフ",
+          email: "excluded@example.com",
+          excludedFromShift: true,
+          isDeleted: false,
+        });
+        return await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-01-25",
+          periodEnd: "2026-01-28",
+          deadline: "2026-01-23",
+          shopClosedDates: [],
+          status: "open",
+          isDeleted: false,
+          submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
+        });
+      });
+
+      const result = await t.query(internal.notification.queries.getRecruitmentEmailData, { recruitmentId });
+      expect(result?.staffEntries.map((entry) => entry.email)).toEqual(["normal@example.com"]);
+    });
   });
 
   describe("getConfirmationEmailData", () => {

--- a/convex/notification/queries.ts
+++ b/convex/notification/queries.ts
@@ -13,6 +13,7 @@ import {
 import { buildShiftTimeLabel } from "../_lib/time";
 import { DASHBOARD_CURRENT_RECRUITMENT_SCAN_LIMIT, OPEN_RECRUITMENT_NOTIFICATION_LIMIT } from "../constants";
 import { getStaffLineAccount } from "../line/service";
+import { isShiftTargetStaff } from "../staff/service";
 import {
   buildConfirmationSnapshotSignature,
   type ConfirmationSnapshotAssignment,
@@ -98,7 +99,7 @@ async function buildConfirmationStaffEntries(
 
 async function getOpenRecruitmentNotificationDataForStaffInternal(ctx: QueryCtx, staffId: Id<"staffs">) {
   const staff = await ctx.db.get(staffId);
-  if (!staff || staff.isDeleted) return null;
+  if (!staff || !isShiftTargetStaff(staff)) return null;
 
   const shop = await ctx.db.get(staff.shopId);
   if (!shop || shop.isDeleted) return null;
@@ -166,7 +167,11 @@ export const getConfirmationEmailData = internalQuery({
     ]);
 
     const targetStaffIdSet = targetStaffIds ? new Set(targetStaffIds) : null;
-    const targetStaffs = targetStaffIdSet ? staffs.filter((staff) => targetStaffIdSet.has(staff._id)) : staffs;
+    // シフト対象外スタッフには確定通知を送らない。
+    const eligibleStaffs = staffs.filter(isShiftTargetStaff);
+    const targetStaffs = targetStaffIdSet
+      ? eligibleStaffs.filter((staff) => targetStaffIdSet.has(staff._id))
+      : eligibleStaffs;
     const staffEntries = await buildConfirmationStaffEntries(ctx, recruitment, targetStaffs, assignments);
 
     return {
@@ -210,7 +215,8 @@ export const getRecruitmentEmailData = internalQuery({
       periodStart: recruitment.periodStart,
       deadline: recruitment.deadline,
       staffEntries: await Promise.all(
-        staffs.map(async (s) => {
+        // シフト対象外スタッフには募集通知を送らない。
+        staffs.filter(isShiftTargetStaff).map(async (s) => {
           const lineAccount = await getStaffLineAccount(ctx, s._id);
           return {
             staffId: s._id,
@@ -235,7 +241,7 @@ export const getRecruitmentNotificationDataForStaff = internalQuery({
   },
   handler: async (ctx, { recruitmentId, staffId }) => {
     const [recruitment, staff] = await Promise.all([ctx.db.get(recruitmentId), ctx.db.get(staffId)]);
-    if (!recruitment || recruitment.isDeleted || !staff || staff.isDeleted) return null;
+    if (!recruitment || recruitment.isDeleted || !staff || !isShiftTargetStaff(staff)) return null;
     if (staff.shopId !== recruitment.shopId) return null;
 
     const now = Date.now();
@@ -278,7 +284,7 @@ export const getCurrentConfirmationEmailDataForStaff = internalQuery({
   args: { staffId: v.id("staffs") },
   handler: async (ctx, { staffId }) => {
     const staff = await ctx.db.get(staffId);
-    if (!staff || staff.isDeleted) return null;
+    if (!staff || !isShiftTargetStaff(staff)) return null;
 
     const shop = await ctx.db.get(staff.shopId);
     if (!shop || shop.isDeleted) return null;
@@ -369,7 +375,7 @@ export const getReissueEmailData = internalQuery({
   },
   handler: async (ctx, { staffId, recruitmentId }) => {
     const [staff, recruitment] = await Promise.all([ctx.db.get(staffId), ctx.db.get(recruitmentId)]);
-    if (!staff || staff.isDeleted || !recruitment || recruitment.isDeleted) return null;
+    if (!staff || !isShiftTargetStaff(staff) || !recruitment || recruitment.isDeleted) return null;
     if (staff.shopId !== recruitment.shopId) return null;
     if (recruitment.status !== "confirmed") return null;
 

--- a/convex/notification/reminderQueries.ts
+++ b/convex/notification/reminderQueries.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { internalQuery } from "../_generated/server";
 import { formatPeriodLabel, getDeadlineCutoff } from "../_lib/dateFormat";
 import { getStaffLineAccount } from "../line/service";
+import { isShiftTargetStaff } from "../staff/service";
 
 /**
  * 催促メール送信に必要なデータを取得（未提出スタッフのみ）
@@ -31,7 +32,8 @@ export const getReminderEmailData = internalQuery({
     ]);
 
     const submittedStaffIds = new Set(submissions.map((s) => s.staffId));
-    const unsubmittedStaffs = staffs.filter((s) => !submittedStaffIds.has(s._id));
+    // シフト対象外スタッフは募集自体を受け取らないため、催促も送らない。
+    const unsubmittedStaffs = staffs.filter((s) => isShiftTargetStaff(s) && !submittedStaffIds.has(s._id));
     const staffEntries = (
       await Promise.all(
         unsubmittedStaffs.map(async (s) => {
@@ -68,7 +70,7 @@ export const getReminderEmailDataForStaff = internalQuery({
   },
   handler: async (ctx, { recruitmentId, staffId }) => {
     const [recruitment, staff] = await Promise.all([ctx.db.get(recruitmentId), ctx.db.get(staffId)]);
-    if (!recruitment || recruitment.isDeleted || !staff || staff.isDeleted) return null;
+    if (!recruitment || recruitment.isDeleted || !staff || !isShiftTargetStaff(staff)) return null;
     if (staff.shopId !== recruitment.shopId) return null;
     if (recruitment.status !== "open" || !recruitment.reminderScheduledAt) return null;
     if (Date.now() >= getDeadlineCutoff(recruitment.deadline)) return null;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -88,6 +88,8 @@ const schema = defineSchema({
     email: v.string(),
     emailNormalized: v.optional(v.string()),
     userId: v.optional(v.id("users")),
+    // シフト対象外フラグ（店舗共通アドレス等、シフトを出さないスタッフ）。未定義は false 扱い。
+    excludedFromShift: v.optional(v.boolean()),
     isDeleted: v.boolean(),
   })
     .index("by_shopId", ["shopId"])

--- a/convex/shiftBoard/queries.test.ts
+++ b/convex/shiftBoard/queries.test.ts
@@ -29,6 +29,43 @@ describe("shiftBoard/queries", () => {
     expect(result).toBeNull();
   });
 
+  it("シフト対象外スタッフはシフト表に含めない", async () => {
+    const t = convexTest(schema, modules);
+    const { recruitmentId, includedStaffId } = await t.run(async (ctx) => {
+      const { shopId } = await seedManagerShop(ctx, { subject: "manager_excluded", shopName: "テスト店舗" });
+      const includedStaffId = await ctx.db.insert("staffs", {
+        shopId,
+        name: "通常スタッフ",
+        email: "normal@example.com",
+        isDeleted: false,
+      });
+      await ctx.db.insert("staffs", {
+        shopId,
+        name: "対象外スタッフ",
+        email: "excluded@example.com",
+        excludedFromShift: true,
+        isDeleted: false,
+      });
+      const recruitmentId = await ctx.db.insert("recruitments", {
+        shopId,
+        periodStart: "2026-04-01",
+        periodEnd: "2026-04-07",
+        deadline: "2026-03-28",
+        shopClosedDates: [],
+        status: "open",
+        isDeleted: false,
+        submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
+      });
+      return { recruitmentId, includedStaffId };
+    });
+
+    const result = await t
+      .withIdentity({ subject: "manager_excluded" })
+      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+
+    expect(result?.staffs.map((s) => s._id)).toEqual([includedStaffId]);
+  });
+
   it("全休み提出は提出済みとして返す", async () => {
     const t = convexTest(schema, modules);
     const { recruitmentId, staffId } = await t.run(async (ctx) => {

--- a/convex/shiftBoard/queries.ts
+++ b/convex/shiftBoard/queries.ts
@@ -8,6 +8,7 @@ import {
   SHIFT_BOARD_STAFF_LIMIT,
   SHIFT_BOARD_TIME_UNIT_MINUTES,
 } from "../constants";
+import { isShiftTargetStaff } from "../staff/service";
 
 function getBoardTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
   if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
@@ -91,7 +92,7 @@ export const getShiftBoardData = managerQuery({
         draftSavedAt: effectiveDraftSavedAt,
       },
       submissionPattern,
-      staffs: allStaffs.map((s) => {
+      staffs: allStaffs.filter(isShiftTargetStaff).map((s) => {
         const submission = submissionByStaffId.get(s._id);
         // firstSubmittedAt がない既存 submission は submittedAt を初回提出時刻として扱う。
         const firstSubmittedAt = submission ? (submission.firstSubmittedAt ?? submission.submittedAt) : null;

--- a/convex/shiftView/queries.ts
+++ b/convex/shiftView/queries.ts
@@ -4,6 +4,7 @@ import { staffSessionQuery } from "../_lib/functions";
 import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { SHIFT_ASSIGNMENT_LIMIT, SHIFT_BOARD_STAFF_LIMIT, SHIFT_BOARD_TIME_UNIT_MINUTES } from "../constants";
+import { isShiftTargetStaff } from "../staff/service";
 
 function getViewTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
   if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
@@ -60,7 +61,7 @@ export const getShiftViewData = staffSessionQuery({
       periodLabel: formatPeriodLabel(recruitment.periodStart, recruitment.periodEnd),
       periodStart: recruitment.periodStart,
       periodEnd: recruitment.periodEnd,
-      staffs: staffs.map((s) => ({ _id: s._id, name: s.name })),
+      staffs: staffs.filter(isShiftTargetStaff).map((s) => ({ _id: s._id, name: s.name })),
       positions: positions.map((p) => ({ _id: p._id, name: p.name, color: p.color, isDefault: Boolean(p.isDefault) })),
       assignments: assignments.map((a) => ({
         staffId: a.staffId,

--- a/convex/staff/mutations.test.ts
+++ b/convex/staff/mutations.test.ts
@@ -681,4 +681,69 @@ describe("staff/mutations", () => {
       ).rejects.toThrow("自分のアカウントは削除できません");
     });
   });
+
+  describe("setShiftExclusion", () => {
+    it("未認証の場合エラーをthrow", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { staffId } = await data;
+      await expect(t.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true })).rejects.toThrow();
+    });
+
+    it("シフト対象外フラグをトグルできる", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { staffId } = await data;
+      const asManager = t.withIdentity({ subject: "user_mgr" });
+
+      await asManager.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true });
+      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(true);
+
+      await asManager.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: false });
+      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(false);
+    });
+
+    it("管理者自身もシフト対象外にできる（削除と異なる）", async () => {
+      const t = convexTest(schema, modules);
+
+      const adminStaffId = await t.run(async (ctx) => {
+        const { userId, shopId } = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        return await ctx.db.insert("staffs", {
+          shopId,
+          name: "店舗共通アドレス",
+          email: "mgr@example.com",
+          userId,
+          isDeleted: false,
+        });
+      });
+
+      await t
+        .withIdentity({ subject: "user_mgr" })
+        .mutation(api.staff.mutations.setShiftExclusion, { staffId: adminStaffId, excluded: true });
+
+      expect(await t.run(async (ctx) => (await ctx.db.get(adminStaffId))?.excludedFromShift)).toBe(true);
+    });
+
+    it("他店舗のスタッフは変更できない（IDOR）", async () => {
+      const { t } = setupShopWithStaff();
+
+      const otherStaffId = await t.run(async (ctx) => {
+        const otherShopId = await seedShop(ctx, "他店舗");
+        return await ctx.db.insert("staffs", {
+          shopId: otherShopId,
+          name: "他店スタッフ",
+          email: "other@example.com",
+          isDeleted: false,
+        });
+      });
+
+      await expect(
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.staff.mutations.setShiftExclusion, { staffId: otherStaffId, excluded: true }),
+      ).rejects.toThrow("Not found");
+    });
+  });
 });

--- a/convex/staff/mutations.test.ts
+++ b/convex/staff/mutations.test.ts
@@ -745,5 +745,51 @@ describe("staff/mutations", () => {
           .mutation(api.staff.mutations.setShiftExclusion, { staffId: otherStaffId, excluded: true }),
       ).rejects.toThrow("Not found");
     });
+
+    it("対象外にすると発行済みのセッション・マジックリンクを失効させる", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { shopId, staffId } = await data;
+
+      const { sessionId, magicLinkId } = await t.run(async (ctx) => {
+        const recruitmentId = await ctx.db.insert("recruitments", {
+          shopId,
+          periodStart: "2026-04-01",
+          periodEnd: "2026-04-07",
+          deadline: "2026-03-28",
+          shopClosedDates: [],
+          status: "open",
+          isDeleted: false,
+          submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
+        });
+        const sessionId = await ctx.db.insert("sessions", {
+          sessionToken: "session-token",
+          staffId,
+          shopId,
+          recruitmentId,
+          accessKind: "submit",
+          expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        });
+        const magicLinkId = await ctx.db.insert("magicLinks", {
+          token: "magic-token",
+          staffId,
+          shopId,
+          recruitmentId,
+          accessKind: "submit",
+          expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+        });
+        return { sessionId, magicLinkId };
+      });
+
+      await t
+        .withIdentity({ subject: "user_mgr" })
+        .mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true });
+
+      const { session, magicLink } = await t.run(async (ctx) => ({
+        session: await ctx.db.get(sessionId),
+        magicLink: await ctx.db.get(magicLinkId),
+      }));
+      expect(session?.revokedAt).toEqual(expect.any(Number));
+      expect(magicLink?.revokedAt).toEqual(expect.any(Number));
+    });
   });
 });

--- a/convex/staff/mutations.ts
+++ b/convex/staff/mutations.ts
@@ -226,6 +226,28 @@ export const setShiftExclusion = managerMutation({
     }
     // 削除と異なり、管理者（店舗共通アドレス本人）もシフト対象外にできる（主ユースケース）。
     await ctx.db.patch(args.staffId, { excludedFromShift: args.excluded });
+
+    // 対象外にする場合は、発行済みのシフト用セッション・マジックリンクを失効させ、
+    // 古いリンクでのシフト閲覧・希望提出を即座に遮断する（LINE連携は他通知で使うため残す）。
+    if (args.excluded) {
+      const [sessions, magicLinks] = await Promise.all([
+        ctx.db
+          .query("sessions")
+          .withIndex("by_staffId", (q) => q.eq("staffId", args.staffId))
+          .collect(),
+        ctx.db
+          .query("magicLinks")
+          .withIndex("by_staffId", (q) => q.eq("staffId", args.staffId))
+          .collect(),
+      ]);
+      const now = Date.now();
+      await Promise.all([
+        ...sessions
+          .filter((session) => !session.revokedAt)
+          .map((session) => ctx.db.patch(session._id, { revokedAt: now })),
+        ...magicLinks.filter((link) => !link.revokedAt).map((link) => ctx.db.patch(link._id, { revokedAt: now })),
+      ]);
+    }
   },
 });
 

--- a/convex/staff/mutations.ts
+++ b/convex/staff/mutations.ts
@@ -214,6 +214,21 @@ export const sendCurrentShiftNotification = managerMutation({
   },
 });
 
+export const setShiftExclusion = managerMutation({
+  args: {
+    staffId: v.id("staffs"),
+    excluded: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const staff = await ctx.db.get(args.staffId);
+    if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted) {
+      throw new ConvexError("Not found");
+    }
+    // 削除と異なり、管理者（店舗共通アドレス本人）もシフト対象外にできる（主ユースケース）。
+    await ctx.db.patch(args.staffId, { excludedFromShift: args.excluded });
+  },
+});
+
 export const deleteStaff = managerMutation({
   args: {
     staffId: v.id("staffs"),

--- a/convex/staff/service.ts
+++ b/convex/staff/service.ts
@@ -5,6 +5,14 @@ export function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
 }
 
+/**
+ * シフト対象スタッフかどうか（論理削除されておらず、シフト対象外でもない）。
+ * シフトボード表示・募集/催促/確定などシフト関連通知の対象判定に使う。
+ */
+export function isShiftTargetStaff(staff: { isDeleted: boolean; excludedFromShift?: boolean }) {
+  return !staff.isDeleted && !staff.excludedFromShift;
+}
+
 export async function findActiveStaffByEmail(
   ctx: { db: MutationCtx["db"] },
   shopId: Id<"shops">,

--- a/convex/staffAuth/mutations.test.ts
+++ b/convex/staffAuth/mutations.test.ts
@@ -78,6 +78,24 @@ describe("staffAuth/mutations", () => {
       }
     });
 
+    it("シフト対象外スタッフのトークンはexpired(invalid_link)になる", async () => {
+      const t = convexTest(schema, modules);
+      const { magicLinkToken, staffId } = await setupTestData(t);
+      await t.run(async (ctx) => {
+        await ctx.db.patch(staffId, { excludedFromShift: true });
+      });
+
+      const result = await t.mutation(api.staffAuth.mutations.verifyToken, {
+        token: magicLinkToken,
+        accessKind: "view",
+      });
+
+      expect(result.status).toBe("expired");
+      if (result.status === "expired") {
+        expect(result.reason).toBe("invalid_link");
+      }
+    });
+
     it("有効なトークンでセッションが14日後に期限切れになる", async () => {
       const t = convexTest(schema, modules);
       const { magicLinkToken } = await setupTestData(t);

--- a/convex/staffAuth/mutations.ts
+++ b/convex/staffAuth/mutations.ts
@@ -6,6 +6,7 @@ import { rateLimit } from "../_lib/rateLimits";
 import { recruitmentMatchesAccessKind, sessionMatchesAccessKind, staffAccessKindValidator } from "../_lib/staffAccess";
 import { generateUUID } from "../_lib/uuid";
 import { RATE_LIMIT_RETRY_FALLBACK_MS, STAFF_SESSION_TTL_MS } from "../constants";
+import { isShiftTargetStaff } from "../staff/service";
 import { reissueSchema } from "./schemas";
 
 type ExpiredReason = "invalid_link" | "recruitment_deleted" | "submission_closed";
@@ -59,7 +60,8 @@ export const verifyToken = mutation({
     if (recruitment.isDeleted) {
       return expired(magicLink.recruitmentId, "recruitment_deleted");
     }
-    if (!staff || staff.isDeleted || !shop || shop.isDeleted || staff.shopId !== magicLink.shopId) {
+    // シフト対象外スタッフはマジックリンクからセッションを発行させない。
+    if (!staff || !isShiftTargetStaff(staff) || !shop || shop.isDeleted || staff.shopId !== magicLink.shopId) {
       return expired(magicLink.recruitmentId, "invalid_link");
     }
 
@@ -183,6 +185,8 @@ export const requestReissue = mutation({
       )
       .first();
     if (!staff) return logSkip("staff_not_found", { emailDomain });
+    // シフト対象外スタッフには確定シフトの再発行リンクを送らない。
+    if (!isShiftTargetStaff(staff)) return logSkip("staff_excluded", { emailDomain });
 
     const staffId = staff._id;
 

--- a/doc/INDEX.md
+++ b/doc/INDEX.md
@@ -20,6 +20,7 @@
 | [ログイン後オンボーディング](features/dashboard-onboarding.md) | 店舗登録後にシフト担当者自身で募集作成・通知確認・提出確認を試すDashboard内Callout | 実装済 |
 | [シフト募集管理](features/shift-recruitment-management.md) | シフト担当者がシフト募集を作成・確認・削除する管理導線 | 実装済 |
 | [希望シフト提出](features/shift-submission.md) | スタッフの希望提出と前回シフトあり週パターンの再利用 | 実装済 |
+| [シフト対象外スタッフ](features/shift-exclusion.md) | 店舗共通アドレス等シフトを出さないスタッフを表示・シフト関連通知の対象から外す | 実装済 |
 | [シフト確定催促リマインダー](features/shift-confirmation-reminder.md) | 締切翌日17時に未確定の募集があれば店舗マネージャー全員へ確定を催促（失敗は要対応Inbox対象外） | 実装済 |
 | [公開サブページ](features/public-pages.md) | LPコンテンツを流用した、できること・FAQ・デモへの公開導線 | 実装済 |
 

--- a/doc/features/shift-exclusion.md
+++ b/doc/features/shift-exclusion.md
@@ -10,6 +10,8 @@
   - シフトボード（ShiftForm）・スタッフ向け確定シフト表示
   - 募集開始 / 提出催促リマインダー / 確定シフト の各通知（一括・個別手動再送・追加/メール変更/LINE follow 追送すべて）
   - ダッシュボードの提出率の母数（総スタッフ数）
+- 対象外にすると発行済みのシフト用セッション・マジックリンクを失効させ、以降は古いリンク/セッションでもシフト閲覧・希望提出・確定シフト再発行ができない（スタッフ認証境界で `excludedFromShift` を弾く）。LINE連携トークンは他通知で使うため残す
+- 提出率の分子（提出数）は母数を上限にクランプし、対象外スタッフの過去提出が残っても「3/2人」のような不可能な比率を表示しない
 - 確定済みのシフト割当（`shiftAssignments`）は削除しない。対象に戻せば再び表示・通知される
 
 ## 関連ファイル
@@ -18,10 +20,12 @@
 
 - `convex/schema.ts` — `staffs.excludedFromShift`（`v.optional(v.boolean())`）
 - `convex/staff/service.ts` — `isShiftTargetStaff`（対象判定の純粋関数）
-- `convex/staff/mutations.ts` — `setShiftExclusion`（フラグ切り替え）
+- `convex/staff/mutations.ts` — `setShiftExclusion`（フラグ切り替え＋対象外時にセッション/マジックリンク失効）
+- `convex/_lib/functions.ts` — `staffSessionQuery` / `staffSessionMutation` で対象外を弾く
+- `convex/staffAuth/mutations.ts` — `verifyToken`（マジックリンク→セッション発行）/ `requestReissue` で対象外を弾く
 - `convex/shiftBoard/queries.ts` / `convex/shiftView/queries.ts` — シフト表示から除外
 - `convex/notification/queries.ts` / `convex/notification/reminderQueries.ts` — 各シフト関連通知の対象から除外
-- `convex/dashboard/queries.ts` — `getTotalStaffCount`（提出率の母数から除外）/ `getDashboardStaffs`（フラグ露出）
+- `convex/dashboard/queries.ts` — `getTotalStaffCount`（提出率の母数から除外）/ `responseCount` クランプ / `getDashboardStaffs`（フラグ露出）
 
 ### フロントエンド（`src/`）
 

--- a/doc/features/shift-exclusion.md
+++ b/doc/features/shift-exclusion.md
@@ -1,0 +1,37 @@
+# シフト対象外スタッフ
+
+実際にはシフトを出さないスタッフ（店舗初回登録時の店舗共通アドレス等）を、シフト表示と「シフト関連通知」の対象から外す機能。スタッフ一覧の「…」メニューから個別に切り替える。LINE連携依頼・規約同意などシフト以外の通知は従来どおり送る。
+
+## 切り替え方法・挙動
+
+- スタッフ一覧の各行の「…」メニューから「シフト対象外にする」/「シフト対象に戻す」で切り替える（管理者本人も対象外にできる）
+- 対象外スタッフは行に「シフト対象外」バッジが付き、「現在募集中のシフトを送る」「現在の確定シフトを送る」が無効になる
+- 対象外スタッフは以下から除外される:
+  - シフトボード（ShiftForm）・スタッフ向け確定シフト表示
+  - 募集開始 / 提出催促リマインダー / 確定シフト の各通知（一括・個別手動再送・追加/メール変更/LINE follow 追送すべて）
+  - ダッシュボードの提出率の母数（総スタッフ数）
+- 確定済みのシフト割当（`shiftAssignments`）は削除しない。対象に戻せば再び表示・通知される
+
+## 関連ファイル
+
+### バックエンド（`convex/`）
+
+- `convex/schema.ts` — `staffs.excludedFromShift`（`v.optional(v.boolean())`）
+- `convex/staff/service.ts` — `isShiftTargetStaff`（対象判定の純粋関数）
+- `convex/staff/mutations.ts` — `setShiftExclusion`（フラグ切り替え）
+- `convex/shiftBoard/queries.ts` / `convex/shiftView/queries.ts` — シフト表示から除外
+- `convex/notification/queries.ts` / `convex/notification/reminderQueries.ts` — 各シフト関連通知の対象から除外
+- `convex/dashboard/queries.ts` — `getTotalStaffCount`（提出率の母数から除外）/ `getDashboardStaffs`（フラグ露出）
+
+### フロントエンド（`src/`）
+
+- `src/components/features/Dashboard/types.ts` — `Staff.excludedFromShift`
+- `src/components/features/Dashboard/StaffRoster/StaffRow.tsx` — バッジ・切り替えメニュー・通知項目の無効化
+- `src/components/features/Dashboard/StaffRoster/index.tsx` — コールバック中継
+- `src/components/features/Dashboard/DashboardContent/index.tsx` — `setShiftExclusion` 接続・トースト
+
+## API 一覧
+
+| API | 種別 | 用途 |
+|---|---|---|
+| `api.staff.mutations.setShiftExclusion` | mutation | 指定スタッフのシフト対象外フラグを切り替える |

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -203,6 +203,7 @@ export const DashboardContent = ({
   const sendLineInvite = useShopMutation(api.line.mutations.sendInvite);
   const sendOpenRecruitmentNotifications = useShopMutation(api.staff.mutations.sendOpenRecruitmentNotifications);
   const sendCurrentShiftNotification = useShopMutation(api.staff.mutations.sendCurrentShiftNotification);
+  const setShiftExclusion = useShopMutation(api.staff.mutations.setShiftExclusion);
   const ensureShopRegistrationLink = useShopMutation(api.staffRegistration.mutations.ensureShopRegistrationLink);
   const approveStaffRequest = useShopMutation(api.staffRegistration.mutations.approveRequest);
   const rejectStaffRequest = useShopMutation(api.staffRegistration.mutations.rejectRequest);
@@ -582,6 +583,19 @@ export const DashboardContent = ({
     currentShiftNotificationDialog.open();
   };
 
+  const handleToggleShiftExclusion = async (staff: Staff) => {
+    const nextExcluded = !staff.excludedFromShift;
+    try {
+      await setShiftExclusion({ staffId: staff._id, excluded: nextExcluded });
+      toaster.create({
+        title: nextExcluded ? "シフト対象外にしました" : "シフト対象に戻しました",
+        type: "success",
+      });
+    } catch (error) {
+      showErrorToast(error);
+    }
+  };
+
   const { run: handleSendCurrentShiftConfirm, isRunning: isSendingCurrentShift } = useSingleFlight(async () => {
     if (!currentShiftNotificationTarget) return;
     try {
@@ -672,6 +686,7 @@ export const DashboardContent = ({
               onSendLineInvite={handleSendLineInviteClick}
               onSendRecruitments={handleSendRecruitmentsClick}
               onSendCurrentShift={handleSendCurrentShiftClick}
+              onToggleShiftExclusion={handleToggleShiftExclusion}
               hasCurrentShift={currentRecruitments.length > 0}
               onLoadMore={loadMoreStaffs}
             />

--- a/src/components/features/Dashboard/StaffRoster/StaffRow.tsx
+++ b/src/components/features/Dashboard/StaffRoster/StaffRow.tsx
@@ -1,5 +1,15 @@
 import { Badge, Flex, HStack, Menu, Portal, Stack, Text } from "@chakra-ui/react";
-import { LuCalendarCheck, LuEllipsisVertical, LuMail, LuPencil, LuQrCode, LuSend, LuTrash2 } from "react-icons/lu";
+import {
+  LuCalendarCheck,
+  LuEllipsisVertical,
+  LuMail,
+  LuPencil,
+  LuQrCode,
+  LuSend,
+  LuTrash2,
+  LuUserCheck,
+  LuUserX,
+} from "react-icons/lu";
 import type { Staff } from "@/src/components/features/Dashboard/types";
 import { IconButton } from "@/src/components/ui/Button";
 
@@ -11,6 +21,7 @@ type Props = {
   onSendLineInvite: (staff: Staff) => void;
   onSendRecruitments: (staff: Staff) => void;
   onSendCurrentShift: (staff: Staff) => void;
+  onToggleShiftExclusion: (staff: Staff) => void;
   hasCurrentShift: boolean;
 };
 
@@ -22,15 +33,18 @@ export function StaffRow({
   onSendLineInvite,
   onSendRecruitments,
   onSendCurrentShift,
+  onToggleShiftExclusion,
   hasCurrentShift,
 }: Props) {
   const initial = staff.name.trim().charAt(0) || "?";
   const avatarPalette = staff.isManager ? { bg: "teal.500", fg: "white" } : { bg: "teal.50", fg: "teal.700" };
   const isLineActive = staff.isLineLinked && staff.isLineFollowing;
+  const isExcluded = staff.excludedFromShift;
   const hasEmail = staff.email.length > 0;
   const canShowLineQr = !isLineActive;
   const canSendLineInvite = hasEmail && !isLineActive;
-  const canSendNotification = hasEmail || isLineActive;
+  // シフト対象外スタッフには募集・確定通知を送れない（送信先から除外されるため）。
+  const canSendNotification = (hasEmail || isLineActive) && !isExcluded;
   const canSendCurrentShift = canSendNotification && hasCurrentShift;
 
   return (
@@ -72,6 +86,11 @@ export function StaffRow({
           {isLineActive && (
             <Badge colorPalette="green" variant="subtle" borderRadius="full" px={2} textStyle="2xs">
               LINE連携済み
+            </Badge>
+          )}
+          {isExcluded && (
+            <Badge colorPalette="gray" variant="subtle" borderRadius="full" px={2} textStyle="2xs">
+              シフト対象外
             </Badge>
           )}
         </HStack>
@@ -141,6 +160,11 @@ export function StaffRow({
               >
                 <LuMail />
                 LINE連携リンクをメールで送る
+              </Menu.Item>
+              <Menu.Separator />
+              <Menu.Item value="toggle-shift-exclusion" cursor="pointer" onClick={() => onToggleShiftExclusion(staff)}>
+                {isExcluded ? <LuUserCheck /> : <LuUserX />}
+                {isExcluded ? "シフト対象に戻す" : "シフト対象外にする"}
               </Menu.Item>
               <Menu.Separator />
               <Menu.Item

--- a/src/components/features/Dashboard/StaffRoster/index.stories.tsx
+++ b/src/components/features/Dashboard/StaffRoster/index.stories.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { mockStaffs, mockStaffsMany } from "@/src/components/features/Dashboard/storyMocks";
+import { mockStaffs, mockStaffsMany, mockStaffsWithExcluded } from "@/src/components/features/Dashboard/storyMocks";
 import { StaffRoster, StaffRosterSkeleton } from ".";
 
 const noop = () => {};
@@ -22,6 +22,7 @@ const meta = {
     onSendLineInvite: noop,
     onSendRecruitments: noop,
     onSendCurrentShift: noop,
+    onToggleShiftExclusion: noop,
     hasCurrentShift: true,
     onLoadMore: noop,
   },
@@ -44,6 +45,12 @@ export const CanLoadMore: Story = {
     staffs: mockStaffsMany,
     status: "CanLoadMore",
     canLoadMore: true,
+  },
+};
+
+export const WithExcluded: Story = {
+  args: {
+    staffs: mockStaffsWithExcluded,
   },
 };
 

--- a/src/components/features/Dashboard/StaffRoster/index.tsx
+++ b/src/components/features/Dashboard/StaffRoster/index.tsx
@@ -18,6 +18,7 @@ type Props = {
   onSendLineInvite: (staff: Staff) => void;
   onSendRecruitments: (staff: Staff) => void;
   onSendCurrentShift: (staff: Staff) => void;
+  onToggleShiftExclusion: (staff: Staff) => void;
   hasCurrentShift: boolean;
   onLoadMore: () => void;
 };
@@ -33,6 +34,7 @@ export const StaffRoster = ({
   onSendLineInvite,
   onSendRecruitments,
   onSendCurrentShift,
+  onToggleShiftExclusion,
   hasCurrentShift,
   onLoadMore,
 }: Props) => {
@@ -102,6 +104,7 @@ export const StaffRoster = ({
                 onSendLineInvite={onSendLineInvite}
                 onSendRecruitments={onSendRecruitments}
                 onSendCurrentShift={onSendCurrentShift}
+                onToggleShiftExclusion={onToggleShiftExclusion}
                 hasCurrentShift={hasCurrentShift}
               />
             ))}

--- a/src/components/features/Dashboard/storyMocks.ts
+++ b/src/components/features/Dashboard/storyMocks.ts
@@ -93,6 +93,36 @@ export const mockStaffs = [
   },
 ] as unknown as Staff[];
 
+export const mockStaffsWithExcluded = [
+  {
+    _id: "s1",
+    name: "店舗共通アドレス",
+    email: "shop@example.com",
+    isManager: true,
+    isLineLinked: false,
+    isLineFollowing: false,
+    excludedFromShift: true,
+  },
+  {
+    _id: "s2",
+    name: "佐藤花子",
+    email: "sato@example.com",
+    isManager: false,
+    isLineLinked: false,
+    isLineFollowing: false,
+    excludedFromShift: false,
+  },
+  {
+    _id: "s3",
+    name: "鈴木一郎",
+    email: "suzuki@example.com",
+    isManager: false,
+    isLineLinked: true,
+    isLineFollowing: false,
+    excludedFromShift: true,
+  },
+] as unknown as Staff[];
+
 export const mockStaffsMany = [
   {
     _id: "s1",

--- a/src/components/features/Dashboard/types.ts
+++ b/src/components/features/Dashboard/types.ts
@@ -160,6 +160,7 @@ export type Staff = {
   isManager: boolean;
   isLineLinked: boolean;
   isLineFollowing: boolean;
+  excludedFromShift: boolean;
 };
 
 export type StaffRegistrationRequest = {


### PR DESCRIPTION
店舗共通アドレス等、実際にはシフトを出さないスタッフを
シフト表示と「シフト関連通知」の対象から外せるようにする。

- staffs.excludedFromShift フラグを追加（optional）
- スタッフ一覧の「…」メニューから個別に切り替え（管理者本人も可）
- 対象外スタッフを除外: シフトボード/確定シフト表示、募集・催促・
  確定の各通知（一括/個別再送/追加・メール変更・LINE follow 追送）、
  提出率の母数
- LINE連携依頼・規約同意などシフト以外の通知は従来どおり送る

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018SHEtA3mS5MYCjeA38Td5b