### PR TITLE
NewLandingPageのSPレイアウトを最適化

### DIFF
--- a/src/components/features/NewLandingPage/BottomCtaSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/BottomCtaSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/BottomCtaSection/index.tsx
+++ b/src/components/features/NewLandingPage/BottomCtaSection/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Flex, Grid, Heading, Icon, Image, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Grid, Heading, HStack, Icon, Image, Stack, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuChevronRight, LuMail, LuMessageCircle, LuMousePointerClick } from "react-icons/lu";
 import { Button } from "@/src/components/ui/Button";
@@ -10,7 +10,7 @@ export const BottomCtaSection = () => (
     <Container maxW="7xl">
       <Grid templateColumns={{ base: "1fr", lg: "minmax(0, 0.9fr) minmax(420px, 0.7fr)" }} gap={9} alignItems="center">
         <VStack align="start" gap={6}>
-          <Heading as="h2" fontSize={{ base: "3xl", md: "4xl" }} lineHeight="1.35" letterSpacing="0">
+          <Heading as="h2" fontSize={{ base: "2xl", sm: "3xl", md: "4xl" }} lineHeight="1.35" letterSpacing="0">
             シフトのやり取りを、
             <Box as="span" display="block" color="teal.700">
               LINEとメールでひとつに。
@@ -19,25 +19,43 @@ export const BottomCtaSection = () => (
           <Text color="gray.800" fontSize="md" lineHeight="1.9" fontWeight="semibold" maxW="620px">
             希望シフトを集めるところから、確定を知らせるところまで。まずは無料で、毎月のシフト連絡をラクにしませんか。
           </Text>
-          <Flex gap={4} flexWrap="wrap">
+          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }} flexWrap="wrap">
             <BottomButton href="/signup" label="無料で試してみる" primary />
             <BottomButton href="/demo/flow" label="登録不要でデモを見る" />
-          </Flex>
+          </Stack>
         </VStack>
 
-        <Box position="relative" minH="240px">
-          <Flex position="absolute" insetInlineStart="0" bottom="0" align="end" gap={5}>
-            <Image src={makerImage} alt="シフトを作る人のイメージ" w="150px" objectFit="contain" />
-            <Image src={userImage} alt="シフトを提出する人のイメージ" w="150px" objectFit="contain" />
-          </Flex>
-          <Flex position="absolute" insetInlineEnd="0" top="26px" direction="column" gap={4}>
-            <ChannelPill icon={LuMessageCircle} label="LINE" />
-            <ChannelPill icon={LuMail} label="メール" />
-          </Flex>
-        </Box>
+        <DesktopVisual />
+        <MobileVisual />
       </Grid>
     </Container>
   </Box>
+);
+
+const DesktopVisual = () => (
+  <Box hideBelow="lg" position="relative" minH="240px">
+    <Flex position="absolute" insetInlineStart="0" bottom="0" align="end" gap={5}>
+      <Image src={makerImage} alt="シフトを作る人のイメージ" w="150px" objectFit="contain" />
+      <Image src={userImage} alt="シフトを提出する人のイメージ" w="150px" objectFit="contain" />
+    </Flex>
+    <Flex position="absolute" insetInlineEnd="0" top="26px" direction="column" gap={4}>
+      <ChannelPill icon={LuMessageCircle} label="LINE" />
+      <ChannelPill icon={LuMail} label="メール" />
+    </Flex>
+  </Box>
+);
+
+const MobileVisual = () => (
+  <VStack hideFrom="lg" gap={6} pt={2}>
+    <HStack gap={4}>
+      <ChannelPill icon={LuMessageCircle} label="LINE" />
+      <ChannelPill icon={LuMail} label="メール" />
+    </HStack>
+    <Flex align="end" justify="center" gap={5}>
+      <Image src={makerImage} alt="シフトを作る人のイメージ" w="132px" objectFit="contain" />
+      <Image src={userImage} alt="シフトを提出する人のイメージ" w="132px" objectFit="contain" />
+    </Flex>
+  </VStack>
 );
 
 const BottomButton = ({ href, label, primary = false }: { href: string; label: string; primary?: boolean }) => (
@@ -48,6 +66,7 @@ const BottomButton = ({ href, label, primary = false }: { href: string; label: s
     bg={primary ? undefined : "white"}
     h="52px"
     minW="220px"
+    w={{ base: "full", sm: "auto" }}
     px={7}
     borderRadius="md"
     fontWeight="bold"

--- a/src/components/features/NewLandingPage/BottomCtaSection/index.tsx
+++ b/src/components/features/NewLandingPage/BottomCtaSection/index.tsx
@@ -19,7 +19,7 @@ export const BottomCtaSection = () => (
           <Text color="gray.800" fontSize="md" lineHeight="1.9" fontWeight="semibold" maxW="620px">
             希望シフトを集めるところから、確定を知らせるところまで。まずは無料で、毎月のシフト連絡をラクにしませんか。
           </Text>
-          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }} flexWrap="wrap">
+          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }}>
             <BottomButton href="/signup" label="無料で試してみる" primary />
             <BottomButton href="/demo/flow" label="登録不要でデモを見る" />
           </Stack>
