### PR TITLE
LPのSEO用title・descriptionを更新

### DIFF
--- a/src/helpers/seo/index.ts
+++ b/src/helpers/seo/index.ts
@@ -38,7 +38,12 @@ type BuildMetaOptions = {
  * - Adds `robots: noindex, nofollow` when `noindex` is set
  */
 export const buildMeta = ({ title, description, noindex, canonical }: BuildMetaOptions): MetaList => {
-  const hasSiteName = title === SITE_NAME || title.startsWith(`${SITE_NAME}｜`) || title.startsWith(`${SITE_NAME} | `);
+  const hasSiteName =
+    title === SITE_NAME ||
+    title.startsWith(`${SITE_NAME}｜`) ||
+    title.startsWith(`${SITE_NAME} | `) ||
+    title.endsWith(`｜${SITE_NAME}`) ||
+    title.endsWith(` | ${SITE_NAME}`);
   const fullTitle = hasSiteName ? title : `${title} | ${SITE_NAME}`;
   const entries: MetaEntry[] = [
     { title: fullTitle },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,9 +8,9 @@ export const Route = createFileRoute("/")({
     links: buildLinks({ canonical: "/" }),
     meta: [
       ...buildMeta({
-        title: "シフトリ｜LINEでシフト希望を集める無料シフト管理ツール",
+        title: "LINEでシフト希望を集める無料シフト管理｜シフトリ",
         description:
-          "LINEでスタッフにシフト希望を依頼し、提出状況の確認からシフト作成・確定共有まで進められます。アプリ不要で、小さなお店でもかんたんに始められるシフト管理ツールです。",
+          "LINEやメールのリンクからスタッフはアプリ登録なしでシフト希望を提出。自動集計・未提出リマインド・確定シフトの共有まで無料。5〜30名の小規模店舗向けシフト管理ツール。",
         canonical: "/",
       }),
       ...jsonLdMeta({


### PR DESCRIPTION
LINE経由でのシフト希望集めと小規模店舗向けの訴求を強めるため、
トップページのtitle/descriptionを差し替え。ブランド名を末尾に
置くタイトル形式に対応するため、buildMetaのサイト名重複判定に
末尾一致のチェックを追加。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016iaPCPp5rrBdoHbDAU4WZp