### PR TITLE
fix: success snackbarの表示時間を文字数で自動算出する

### DIFF
--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -11,9 +11,6 @@ const CLOSED_DAY_LABELS = {
   sat: "土曜日",
 } as const;
 const DASHBOARD_DATA_TIMEOUT = 20_000;
-// 成功トーストは文字数に応じて最大8秒表示される（src/components/ui/toaster.tsx）。
-// 消滅を待つ際はデフォルト5秒では足りないため、余裕を持ったタイムアウトを使う。
-const TOAST_HIDDEN_TIMEOUT = 10_000;
 const SHIFT_BOARD_OPEN_BUTTON_NAME = /回収状況を見る|シフトを組む|シフトを見る/;
 const STAFF_ADDED_TOAST_TITLE = /スタッフを追加しました|スタッフを追加し、案内通知を送りました/;
 const RECRUITMENT_CREATED_TOAST_TITLE = /募集をつくりました|募集をつくり、スタッフに通知しました/;
@@ -211,9 +208,7 @@ export class DashboardPage {
 
     await dialog.getByRole("button", { name: /保存する|変更を保存/ }).click();
     await expect(dialog).not.toBeVisible();
-    const toast = this.page.getByText("スタッフ情報を更新しました").first();
-    await expect(toast).toBeVisible();
-    await expect(toast).not.toBeVisible();
+    await this.expectToastVisibleThenHidden("スタッフ情報を更新しました");
   }
 
   async deleteStaff(staffName: string) {
@@ -441,9 +436,12 @@ export class DashboardPage {
   }
 
   private async expectToastVisibleThenHidden(title: string | RegExp) {
-    const toast = this.page.getByText(title).first();
+    const toast = this.page.locator("[data-scope='toast'][data-part='root']").filter({ hasText: title }).first();
     await expect(toast).toBeVisible();
-    await expect(toast).not.toBeVisible({ timeout: TOAST_HIDDEN_TIMEOUT });
+    // 自動消滅は文字数に応じて最大8秒かかりテスト全体がタイムアウトするため、
+    // 閉じるボタン（全トーストに存在）で即座に閉じて消滅を確認する。
+    await toast.getByRole("button").click();
+    await expect(toast).not.toBeVisible();
   }
 
   private async openStaffMenu(staffName: string) {

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -11,6 +11,9 @@ const CLOSED_DAY_LABELS = {
   sat: "土曜日",
 } as const;
 const DASHBOARD_DATA_TIMEOUT = 20_000;
+// 成功トーストは文字数に応じて最大8秒表示される（src/components/ui/toaster.tsx）。
+// 消滅を待つ際はデフォルト5秒では足りないため、余裕を持ったタイムアウトを使う。
+const TOAST_HIDDEN_TIMEOUT = 10_000;
 const SHIFT_BOARD_OPEN_BUTTON_NAME = /回収状況を見る|シフトを組む|シフトを見る/;
 const STAFF_ADDED_TOAST_TITLE = /スタッフを追加しました|スタッフを追加し、案内通知を送りました/;
 const RECRUITMENT_CREATED_TOAST_TITLE = /募集をつくりました|募集をつくり、スタッフに通知しました/;
@@ -440,7 +443,7 @@ export class DashboardPage {
   private async expectToastVisibleThenHidden(title: string | RegExp) {
     const toast = this.page.getByText(title).first();
     await expect(toast).toBeVisible();
-    await expect(toast).not.toBeVisible();
+    await expect(toast).not.toBeVisible({ timeout: TOAST_HIDDEN_TIMEOUT });
   }
 
   private async openStaffMenu(staffName: string) {

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -11,7 +11,7 @@ import { ContentWrapper } from "@/src/components/templates/ContentWrapper";
 import { Button } from "@/src/components/ui/Button";
 import { Dialog, useDialog } from "@/src/components/ui/Dialog";
 import { StepperDialog } from "@/src/components/ui/StepperDialog";
-import { showErrorToast, toaster } from "@/src/components/ui/toaster";
+import { showErrorToast, showSuccessToast, toaster } from "@/src/components/ui/toaster";
 import { formatDateShort } from "@/src/domains/shift/date";
 import { useShopMutation } from "@/src/hooks/useShopMutation";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
@@ -283,7 +283,7 @@ export const DashboardContent = ({
       const result = await resendNotificationFailure({ failureId });
       if (result.scheduled) {
         setAcceptedNotificationFailureIds((current) => new Set(current).add(failureId));
-        toaster.create({ title: "再通知を受け付けました", type: "success" });
+        showSuccessToast({ title: "再通知を受け付けました" });
         return;
       }
       toaster.create({
@@ -351,7 +351,7 @@ export const DashboardContent = ({
         managerEmail: data.email,
         acceptedLegal: data.acceptedLegal as true,
       });
-      toaster.create({ title: "セットアップが完了しました", type: "success" });
+      showSuccessToast({ title: "セットアップが完了しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -361,10 +361,9 @@ export const DashboardContent = ({
     try {
       await createRecruitment(data);
       recruitmentModal.close();
-      toaster.create({
+      showSuccessToast({
         title: "募集をつくり、スタッフに通知しました",
         description: "LINE連携済みのスタッフにはLINE、未連携のスタッフにはメールで届きます。",
-        type: "success",
       });
     } catch (error) {
       const message = getCreateRecruitmentErrorMessage(error);
@@ -387,7 +386,7 @@ export const DashboardContent = ({
       await deleteRecruitmentMut({ recruitmentId: deleteRecruitmentTarget._id });
       deleteRecruitmentDialog.close();
       setDeleteRecruitmentTarget(null);
-      toaster.create({ title: "シフト募集を削除しました", type: "success" });
+      showSuccessToast({ title: "シフト募集を削除しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -396,7 +395,7 @@ export const DashboardContent = ({
   const { run: handleAcceptManagerLegalConsent, isRunning: legalConsentSubmitting } = useSingleFlight(async () => {
     try {
       await acceptManagerLegalConsent({ acceptedLegal: true });
-      toaster.create({ title: "同意を記録しました", type: "success" });
+      showSuccessToast({ title: "同意を記録しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -407,10 +406,9 @@ export const DashboardContent = ({
       try {
         await addStaffs({ entries: data.entries });
         staffModal.close();
-        toaster.create({
+        showSuccessToast({
           title: "スタッフを追加し、案内通知を送りました",
           description: "同意依頼とLINE連携案内をメールで送りました。募集中シフトがある場合は提出リンクも届きます。",
-          type: "success",
         });
       } catch (error) {
         showErrorToast(error);
@@ -444,10 +442,9 @@ export const DashboardContent = ({
     async (request: StaffRegistrationRequest) => {
       try {
         await approveStaffRequest({ requestId: request._id });
-        toaster.create({
+        showSuccessToast({
           title: "スタッフ申請を承認し、案内通知を送りました",
           description: "LINE連携案内をメールで送りました。募集中シフトがある場合は提出リンクも届きます。",
-          type: "success",
         });
       } catch (error) {
         showErrorToast(error);
@@ -464,7 +461,7 @@ export const DashboardContent = ({
     try {
       await rejectStaffRequest({ requestId: rejectRequestTarget._id });
       setRejectRequestTarget(null);
-      toaster.create({ title: "スタッフ申請を却下しました", type: "success" });
+      showSuccessToast({ title: "スタッフ申請を却下しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -494,7 +491,7 @@ export const DashboardContent = ({
     try {
       await editStaffMut({ staffId: editTarget._id, name: data.name, email: data.email });
       editStaffModal.close();
-      toaster.create({ title: "スタッフ情報を更新しました", type: "success" });
+      showSuccessToast({ title: "スタッフ情報を更新しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -504,7 +501,7 @@ export const DashboardContent = ({
     try {
       await updateShopSettings(data);
       editShopModal.close();
-      toaster.create({ title: "店舗設定を更新しました", type: "success" });
+      showSuccessToast({ title: "店舗設定を更新しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -515,7 +512,7 @@ export const DashboardContent = ({
     try {
       await deleteStaffMut({ staffId: deleteTarget._id });
       deleteStaffDialog.close();
-      toaster.create({ title: "スタッフを削除しました", type: "success" });
+      showSuccessToast({ title: "スタッフを削除しました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -547,7 +544,7 @@ export const DashboardContent = ({
     try {
       await sendLineInvite({ staffId: lineInviteTarget._id });
       lineInviteDialog.close();
-      toaster.create({ title: "LINE連携リンクをメールで送りました", type: "success" });
+      showSuccessToast({ title: "LINE連携リンクをメールで送りました" });
     } catch (error) {
       showErrorToast(error);
     }
@@ -564,7 +561,7 @@ export const DashboardContent = ({
       const result = await sendOpenRecruitmentNotifications({ staffId: recruitmentNotificationTarget._id });
       recruitmentNotificationDialog.close();
       if (result.scheduled) {
-        toaster.create({ title: "シフト募集通知を送りました", type: "success" });
+        showSuccessToast({ title: "シフト募集通知を送りました" });
         return;
       }
       toaster.create({
@@ -588,7 +585,7 @@ export const DashboardContent = ({
       const result = await sendCurrentShiftNotification({ staffId: currentShiftNotificationTarget._id });
       currentShiftNotificationDialog.close();
       if (result.scheduled) {
-        toaster.create({ title: "現在の確定シフトを送りました", type: "success" });
+        showSuccessToast({ title: "現在の確定シフトを送りました" });
         return;
       }
       toaster.create({

--- a/src/components/features/Demo/DemoShiftBoardPage/index.tsx
+++ b/src/components/features/Demo/DemoShiftBoardPage/index.tsx
@@ -5,7 +5,7 @@ import { LuCircleCheck } from "react-icons/lu";
 import { ShiftForm } from "@/src/components/features/Shift/ShiftForm";
 import { Dialog, useDialog } from "@/src/components/ui/Dialog";
 import type { TourHandle } from "@/src/components/ui/Tour";
-import { toaster } from "@/src/components/ui/toaster";
+import { showSuccessToast } from "@/src/components/ui/toaster";
 import { DEFAULT_POSITION } from "@/src/domains/shift/constants";
 import { formatDateShort, formatDateTime, getWeekdayLabel } from "@/src/domains/shift/date";
 import type { ShiftData, ViewMode } from "@/src/domains/shift/types";
@@ -92,7 +92,7 @@ export const DemoShiftBoardPage = ({ baseDate, headerStart, height = "100dvh" }:
     // tour は handleOpenConfirm 時点で skip + idle 済み。確定後も FAB を出しておきたいので idle のまま
     setConfirmedAt(Date.now());
     confirmModal.close();
-    toaster.create({ title: "確定しました", type: "success" });
+    showSuccessToast({ title: "確定しました" });
   }, [confirmModal]);
 
   const handleTourCloseRequest = useCallback(() => {
@@ -101,7 +101,7 @@ export const DemoShiftBoardPage = ({ baseDate, headerStart, height = "100dvh" }:
   }, []);
 
   const handleSaveDraft = useCallback(() => {
-    toaster.create({ title: "保存しました", type: "success" });
+    showSuccessToast({ title: "保存しました" });
   }, []);
 
   const confirmTitle = isConfirmed

--- a/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
@@ -13,7 +13,7 @@ import { ShiftForm } from "@/src/components/features/Shift/ShiftForm";
 import type { ReminderStatus } from "@/src/components/features/Shift/ShiftForm/components";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { Dialog, useDialog } from "@/src/components/ui/Dialog";
-import { showErrorToast, toaster } from "@/src/components/ui/toaster";
+import { showErrorToast, showSuccessToast, toaster } from "@/src/components/ui/toaster";
 import { toDisplayIssues } from "@/src/domains/shift/assignmentIssues";
 import { type AssignmentWarning, computeAssignmentWarnings } from "@/src/domains/shift/assignmentWarnings";
 import { buildAssignments } from "@/src/domains/shift/buildAssignments";
@@ -453,9 +453,8 @@ export const ShiftBoardPage = ({ data, recruitmentId }: Props) => {
         toaster.create({ title: "前回通知から変更されたスタッフはいません", type: "info" });
         return;
       }
-      toaster.create({
+      showSuccessToast({
         title: isConfirmed ? "変更があるスタッフへの通知を受け付けました" : "確定しました",
-        type: "success",
       });
     } catch (error) {
       if (handleMutationError(error)) {
@@ -468,7 +467,7 @@ export const ShiftBoardPage = ({ data, recruitmentId }: Props) => {
     try {
       const saved = await persistCurrentShifts();
       if (!saved) return;
-      toaster.create({ title: "保存しました", type: "success" });
+      showSuccessToast({ title: "保存しました" });
     } catch (error) {
       handleMutationError(error);
     }
@@ -497,7 +496,7 @@ export const ShiftBoardPage = ({ data, recruitmentId }: Props) => {
     try {
       const saved = await persistCurrentShifts();
       if (!saved) return;
-      toaster.create({ title: "保存しました", type: "success" });
+      showSuccessToast({ title: "保存しました" });
       blocker.proceed?.();
     } catch (error) {
       // 保存に失敗した場合はダイアログを開いたまま留まる

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -15,6 +15,20 @@ export function showErrorToast(error: unknown): void {
   toaster.create({ title, type: "error", duration: Number.POSITIVE_INFINITY });
 }
 
+// 読了に必要な時間を文字数から概算する。短文は2秒、長文は最大8秒でクランプする
+function calcReadingDuration(title: string, description?: string): number {
+  const charCount = title.length + (description?.length ?? 0);
+  return Math.min(8000, Math.max(2000, charCount * 120));
+}
+
+export function showSuccessToast(args: { title: string; description?: string }): void {
+  toaster.create({
+    ...args,
+    type: "success",
+    duration: calcReadingDuration(args.title, args.description),
+  });
+}
+
 export const toaster = createToaster({
   placement: "top",
   pauseOnPageIdle: true,

--- a/src/pages/staff-legal-consent/index.tsx
+++ b/src/pages/staff-legal-consent/index.tsx
@@ -8,7 +8,7 @@ import {
 import { useAcceptStaffLegalConsent } from "@/src/components/features/StaffLegalConsent/useAcceptStaffLegalConsent";
 import { StaffLayout } from "@/src/components/templates/StaffLayout";
 import { FullPageSpinner } from "@/src/components/ui/FullPageSpinner";
-import { showErrorToast, toaster } from "@/src/components/ui/toaster";
+import { showErrorToast, showSuccessToast, toaster } from "@/src/components/ui/toaster";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 
 type Props = {
@@ -50,7 +50,7 @@ export function StaffLegalConsentRoutePage({ token }: Props) {
           shopName: pageData.shopName,
           documents: pageData.documents,
         });
-        toaster.create({ title: "同意を記録しました", type: "success" });
+        showSuccessToast({ title: "同意を記録しました" });
       } else {
         toaster.create({ title: "リンクの有効期限が切れています", type: "error" });
       }

--- a/src/pages/staff-registration/index.tsx
+++ b/src/pages/staff-registration/index.tsx
@@ -5,7 +5,7 @@ import type { StaffRegistrationFormData } from "@/convex/staffRegistration/schem
 import { StaffRegistrationPage, type StaffRegistrationPageData } from "@/src/components/features/StaffRegistration";
 import { StaffLayout } from "@/src/components/templates/StaffLayout";
 import { FullPageSpinner } from "@/src/components/ui/FullPageSpinner";
-import { showErrorToast, toaster } from "@/src/components/ui/toaster";
+import { showErrorToast, showSuccessToast, toaster } from "@/src/components/ui/toaster";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 
 type Props = {
@@ -43,7 +43,7 @@ export function StaffRegistrationRoutePage({ token }: Props) {
         });
         if (result.status === "ok") {
           setSubmitted(true);
-          toaster.create({ title: "参加申請を送りました", type: "success" });
+          showSuccessToast({ title: "参加申請を送りました" });
         } else {
           toaster.create({
             title: DUPLICATE_REGISTRATION_MESSAGE[result.status],


### PR DESCRIPTION
長文のsuccessトーストが2秒で消え読み切れない問題を解消。
showErrorToastと対になるshowSuccessToastヘルパーを新設し、
title+descriptionの文字数から読了時間（2～8秒）を算出。
全success呼び出しをヘルパーに統一。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YHnJaLuzR42ZEcDCBgTmQj