@@ -52,8 +52,8 @@ const MobileVisual = () => (
       <ChannelPill icon={LuMail} label="メール" />
     </HStack>
     <Flex align="end" justify="center" gap={5}>
-      <Image src={makerImage} alt="シフトを作る人のイメージ" w="132px" objectFit="contain" />
-      <Image src={userImage} alt="シフトを提出する人のイメージ" w="132px" objectFit="contain" />
+      <Image src={makerImage} alt="シフトを作る人のイメージ" w="128px" objectFit="contain" />
+      <Image src={userImage} alt="シフトを提出する人のイメージ" w="128px" objectFit="contain" />
     </Flex>
   </VStack>
 );

--- a/src/components/features/NewLandingPage/ComparisonSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/ComparisonSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/ComparisonSection/index.tsx
+++ b/src/components/features/NewLandingPage/ComparisonSection/index.tsx
@@ -1,5 +1,6 @@
-import { Box, Container, Flex, Heading, Icon, Table, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Icon, Table, Text, VStack } from "@chakra-ui/react";
 import { LuArrowDown } from "react-icons/lu";
+import { SectionHeading } from "../SectionHeading";
 
 const comparisonRows = [
   {
@@ -28,14 +29,7 @@ export const ComparisonSection = () => (
   <Box as="section" bg="white" py={14}>
     <Container maxW="7xl">
       <VStack gap={7}>
-        <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          <Box as="span" display="inline-block">
-            紙・Excel・LINEグループの
-          </Box>
-          <Box as="span" display="inline-block">
-            シフト管理を、ひとつに。
-          </Box>
-        </Heading>
+        <SectionHeading phrases={["紙・Excel・LINEグループの", "シフト管理を、ひとつに。"]} textAlign="center" />
 
         <ComparisonTable />
         <ComparisonCards />

--- a/src/components/features/NewLandingPage/ComparisonSection/index.tsx
+++ b/src/components/features/NewLandingPage/ComparisonSection/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Container, Heading, Table, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Heading, Icon, Table, Text, VStack } from "@chakra-ui/react";
+import { LuArrowDown } from "react-icons/lu";
 
 const comparisonRows = [
   {
@@ -28,41 +29,16 @@ export const ComparisonSection = () => (
     <Container maxW="7xl">
       <VStack gap={7}>
         <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          紙・Excel・LINEグループのシフト管理を、ひとつに。
+          <Box as="span" display="inline-block">
+            紙・Excel・LINEグループの
+          </Box>
+          <Box as="span" display="inline-block">
+            シフト管理を、ひとつに。
+          </Box>
         </Heading>
 
-        <Box w="full" overflowX="auto" borderWidth="1px" borderColor="gray.200" borderRadius="lg">
-          <Table.Root size="md">
-            <Table.Header>
-              <Table.Row bg="gray.50">
-                <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center" w="28%">
-                  項目
-                </Table.ColumnHeader>
-                <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center">
-                  紙・Excel・LINEグループ
-                </Table.ColumnHeader>
-                <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center">
-                  シフトリ
-                </Table.ColumnHeader>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {comparisonRows.map((row) => (
-                <Table.Row key={row.item}>
-                  <Table.Cell color="gray.950" fontWeight="bold" textAlign="center" verticalAlign="middle">
-                    {row.item}
-                  </Table.Cell>
-                  <Table.Cell color="gray.700" fontWeight="semibold" textAlign="center" verticalAlign="middle">
-                    {row.old}
-                  </Table.Cell>
-                  <Table.Cell color="teal.700" fontWeight="black" textAlign="center" verticalAlign="middle">
-                    {row.shiftori}
-                  </Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table.Root>
-        </Box>
+        <ComparisonTable />
+        <ComparisonCards />
 
         <Text color="gray.600" fontSize="sm" textAlign="center" lineHeight="1.8">
           連絡する場所を増やさずに、誰が出したかの確認も、確定の連絡も、同じ画面でできます。
@@ -70,4 +46,64 @@ export const ComparisonSection = () => (
       </VStack>
     </Container>
   </Box>
+);
+
+const ComparisonTable = () => (
+  <Box hideBelow="md" w="full" overflowX="auto" borderWidth="1px" borderColor="gray.200" borderRadius="lg">
+    <Table.Root size="md">
+      <Table.Header>
+        <Table.Row bg="gray.50">
+          <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center" w="28%">
+            項目
+          </Table.ColumnHeader>
+          <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center">
+            紙・Excel・LINEグループ
+          </Table.ColumnHeader>
+          <Table.ColumnHeader color="gray.800" fontWeight="bold" textAlign="center">
+            シフトリ
+          </Table.ColumnHeader>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {comparisonRows.map((row) => (
+          <Table.Row key={row.item}>
+            <Table.Cell color="gray.950" fontWeight="bold" textAlign="center" verticalAlign="middle">
+              {row.item}
+            </Table.Cell>
+            <Table.Cell color="gray.700" fontWeight="semibold" textAlign="center" verticalAlign="middle">
+              {row.old}
+            </Table.Cell>
+            <Table.Cell color="teal.700" fontWeight="black" textAlign="center" verticalAlign="middle">
+              {row.shiftori}
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table.Root>
+  </Box>
+);
+
+const ComparisonCards = () => (
+  <VStack hideFrom="md" align="stretch" gap={3} w="full">
+    {comparisonRows.map((row) => (
+      <Box key={row.item} borderWidth="1px" borderColor="gray.200" borderRadius="lg" overflow="hidden">
+        <Box bg="gray.50" px={4} py={2.5}>
+          <Text color="gray.950" fontSize="sm" fontWeight="bold">
+            {row.item}
+          </Text>
+        </Box>
+        <VStack align="stretch" gap={2} px={4} py={4}>
+          <Text color="gray.600" fontSize="sm" fontWeight="semibold" lineHeight="1.7">
+            {row.old}
+          </Text>
+          <Flex align="center" gap={2}>
+            <Icon as={LuArrowDown} boxSize={4} color="teal.500" flexShrink={0} />
+            <Text color="teal.700" fontSize="sm" fontWeight="black" lineHeight="1.7">
+              {row.shiftori}
+            </Text>
+          </Flex>
+        </VStack>
+      </Box>
+    ))}
+  </VStack>
 );

--- a/src/components/features/NewLandingPage/FaqArticlesSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/FaqArticlesSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/FaqArticlesSection/index.tsx
+++ b/src/components/features/NewLandingPage/FaqArticlesSection/index.tsx
@@ -1,21 +1,9 @@
-import {
-  Accordion,
-  Badge,
-  Box,
-  Container,
-  Flex,
-  Heading,
-  Icon,
-  Image,
-  Link,
-  SimpleGrid,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Accordion, Badge, Box, Container, Flex, Icon, Image, Link, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuArrowRight, LuBookOpen, LuFileSpreadsheet, LuMessageCircle, LuMonitorCheck } from "react-icons/lu";
 import type { ArticleContent } from "@/src/components/features/ArticleSite/articleContent";
 import { articles } from "@/src/components/features/ArticleSite/articleContent";
+import { SectionHeading } from "../SectionHeading";
 
 const faqs = [
   {
@@ -64,9 +52,7 @@ export const FaqArticlesSection = () => (
     <Container maxW="7xl">
       <VStack align="stretch" gap={12}>
         <Box id="faq">
-          <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            よくある質問
-          </Heading>
+          <SectionHeading phrases={["よくある質問"]} />
           <Accordion.Root collapsible multiple variant="plain" mt={5}>
             <VStack align="stretch" gap={2.5}>
               {faqs.map((faq) => (
@@ -101,9 +87,7 @@ export const FaqArticlesSection = () => (
         <Box id="articles">
           <Flex align="end" justify="space-between" gap={5} mb={5}>
             <Box>
-              <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-                お役立ち記事
-              </Heading>
+              <SectionHeading phrases={["お役立ち記事"]} />
               <Text mt={2} color="gray.700" fontSize="sm" lineHeight="1.7" fontWeight="semibold">
                 シフト管理に役立つノウハウを公開中
               </Text>

--- a/src/components/features/NewLandingPage/FaqArticlesSection/index.tsx
+++ b/src/components/features/NewLandingPage/FaqArticlesSection/index.tsx
@@ -113,6 +113,8 @@ export const FaqArticlesSection = () => (
               color="teal.700"
               fontSize="sm"
               fontWeight="bold"
+              whiteSpace="nowrap"
+              flexShrink={0}
               _hover={{ textDecoration: "none", color: "teal.900" }}
             >
               すべての記事を見る

--- a/src/components/features/NewLandingPage/FlowSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/FlowSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/FlowSection/index.tsx
+++ b/src/components/features/NewLandingPage/FlowSection/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Container, Flex, Heading, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
-import { LuBell, LuChevronRight, LuLaptop, LuMailCheck, LuSmartphone } from "react-icons/lu";
+import { LuBell, LuChevronDown, LuChevronRight, LuLaptop, LuMailCheck, LuSmartphone } from "react-icons/lu";
 
 const flowSteps: Array<{ icon: IconType; title: string; body: string }> = [
   {
@@ -30,10 +30,15 @@ export const FlowSection = () => (
     <Container maxW="7xl">
       <VStack gap={10}>
         <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          毎月のシフト作成が、この4ステップで終わります。
+          <Box as="span" display="inline-block">
+            毎月のシフト作成が、
+          </Box>
+          <Box as="span" display="inline-block">
+            この4ステップで終わります。
+          </Box>
         </Heading>
 
-        <SimpleGrid columns={{ base: 1, md: 4 }} gap={0} w="full">
+        <SimpleGrid columns={{ base: 1, md: 4 }} gap={{ base: 5, md: 0 }} w="full">
           {flowSteps.map((step, index) => (
             <FlowStep key={step.title} number={index + 1} isLast={index === flowSteps.length - 1} {...step} />
           ))}
@@ -81,5 +86,7 @@ const FlowStep = ({
         {body}
       </Text>
     </Box>
+
+    {!isLast && <Icon as={LuChevronDown} hideFrom="md" boxSize={8} mt={1} color="teal.400" />}
   </Flex>
 );

--- a/src/components/features/NewLandingPage/FlowSection/index.tsx
+++ b/src/components/features/NewLandingPage/FlowSection/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Container, Flex, Heading, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuBell, LuChevronDown, LuChevronRight, LuLaptop, LuMailCheck, LuSmartphone } from "react-icons/lu";
+import { SectionHeading } from "../SectionHeading";
 
 const flowSteps: Array<{ icon: IconType; title: string; body: string }> = [
   {
@@ -29,14 +30,7 @@ export const FlowSection = () => (
   <Box as="section" bg="white" py={14}>
     <Container maxW="7xl">
       <VStack gap={10}>
-        <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          <Box as="span" display="inline-block">
-            毎月のシフト作成が、
-          </Box>
-          <Box as="span" display="inline-block">
-            この4ステップで終わります。
-          </Box>
-        </Heading>
+        <SectionHeading phrases={["毎月のシフト作成が、", "この4ステップで終わります。"]} textAlign="center" />
 
         <SimpleGrid columns={{ base: 1, md: 4 }} gap={{ base: 5, md: 0 }} w="full">
           {flowSteps.map((step, index) => (

--- a/src/components/features/NewLandingPage/HeroSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/HeroSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/HeroSection/index.tsx
+++ b/src/components/features/NewLandingPage/HeroSection/index.tsx
@@ -9,6 +9,7 @@ import {
   Image,
   Link,
   SimpleGrid,
+  Stack,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -56,16 +57,22 @@ export const HeroSection = () => (
               bg="teal.50"
               color="teal.700"
               borderRadius="full"
-              px={4}
+              px={{ base: 3, md: 4 }}
               py={2}
-              textStyle="sm"
+              textStyle={{ base: "xs", md: "sm" }}
               fontWeight="bold"
+              whiteSpace="nowrap"
             >
-              <Icon as={LuClipboardCheck} boxSize={4} />
+              <Icon as={LuClipboardCheck} boxSize={4} flexShrink={0} />
               小規模店舗向け｜LINEで使える無料のシフト管理
             </Flex>
 
-            <Heading as="h1" fontSize={{ base: "4xl", md: "5xl", xl: "6xl" }} lineHeight="1.18" letterSpacing="0">
+            <Heading
+              as="h1"
+              fontSize={{ base: "3xl", sm: "4xl", md: "5xl", xl: "6xl" }}
+              lineHeight={{ base: "1.3", md: "1.18" }}
+              letterSpacing="0"
+            >
               シフトのやり取りを、
               <Box as="span" display="block" color="teal.600">
                 LINEとメール
@@ -88,16 +95,23 @@ export const HeroSection = () => (
             </Text>
           </VStack>
 
-          <HStack gap={4} flexWrap="wrap">
+          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }} flexWrap="wrap">
             <HeroButton href="/signup" label="無料で試してみる" tone="primary" />
             <HeroButton href="/demo/flow" label="登録不要でデモを見る" tone="secondary" />
-          </HStack>
+          </Stack>
         </VStack>
 
         <HeroVisual />
       </Grid>
 
-      <SimpleGrid columns={{ base: 2, md: 5 }} gap={5} mt={10} pt={7} borderTopWidth="1px" borderColor="gray.100">
+      <SimpleGrid
+        columns={{ base: 1, sm: 2, md: 5 }}
+        gap={{ base: 3, md: 5 }}
+        mt={10}
+        pt={7}
+        borderTopWidth="1px"
+        borderColor="gray.100"
+      >
         {heroBenefits.map((benefit) => (
           <HeroBenefit key={benefit.label} {...benefit} />
         ))}
@@ -157,8 +171,9 @@ const HeroButton = ({ href, label, tone }: { href: string; label: string; tone: 
       colorPalette="teal"
       variant={isPrimary ? "solid" : "outline"}
       bg={isPrimary ? undefined : "white"}
-      h="64px"
+      h={{ base: "56px", md: "64px" }}
       minW="220px"
+      w={{ base: "full", sm: "auto" }}
       px={8}
       borderRadius="md"
       fontWeight="bold"
@@ -205,8 +220,14 @@ const HeroVisual = () => (
 );
 
 const HeroBenefit = ({ icon, label }: { icon: IconType; label: string }) => (
-  <Flex align="center" justify="center" gap={3} minH="48px" color="gray.800">
-    <Icon as={icon} boxSize={6} color="teal.600" />
+  <Flex
+    align="center"
+    justify={{ base: "flex-start", md: "center" }}
+    gap={3}
+    minH={{ base: "32px", md: "48px" }}
+    color="gray.800"
+  >
+    <Icon as={icon} boxSize={6} color="teal.600" flexShrink={0} />
     <Text fontSize="sm" fontWeight="bold" lineHeight="1.5">
       {label}
     </Text>

--- a/src/components/features/NewLandingPage/HeroSection/index.tsx
+++ b/src/components/features/NewLandingPage/HeroSection/index.tsx
@@ -61,7 +61,6 @@ export const HeroSection = () => (
               py={2}
               textStyle={{ base: "xs", md: "sm" }}
               fontWeight="bold"
-              whiteSpace="nowrap"
             >
               <Icon as={LuClipboardCheck} boxSize={4} flexShrink={0} />
               小規模店舗向け｜LINEで使える無料のシフト管理
@@ -95,7 +94,7 @@ export const HeroSection = () => (
             </Text>
           </VStack>
 
-          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }} flexWrap="wrap">
+          <Stack direction={{ base: "column", sm: "row" }} gap={4} w={{ base: "full", sm: "auto" }}>
             <HeroButton href="/signup" label="無料で試してみる" tone="primary" />
             <HeroButton href="/demo/flow" label="登録不要でデモを見る" tone="secondary" />
           </Stack>

--- a/src/components/features/NewLandingPage/PricingSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/PricingSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/PricingSection/index.tsx
+++ b/src/components/features/NewLandingPage/PricingSection/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Container, Flex, Heading, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import { LuCheck } from "react-icons/lu";
 import { Button } from "@/src/components/ui/Button";
+import { SectionHeading } from "../SectionHeading";
 
 const plans = [
   {
@@ -47,14 +48,7 @@ export const PricingSection = () => (
     <Container maxW="7xl">
       <VStack gap={8}>
         <VStack gap={3} textAlign="center">
-          <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            <Box as="span" display="inline-block">
-              シフト管理は、
-            </Box>
-            <Box as="span" display="inline-block">
-              無料から始められます。
-            </Box>
-          </Heading>
+          <SectionHeading phrases={["シフト管理は、", "無料から始められます。"]} />
           <Text color="gray.700" fontSize="md" lineHeight="1.8" fontWeight="semibold">
             少人数のお店なら無料プランのままでOK。人数や店舗が増えたら、そのまま広げられます。
           </Text>
@@ -95,7 +89,7 @@ const PricingCard = ({
 }) => (
   <Flex
     direction="column"
-    minH={{ base: "auto", md: "360px" }}
+    minH={{ md: "360px" }}
     bg="white"
     borderWidth={featured ? "2px" : "1px"}
     borderColor={featured ? "teal.500" : "gray.200"}
@@ -106,14 +100,7 @@ const PricingCard = ({
     <Text color={featured ? "teal.700" : "gray.950"} fontSize="lg" fontWeight="black" lineHeight="1.5">
       {name}
     </Text>
-    <Text
-      mt={3}
-      minH={{ base: "auto", md: "48px" }}
-      color="gray.700"
-      fontSize="sm"
-      lineHeight="1.7"
-      fontWeight="semibold"
-    >
+    <Text mt={3} minH={{ md: "48px" }} color="gray.700" fontSize="sm" lineHeight="1.7" fontWeight="semibold">
       {lead}
     </Text>
 

--- a/src/components/features/NewLandingPage/PricingSection/index.tsx
+++ b/src/components/features/NewLandingPage/PricingSection/index.tsx
@@ -48,7 +48,12 @@ export const PricingSection = () => (
       <VStack gap={8}>
         <VStack gap={3} textAlign="center">
           <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            シフト管理は、無料から始められます。
+            <Box as="span" display="inline-block">
+              シフト管理は、
+            </Box>
+            <Box as="span" display="inline-block">
+              無料から始められます。
+            </Box>
           </Heading>
           <Text color="gray.700" fontSize="md" lineHeight="1.8" fontWeight="semibold">
             少人数のお店なら無料プランのままでOK。人数や店舗が増えたら、そのまま広げられます。
@@ -90,7 +95,7 @@ const PricingCard = ({
 }) => (
   <Flex
     direction="column"
-    minH="360px"
+    minH={{ base: "auto", md: "360px" }}
     bg="white"
     borderWidth={featured ? "2px" : "1px"}
     borderColor={featured ? "teal.500" : "gray.200"}
@@ -101,7 +106,14 @@ const PricingCard = ({
     <Text color={featured ? "teal.700" : "gray.950"} fontSize="lg" fontWeight="black" lineHeight="1.5">
       {name}
     </Text>
-    <Text mt={3} minH="48px" color="gray.700" fontSize="sm" lineHeight="1.7" fontWeight="semibold">
+    <Text
+      mt={3}
+      minH={{ base: "auto", md: "48px" }}
+      color="gray.700"
+      fontSize="sm"
+      lineHeight="1.7"
+      fontWeight="semibold"
+    >
       {lead}
     </Text>
 

--- a/src/components/features/NewLandingPage/ReliefSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/ReliefSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/ReliefSection/index.tsx
+++ b/src/components/features/NewLandingPage/ReliefSection/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Container, Flex, Heading, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuBell, LuMessageCircle, LuSend } from "react-icons/lu";
+import { SectionHeading } from "../SectionHeading";
 
 const reliefItems: Array<{ icon: IconType; title: string; body: string }> = [
   {
@@ -32,14 +33,7 @@ export const ReliefSection = () => (
   >
     <Container maxW="7xl">
       <VStack gap={9}>
-        <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          <Box as="span" display="inline-block">
-            希望シフトの回収はLINEで。
-          </Box>
-          <Box as="span" display="inline-block">
-            催促は自動リマインドで。
-          </Box>
-        </Heading>
+        <SectionHeading phrases={["希望シフトの回収はLINEで。", "催促は自動リマインドで。"]} textAlign="center" />
 
         <SimpleGrid columns={{ base: 1, md: 3 }} gap={8} w="full">
           {reliefItems.map((item) => (

--- a/src/components/features/NewLandingPage/ReliefSection/index.tsx
+++ b/src/components/features/NewLandingPage/ReliefSection/index.tsx
@@ -33,7 +33,12 @@ export const ReliefSection = () => (
     <Container maxW="7xl">
       <VStack gap={9}>
         <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign="center">
-          希望シフトの回収はLINEで。催促は自動リマインドで。
+          <Box as="span" display="inline-block">
+            希望シフトの回収はLINEで。
+          </Box>
+          <Box as="span" display="inline-block">
+            催促は自動リマインドで。
+          </Box>
         </Heading>
 
         <SimpleGrid columns={{ base: 1, md: 3 }} gap={8} w="full">
@@ -47,19 +52,19 @@ export const ReliefSection = () => (
 );
 
 const ReliefCard = ({ icon, title, body }: { icon: IconType; title: string; body: string }) => (
-  <Flex align="center" gap={6}>
+  <Flex align="center" gap={{ base: 4, md: 6 }}>
     <Flex
       align="center"
       justify="center"
       flex="0 0 auto"
-      boxSize={24}
+      boxSize={{ base: 20, md: 24 }}
       bg="teal.50"
       color="teal.600"
       borderRadius="full"
       borderWidth="1px"
       borderColor="teal.100"
     >
-      <Icon as={icon} boxSize={11} />
+      <Icon as={icon} boxSize={{ base: 9, md: 11 }} />
     </Flex>
 
     <Box minW={0}>

--- a/src/components/features/NewLandingPage/SectionHeading/index.stories.tsx
+++ b/src/components/features/NewLandingPage/SectionHeading/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SectionHeading } from ".";
+
+const meta = {
+  title: "Features/NewLandingPage/SectionHeading",
+  component: SectionHeading,
+} satisfies Meta<typeof SectionHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Variants: Story = {
+  args: {
+    phrases: ["毎月のシフト作成が、", "この4ステップで終わります。"],
+    textAlign: "center",
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    phrases: ["シフト希望表は、", "お店に合わせて", "3タイプから選べます。"],
+    textAlign: "center",
+  },
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/SectionHeading/index.tsx
+++ b/src/components/features/NewLandingPage/SectionHeading/index.tsx
@@ -1,0 +1,16 @@
+import { Box, Heading, type HeadingProps } from "@chakra-ui/react";
+
+type SectionHeadingProps = {
+  /** 文節単位の配列。各文節の途中では折り返さない */
+  phrases: string[];
+} & Pick<HeadingProps, "textAlign">;
+
+export const SectionHeading = ({ phrases, textAlign }: SectionHeadingProps) => (
+  <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0" textAlign={textAlign}>
+    {phrases.map((phrase) => (
+      <Box key={phrase} as="span" display="inline-block">
+        {phrase}
+      </Box>
+    ))}
+  </Heading>
+);

--- a/src/components/features/NewLandingPage/SubmissionTypesSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/SubmissionTypesSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/SubmissionTypesSection/index.tsx
+++ b/src/components/features/NewLandingPage/SubmissionTypesSection/index.tsx
@@ -1,4 +1,5 @@
 import { Badge, Box, Container, Flex, Grid, Heading, Icon, Image, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import type { ReactNode } from "react";
 import type { IconType } from "react-icons";
 import { LuCalendarDays, LuCheck, LuClock3, LuMail, LuShieldCheck, LuUsers } from "react-icons/lu";
 import dayImage from "../../LandingPage/SubmissionMethodsSection/function-shift-by-day.webp";
@@ -48,7 +49,15 @@ export const SubmissionTypesSection = () => (
       <VStack gap={9}>
         <VStack gap={3} textAlign="center">
           <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            シフト希望表は、お店に合わせて3タイプから選べます。
+            <Box as="span" display="inline-block">
+              シフト希望表は、
+            </Box>
+            <Box as="span" display="inline-block">
+              お店に合わせて
+            </Box>
+            <Box as="span" display="inline-block">
+              3タイプから選べます。
+            </Box>
           </Heading>
           <Text color="gray.700" fontSize="md" lineHeight="1.8" fontWeight="semibold">
             スタッフが答えやすい形で集めると、聞き直しや抜け漏れが減ります。
@@ -69,7 +78,16 @@ export const SubmissionTypesSection = () => (
             visual="phone"
           />
           <StaffCard
-            title="LINEの人にはLINE。使わない人にはメール。"
+            title={
+              <>
+                <Box as="span" display="inline-block">
+                  LINEの人にはLINE。
+                </Box>
+                <Box as="span" display="inline-block">
+                  使わない人にはメール。
+                </Box>
+              </>
+            }
             body="連絡手段が混ざるお店でも、ひとつの画面から送れます。"
             items={channelItems}
             visual="channel"
@@ -139,7 +157,7 @@ const StaffCard = ({
   items,
   visual,
 }: {
-  title: string;
+  title: ReactNode;
   body: string;
   items: string[];
   visual: "phone" | "channel";

--- a/src/components/features/NewLandingPage/SubmissionTypesSection/index.tsx
+++ b/src/components/features/NewLandingPage/SubmissionTypesSection/index.tsx
@@ -5,6 +5,7 @@ import { LuCalendarDays, LuCheck, LuClock3, LuMail, LuShieldCheck, LuUsers } fro
 import dayImage from "../../LandingPage/SubmissionMethodsSection/function-shift-by-day.webp";
 import selectionImage from "../../LandingPage/SubmissionMethodsSection/function-shift-by-selection.webp";
 import timeImage from "../../LandingPage/SubmissionMethodsSection/function-shift-by-time.webp";
+import { SectionHeading } from "../SectionHeading";
 
 const submissionTypes: Array<{
   icon: IconType;
@@ -48,17 +49,7 @@ export const SubmissionTypesSection = () => (
     <Container maxW="7xl">
       <VStack gap={9}>
         <VStack gap={3} textAlign="center">
-          <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            <Box as="span" display="inline-block">
-              シフト希望表は、
-            </Box>
-            <Box as="span" display="inline-block">
-              お店に合わせて
-            </Box>
-            <Box as="span" display="inline-block">
-              3タイプから選べます。
-            </Box>
-          </Heading>
+          <SectionHeading phrases={["シフト希望表は、", "お店に合わせて", "3タイプから選べます。"]} />
           <Text color="gray.700" fontSize="md" lineHeight="1.8" fontWeight="semibold">
             スタッフが答えやすい形で集めると、聞き直しや抜け漏れが減ります。
           </Text>

--- a/src/components/features/NewLandingPage/UseCasesSection/index.stories.tsx
+++ b/src/components/features/NewLandingPage/UseCasesSection/index.stories.tsx
@@ -13,3 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};

--- a/src/components/features/NewLandingPage/UseCasesSection/index.tsx
+++ b/src/components/features/NewLandingPage/UseCasesSection/index.tsx
@@ -1,6 +1,7 @@
-import { Box, Container, Flex, Heading, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Flex, Icon, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuBot, LuBuilding2, LuHouse, LuScissors, LuShoppingCart, LuUsers, LuUtensils } from "react-icons/lu";
+import { SectionHeading } from "../SectionHeading";
 
 const industries: Array<{ icon: IconType; label: string }> = [
   { icon: LuUtensils, label: "飲食店" },
@@ -28,14 +29,7 @@ export const UseCasesSection = () => (
     <Container maxW="7xl">
       <VStack align="stretch" gap={12}>
         <VStack align="stretch" gap={5}>
-          <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            <Box as="span" display="inline-block">
-              いろいろなお店で
-            </Box>
-            <Box as="span" display="inline-block">
-              使われています。
-            </Box>
-          </Heading>
+          <SectionHeading phrases={["いろいろなお店で", "使われています。"]} />
           <Flex wrap="wrap" justify="center" rowGap={4} columnGap={{ base: 2, md: 4 }}>
             {industries.map((industry) => (
               <IndustryItem key={industry.label} {...industry} />
@@ -47,9 +41,7 @@ export const UseCasesSection = () => (
         </VStack>
 
         <VStack align="stretch" gap={5}>
-          <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            有料プランで、さらに便利に。
-          </Heading>
+          <SectionHeading phrases={["有料プランで、", "さらに便利に。"]} />
           <SimpleGrid columns={{ base: 1, md: 2 }} gap={5}>
             {paidFeatures.map((feature) => (
               <PaidFeatureCard key={feature.title} {...feature} />

--- a/src/components/features/NewLandingPage/UseCasesSection/index.tsx
+++ b/src/components/features/NewLandingPage/UseCasesSection/index.tsx
@@ -29,13 +29,18 @@ export const UseCasesSection = () => (
       <VStack align="stretch" gap={12}>
         <VStack align="stretch" gap={5}>
           <Heading as="h2" fontSize={{ base: "2xl", md: "3xl" }} lineHeight="1.5" letterSpacing="0">
-            いろいろなお店で使われています。
+            <Box as="span" display="inline-block">
+              いろいろなお店で
+            </Box>
+            <Box as="span" display="inline-block">
+              使われています。
+            </Box>
           </Heading>
-          <SimpleGrid columns={{ base: 2, md: 5, lg: 5 }} gap={4}>
+          <Flex wrap="wrap" justify="center" rowGap={4} columnGap={{ base: 2, md: 4 }}>
             {industries.map((industry) => (
               <IndustryItem key={industry.label} {...industry} />
             ))}
-          </SimpleGrid>
+          </Flex>
           <Text color="gray.700" fontSize="sm" lineHeight="1.8" fontWeight="semibold">
             ランチ・ディナー、平日・週末、早番・遅番、短期スタッフなど、お店のシフトの組み方に合わせて使えます。
           </Text>
@@ -60,7 +65,14 @@ export const UseCasesSection = () => (
 );
 
 const IndustryItem = ({ icon, label }: { icon: IconType; label: string }) => (
-  <Flex direction="column" align="center" gap={3} minH="112px" justify="center">
+  <Flex
+    direction="column"
+    align="center"
+    gap={3}
+    minH={{ base: "88px", md: "112px" }}
+    justify="center"
+    w={{ base: "30%", md: "18%" }}
+  >
     <Icon as={icon} boxSize={10} color="gray.800" strokeWidth={1.7} />
     <Text color="gray.950" fontSize="sm" fontWeight="bold" textAlign="center" lineHeight="1.5">
       {label}

--- a/src/components/features/NewLandingPage/index.stories.tsx
+++ b/src/components/features/NewLandingPage/index.stories.tsx
@@ -14,3 +14,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Desktop: Story = {};
+
+export const Mobile: Story = {
+  tags: ["vrt-mobile2"],
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};


### PR DESCRIPTION
- Hero: 見出しをSPで3xlに縮小、CTAボタンを全幅化、バッジ1行化、ベネフィットをSPで1列左揃えに
- 各セクション見出しをinline-block spanで文節単位の折返しに
- Flow: SPでステップ間に下向き矢印を表示
- Comparison: SPはカード形式（md以上はテーブル維持）
- UseCases: 業種一覧を中央寄せwrapにして孤立を解消
- Pricing: SPで不要なminHを解除
- BottomCta: SPはピル+イラストのstatic構成、CTAを全幅化
- 全セクションにMobile Story（vrt-mobile2）を追加

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BmqJXFzdysr4r7WAeDz2JB