### PR TITLE
feat(notification): LINE通知の1行目に状態ラベル(絵文字+種別)を追加

### DIFF
--- a/convex/notification/templates.test.ts
+++ b/convex/notification/templates.test.ts
@@ -3,7 +3,11 @@ import { formatResendSubject } from "../_lib/emailFormat";
 import {
   buildConfirmationEmailHtml,
   buildLineDefaultReplyText,
+  buildNotificationFailureReminderLineText,
+  buildRecruitmentLineText,
+  buildReminderLineText,
   buildShiftConfirmationLineText,
+  buildShiftConfirmationReminderLineText,
   buildStaffRegistrationOwnerDigestEmailHtml,
   buildStaffRegistrationOwnerDigestLineText,
   STAFF_REGISTRATION_OWNER_DIGEST_SUBJECT,
@@ -35,6 +39,8 @@ describe("notification/templates", () => {
       isResend: false,
     });
 
+    // 通知一覧で一瞬で種別が分かるよう、1行目に状態ラベル（絵文字 + 種別）を置く
+    expect(lineText.startsWith("✅ シフト確定\n")).toBe(true);
     // LINE内ブラウザのGoogle OAuthブロック回避のため、LINE本文のURLのみ外部ブラウザで開かせる
     expect(lineText).toContain("https://example.com/shifts/view?token=test&openExternalBrowser=1");
     expect(emailHtml).not.toContain("openExternalBrowser");
@@ -48,6 +54,53 @@ describe("notification/templates", () => {
     expect(emailHtml).toContain("休み");
   });
 
+  it("シフト変更（再送）の確定通知は変更ラベルを1行目に置く", () => {
+    const lineText = buildShiftConfirmationLineText({
+      staffName: "田中太郎",
+      shopName: "テスト店舗",
+      periodLabel: "1/20(火)〜1/22(木)",
+      shifts: [{ date: "1/20(火)", timeLabel: "出勤" }],
+      magicLinkUrl: "https://example.com/shifts/view?token=test",
+      isResend: true,
+    });
+
+    expect(lineText.startsWith("🔁 シフト変更\n")).toBe(true);
+  });
+
+  it("各LINE通知の1行目に状態ラベル（絵文字 + 種別）を置く", () => {
+    const recruitment = buildRecruitmentLineText({
+      staffName: "田中太郎",
+      shopName: "テスト店舗",
+      periodLabel: "7/2(木)〜7/30(木)",
+      deadline: "6/25(金) 23:59",
+      magicLinkUrl: "https://example.com/shifts/submit?token=test",
+    });
+    const reminder = buildReminderLineText({
+      staffName: "田中太郎",
+      shopName: "テスト店舗",
+      periodLabel: "7/2(木)〜7/30(木)",
+      linkExpiresAtLabel: "6/25(金) 23:59",
+      magicLinkUrl: "https://example.com/shifts/submit?token=test",
+    });
+    const confirmationReminder = buildShiftConfirmationReminderLineText({
+      periodLabel: "7/2(木)〜7/30(木)",
+      deadlineLabel: "6/30(火) 23:59",
+      dashboardUrl: "https://shiftori.app/dashboard",
+    });
+    const failure = buildNotificationFailureReminderLineText({
+      dashboardUrl: "https://shiftori.app/dashboard",
+    });
+
+    expect(recruitment.startsWith("📩 提出依頼\n")).toBe(true);
+    expect(reminder.startsWith("🔔 提出リマインド\n")).toBe(true);
+    expect(confirmationReminder.startsWith("⏰ 締切超過\n")).toBe(true);
+    expect(failure.startsWith("⚠️ 通知失敗\n")).toBe(true);
+    // ⚠️ は対応必須の通知失敗のみ。他の種別には使わない
+    expect(recruitment).not.toContain("⚠️");
+    expect(reminder).not.toContain("⚠️");
+    expect(confirmationReminder).not.toContain("⚠️");
+  });
+
   it("スタッフ参加申請のオーナー通知はダッシュボードリンクのみを案内し、申請者情報を含めない", () => {
     const dashboardUrl = "https://shiftori.app/dashboard";
     const lineText = buildStaffRegistrationOwnerDigestLineText({ dashboardUrl });
@@ -59,6 +112,7 @@ describe("notification/templates", () => {
     expect(formatResendSubject("テスト店舗", STAFF_REGISTRATION_OWNER_DIGEST_SUBJECT)).toBe(
       "【シフトリ：テスト店舗】スタッフの承認依頼が届いています",
     );
+    expect(lineText.startsWith("📝 承認依頼\n")).toBe(true);
     expect(lineText).toContain("スタッフの承認依頼が届いています。");
     expect(lineText).toContain("シフトリのダッシュボードで確認してください。");
     expect(lineText).toContain(`${dashboardUrl}?openExternalBrowser=1`);

--- a/convex/notification/templates.ts
+++ b/convex/notification/templates.ts
@@ -28,6 +28,8 @@ export function buildShiftConfirmationLineText(params: {
   isResend: boolean;
 }): string {
   const lines = [
+    params.isResend ? "🔁 シフト変更" : "✅ シフト確定",
+    "",
     `${params.staffName}さん`,
     "",
     params.isResend
@@ -57,6 +59,8 @@ export function buildRecruitmentLineText(params: {
   magicLinkUrl: string;
 }): string {
   return [
+    "📩 提出依頼",
+    "",
     `${params.staffName}さん`,
     "",
     `${params.shopName}\n${params.periodLabel} のシフト希望を提出してください。`,
@@ -79,6 +83,8 @@ export function buildReissueLineText(params: {
   magicLinkUrl: string;
 }): string {
   return [
+    "🔁 リンク再発行",
+    "",
     `${params.staffName}さん`,
     "",
     `${params.shopName}\n${params.periodLabel} のシフト閲覧リンクを再発行しました。`,
@@ -99,6 +105,8 @@ export function buildReminderLineText(params: {
   magicLinkUrl: string;
 }): string {
   return [
+    "🔔 提出リマインド",
+    "",
     `${params.staffName}さん`,
     "",
     `${params.shopName}\n${params.periodLabel} のシフト希望の提出期限が近づいています。`,
@@ -394,6 +402,8 @@ type StaffRegistrationOwnerDigestParams = {
 
 export function buildStaffRegistrationOwnerDigestLineText(params: StaffRegistrationOwnerDigestParams): string {
   return [
+    "📝 承認依頼",
+    "",
     "スタッフの承認依頼が届いています。",
     "シフトリのダッシュボードで確認してください。",
     "",
@@ -442,6 +452,8 @@ type NotificationFailureReminderParams = {
 
 export function buildNotificationFailureReminderLineText(params: NotificationFailureReminderParams): string {
   return [
+    "⚠️ 通知失敗",
+    "",
     "通知の送信に失敗したスタッフがいます。",
     "シフトリのダッシュボードを開いて、再通知してください。",
     "",
@@ -492,6 +504,8 @@ type ShiftConfirmationReminderParams = {
 
 export function buildShiftConfirmationReminderLineText(params: ShiftConfirmationReminderParams): string {
   return [
+    "⏰ 締切超過",
+    "",
     `${params.periodLabel} のシフトがまだ確定していません。`,
     `提出締切（${params.deadlineLabel}）を過ぎています。`,
     "スタッフの希望を確認して、シフトを調整・確定してください。",
@@ -600,6 +614,8 @@ export function buildStaffLegalConsentLineText(params: {
   expiresAt: number;
 }): string {
   return [
+    "📄 ご案内",
+    "",
     `${params.staffName}さん`,
     "",
     `${params.shopName} で利用するシフト管理サービス「シフトリ」のご案内です。`,


### PR DESCRIPTION
同時に複数のLINE通知が届いた際、どれも冒頭が期間表記から始まり
種別を見分けづらく見逃しやすかった。各LINEプッシュ本文の1行目に
「絵文字 + 通知種別」のヘッダーを付与し、一覧で一瞬で判別できるようにする。

- 提出依頼📩 / 提出リマインド🔔 / シフト確定✅ / シフト変更🔁 /
  リンク再発行🔁 / 締切超過⏰ / 通知失敗⚠️ / 承認依頼📝 / ご案内📄
- ⚠️ は対応必須の通知失敗のみに限定
- メールHTML・OGPは今回対象外(LINE本文のみ)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QwVFjJXTjQd9fUcA4FpdgM