### PR TITLE
複数店舗・複数マネージャーの設計ドキュメントを追加

### DIFF
--- a/doc/plans/2026-07-03_複数店舗・複数マネージャー設計.md
+++ b/doc/plans/2026-07-03_複数店舗・複数マネージャー設計.md
@@ -1,0 +1,353 @@
+# 複数店舗・複数マネージャー設計
+
+有料機能として「複数店舗登録」「複数マネージャー」を導入するための設計ドキュメント。本ドキュメントは仕様と変更点のみを記載する（実装は別スコープ）。
+
+## 確定方針
+
+| 論点 | 決定 |
+|---|---|
+| 課金単位 | 店舗ごとに独立契約（既存 `shopBillingStates` / 店舗単位Stripe Customer設計を維持） |
+| プラン対応 | 有料（standard/premium）= 複数マネージャー可。free = マネージャー1人 |
+| 複数店舗の課金ゲート | **検討中 → 別スコープ**。今回は機能のみ実装し、ゲート挿入シームを1箇所（`TODO[billing-gate]`）明示する |
+| Stripe連携 | 別フェーズ（当面は `source: "manual"` の手動プラン運用） |
+| billingManagerロール | 操作対象がすべてStripe系のためStripeフェーズに先送り。今回の招待は `role: "manager"` のみ作成 |
+| 招待方式 | `doc/features/manager-billing-roles.md` 踏襲（既存スタッフのmanager昇格、`/manager/invite?token=xxx`、72h・一回限り、Clerkメール一致必須、プレビュー非消費） |
+| 招待配信 | メール自動送信 + 画面にコピー用URL表示（LINE配信は後追い） |
+| ダウングレード時（有料→free） | 既存マネージャーは維持、新規招待の発行のみ不可（発行mutationの `requirePaidFeature` で自然に実現） |
+| スタッフ人数上限 | 今回も強制しない（`isStaffLimitEnforced: false` 維持） |
+
+## 現状整理
+
+### 実装済み（土台）
+
+- `shopMembers`（user↔shop 多対多）: スキーマ上は複数店舗・複数マネージャー対応済み
+- `managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）: optional `shopId` を受け取り所属検証（IDOR対策）。未指定は先頭店舗フォールバック
+- `selectedShopAtom`（`src/stores/shop/index.ts`）+ `useShopMutation`（`src/hooks/useShopMutation.ts`）: **書き込み経路の複数店舗対応は済み**
+- `convex/billing/service.ts`: `requirePaidFeature` / `getShopEntitlements`（planKey直接判定は禁止）
+- 通知fan-out: `convex/_lib/shopManagerRecipients.ts` の `loadShopManagerRecipients` が店舗のactive manager全員を対象にしており **修正不要**
+
+### 未実装（本設計の対象）
+
+- 2店舗目の作成（`convex/setup/mutations.ts` が「既に店舗が登録されています」でブロック）
+- 店舗切替UI、ダッシュボード読み取りの `shopId` 対応（`convex/dashboard/queries.ts` が先頭店舗固定）
+- manager招待フロー全般（`managerInviteTokens` テーブルなし）
+- manager解除、スタッフ一覧の管理者バッジ（現状は「ログイン本人か」で判定しており複数manager非対応）
+
+## フェーズ構成
+
+各フェーズは単体でリリース可能な粒度に分割する。
+
+- **Phase A**: 読み取りのshopId対応 + 店舗切替UI
+- **Phase B**: 2店舗目以降の作成（課金ゲートはシームのみ）
+- **Phase C**: manager招待・解除（有料ゲート）
+- **Phase D**: ドキュメント更新
+
+---
+
+## Phase A: 読み取りのshopId対応 + 店舗切替UI
+
+### A-1. `convex/dashboard/queries.ts` の managerQuery 化
+
+- ローカルの `getManagerShop()`（先頭店舗フォールバック）を削除し、以下を `authenticatedQuery` → `managerQuery` に変更して `ctx.shop` を使う:
+  - `getDashboardShop` / `getDashboardRecruitments` / `hasDashboardPastRecruitments` / `getDashboardPastRecruitments` / `getDashboardCurrentRecruitments` / `getDashboardStaffs`
+- `managerQuery` は `shopId` 未指定なら先頭店舗フォールバックのため後方互換。shop未作成時は `ctx.shop = null` → `getDashboardShop` は `null`（SetupModal表示の既存挙動維持）、他は EMPTY_PAGE / `[]` / `false` を返す
+- `getMyShops` / `getCurrentUser` / `getActiveDashboardAnnouncement` は `authenticatedQuery` のまま
+- 補足（検証済み）: 先頭店舗フォールバックの読み取りは dashboard/queries.ts のみ。他のmanager向けquery（`staffRegistration.getPendingRequests`、`getActiveRegistrationLink`、`line.getLinkStatusByShop`、`getQuotaStatus`、`notificationOutbox.listOpenFailures`、`hasOpenFailures`、`shiftBoard.getShiftBoardData`、`legal.getManagerConsentStatus`）は既に `managerQuery` で shopId 対応済み（フロントが渡していないだけ）
+
+### A-2. `useShopQuery` / `useShopPaginatedQuery` フック新設
+
+新規 `src/hooks/useShopQuery.ts` / `src/hooks/useShopPaginatedQuery.ts`（`useShopMutation.ts` のquery版）。
+
+```ts
+export function useShopQuery<Q extends FunctionReference<"query">>(
+  queryRef: Q,
+  args: Omit<FunctionArgs<Q>, "shopId"> | "skip",
+) {
+  const selectedShop = useAtomValue(selectedShopAtom);
+  const merged =
+    args === "skip" ? "skip"
+    : selectedShop?.shopId ? { ...args, shopId: selectedShop.shopId as Id<"shops"> } : args;
+  return useQuery(queryRef, merged as FunctionArgs<Q> | "skip");
+}
+```
+
+- 置換対象: `src/pages/dashboard/index.tsx` の8クエリ（getDashboardShop, getManagerConsentStatus, getDashboardRecruitments, hasDashboardPastRecruitments, getDashboardPastRecruitments, getDashboardStaffs, getPendingRequests, listOpenFailures）
+- `src/pages/shift-board/index.tsx` は既にshopIdを手渡ししているためリファクタは任意
+
+### A-3. 店舗切替UI（ShopSwitcher）
+
+- 新規 `src/components/templates/Header/ShopSwitcher/index.tsx`（+ `index.stories.tsx`）
+- データ: `getMyShops` + `selectedShopAtom`。**2店舗以上所属のときだけ描画**（単一店舗ユーザーに余分な導線を見せない）
+- UI: `UserMenu` と同型の Chakra `Menu`（トリガー = 現店舗名、選択中はチェックマーク。Phase Bで「新しい店舗を追加」項目を末尾に追加）
+- 配置: `src/components/templates/Header/index.tsx` の user variant、`<UserMenu />` の左隣（SideMenu/BottomMenuは存在せず、Headerが唯一のグローバルナビ）
+- 切替時の挙動: atom更新 + `/dashboard` へ navigate（シフトボード表示中に他店舗へ切り替えた際の誤操作対策）。`src/pages/dashboard/index.tsx` で `<DashboardContent key={selectedShop?.shopId}>` としてページ内state（表示件数等）をリセット
+- `AuthGuard`（`src/components/features/auths/AuthGuard.tsx`）は変更不要（保存値が所属一覧に無ければ先頭店舗へ整合するeffectが既存）
+
+---
+
+## Phase B: 複数店舗登録
+
+### B-1. `createShopCore` の抽出と `createAdditionalShop`
+
+- 新規 `convex/setup/service.ts` に `setupShopAndManager` から店舗作成の共通部を抽出:
+  - `createShopCore(ctx, { userId, shopName, submissionPattern, managerName, managerEmail })`
+  - 内容: `shops` insert → `shopBillingStates`（free/system）→ `shopMembers`（manager）→ `ensureDefaultPosition` → 本人の `staffs` 行（userId紐付け）→ `recordStaffLegalConsent(method: "manager_setup")` → `internal.line.actions.sendInviteEmail` スケジュール
+- `setupShopAndManager` はこれを呼ぶ形に変更（users作成・`recordUserLegalConsent`・users patch・「既に店舗が登録されています」ガードは初回導線用に維持）
+- `convex/setup/mutations.ts` に追加:
+
+```ts
+export const createAdditionalShop = authenticatedMutation({
+  args: { shopName: v.string(), submissionPattern: submissionPatternValidator },
+  handler: async (ctx, args) => {
+    // createShopSchema（setup/schemas.ts）でparse
+    // user必須 + active membership 1件以上（既存マネージャーであること）
+    // ── 課金ゲート差し込みポイント ──────────────────────────
+    // TODO[billing-gate]: 2店舗目以降の作成を有料条件にする場合はここで判定する。
+    //   例) await requireAdditionalShopEntitlement(ctx, user._id);
+    //   契約形態（どの店舗のプランが作成権を与えるか）は別スコープで決定する。
+    // ─────────────────────────────────────────────
+    // MAX_SHOPS_PER_USER（convex/constants.ts、推奨5）のソフト上限チェック
+    // createShopCore(...) → return { shopId, shopName }
+  },
+});
+```
+
+- 法務同意は **user単位判定**（`legal/service.ts` の `getUserLegalConsentState` は userId indexのみ使用）のため、2店舗目作成での再同意は不要。`recordUserLegalConsent` も呼ばない
+
+### B-2. UI導線
+
+- 新規 `src/components/features/ShopCreate/CreateShopDialog/index.tsx`（+ stories）
+  - SetupModal / SetupStep1 のフォーム（shopName + submissionPattern、`zodResolver(createShopSchema)`）を再利用（密結合なら共通フォームとして抽出）
+  - submit は素の `useMutation`（作成対象が新店舗のため shopId 注入不要）→ 成功時 `setSelectedShop` → `/dashboard` へ遷移 → toast
+- エントリポイント:
+  - ShopSwitcher メニュー末尾「新しい店舗を追加」（2店舗以上のユーザー）
+  - `src/components/templates/Header/UserMenu/index.tsx` に「店舗を追加」項目を常設（1店舗ユーザーの導線。切替UIを出さない方針と両立）
+
+---
+
+## Phase C: manager招待・解除
+
+### C-1. スキーマ・定数
+
+`convex/schema.ts` に追加（`magicLinks` / `lineLinkTokens` と同型。追加のみのためマイグレーション不要）:
+
+```ts
+managerInviteTokens: defineTable({
+  shopId: v.id("shops"),
+  staffId: v.id("staffs"),
+  token: v.string(),
+  invitedByUserId: v.id("users"),
+  expiresAt: v.number(),
+  usedAt: v.optional(v.number()),
+  revokedAt: v.optional(v.number()),
+  acceptedByUserId: v.optional(v.id("users")),
+  createdAt: v.number(),
+})
+  .index("by_token", ["token"])
+  .index("by_staffId", ["staffId"])
+  .index("by_shopId", ["shopId"])
+  .index("by_expiresAt", ["expiresAt"]),
+```
+
+- `shopMembers.role` は `v.literal("manager")` のまま維持。billingManager導入時（Stripeフェーズ）に Widen → Migrate → Narrow で `v.union(v.literal("manager"), v.literal("billingManager"))` へ拡張する
+- `convex/constants.ts`: `MANAGER_INVITE_TOKEN_TTL_MS = 72 * 60 * 60 * 1000`
+- `convex/_lib/rateLimits.ts`: `managerInviteIssueShort`（1/分、key: `shopId:staffId`）、`managerInviteAccept`（5/分、key: token先頭8文字。`staffAuth.verifyToken` と同型）
+
+### C-2. 新スライス `convex/managerInvite/`
+
+`queries.ts` / `mutations.ts` / `actions.ts` / `service.ts` / `schemas.ts` + テストで構成。
+
+#### `issueManagerInvite`（managerMutation）
+
+1. `requirePaidFeature(ctx, ctx.shop._id)` — **有料ゲート**（ダウングレード後の新規発行停止もここで自動的に実現）
+2. staff所属検証（他店舗・削除済みは `Not found` に統一 = 列挙対策）
+3. staffのemail空は拒否
+4. 既にmanager（`by_userId_and_shopId_and_isDeleted` にactive行あり）は拒否
+5. レートリミット
+6. 同staffのactive tokenを全revoke（1スタッフ1有効招待。再発行 = 再実行）
+7. `crypto.randomUUID()` + 72h で insert
+8. `ctx.scheduler.runAfter(0, internal.managerInvite.actions.sendManagerInviteEmail, { staffId, token })`
+9. `return { inviteUrl: \`${APP_URL}/manager/invite?token=${token}\`, expiresAt }`（UIがコピー用URLとして即表示）
+
+#### `getManagerInvitePageData`（公開query・非消費プレビュー）
+
+素のqueryで公開（`legal.queries.getStaffConsentPageData` と同パターン）。
+
+- 不在 / revoked / 期限切れ / staff・shop削除 → 一律 `{ status: "expired" }`（状態を区別しない = 列挙対策）
+- `usedAt` あり → `{ status: "alreadyAccepted" }`
+- 有効 → `{ status: "ok", shopName, staffName, expiresAt, viewer: { loggedIn, emailMatches } }`
+  - `ctx.auth.getUserIdentity()` があれば normalize 比較で `emailMatches` を返す。**staffの生メールアドレスは返さない**
+- queryにはレートリミットを書けないため、UUIDエントロピー + accept側のリミットで担保（既存tokenプレビューと同方針）
+
+#### `acceptManagerInvite`（authenticatedMutation、status union返却）
+
+`line.redeemLineToken` と同様、throwせず status を返す。
+
+1. レートリミット → `{ status: "rateLimited" }`
+2. token無効（不在 / revokedAt / usedAt / 期限切れ / staff・shop削除）→ `{ status: "expired" }`
+3. **メール一致検証**: `normalizeEmail(ctx.identity.email)` vs `staff.emailNormalized ?? normalizeEmail(staff.email)`（`staff/service.ts` の normalizeEmail 使用）。不一致 → `{ status: "emailMismatch" }`（**tokenは消費しない**）
+4. users解決: `ctx.user` があればそれ（別店舗manager等の既存ユーザー）。無ければ insert `{ authTokenIdentifier, name: staff.name, email: staff.email, emailNormalized, role: "manager", isDeleted: false }`
+5. 法務同意: `legal/documents.ts` の `LegalConsentMethod` に `"manager_invite"` を追加し、未同意ユーザーには `recordUserLegalConsent`。確認画面に同意文言 + `acceptedLegal: v.literal(true)` 必須（setupと同型）
+6. membership: `by_userId_and_shopId` で検索 → soft-deletedなら patch 復活 / activeなら冪等 / 無ければ insert
+7. `staff.userId = userId` に patch
+8. token消費（`usedAt` + `acceptedByUserId`）
+9. `return { status: "accepted", shopId, shopName }`（フロントが selectedShop に設定）
+
+3〜8は同一mutation内 = 原子的。
+
+#### `revokeManagerInvite`（managerMutation）
+
+対象staffのactive tokenを全revoke。
+
+#### `demoteManager`（managerMutation）
+
+- staff所属検証 → active membership 必須（無ければ `Not found`）
+- **最終管理者ガード**: `by_shopId_and_isDeleted` でactive membershipsをcollectし、対象が唯一なら `ConvexError("最後の管理者は解除できません")`（判定と更新を同一トランザクションで）
+- membershipを `isDeleted: true`。**staffs行と `staff.userId` は残す**（スタッフとしての所属は維持、再昇格可能）。active招待tokenもrevoke
+- 自己解除は許可（最終管理者でなければ）。`{ selfDemoted }` を返し、フロントはAuthGuardの整合effectにselectedShopの付け替えを任せて `/dashboard` へ
+
+#### `deleteStaff` ガード強化（`convex/staff/mutations.ts`）
+
+現在の「自分自身のみ削除不可」を、「`staff.userId` が同店舗のactive shopMembersに載っていれば削除不可（先に管理者を解除する案内）」に変更。
+
+#### `sendManagerInviteEmail`（internalAction、`convex/managerInvite/actions.ts`）
+
+- `line/actions.ts` の `sendInviteEmail` と同パターン（"use node"、internalQueryでデータ取得 → `enqueueEmail`）
+- dry-run抑止は `internal._lib.notificationDeliveryQueries.isNotificationDeliverySuppressedForShop` で判定
+- **dedupeKeyは `email:managerInvite:${staffId}:${token先頭8}`**（tokenを含めないと再発行がpending dedupeで握り潰される）
+- テンプレートは `convex/notification/templates.ts` に `buildManagerInviteEmailHtml` を追加
+- context `"managerInvite.sendInviteEmail"` を `failureResend.ts` の `ACTIONABLE_NOTIFICATION_FAILURE_CONTEXTS` に追加（不達Inboxから再送可能に）
+
+### C-3. `getDashboardStaffs` の isManager 修正
+
+`convex/dashboard/queries.ts` の `isManager: s.userId === ctx.user?._id`（ログイン本人判定）を修正:
+
+- `by_shopId_and_isDeleted` でactive membershipsを1回collect → `managerUserIds` Set → `isManager: s.userId ? managerUserIds.has(s.userId) : false`
+- 追加フィールド: `isSelf`（自己解除警告・削除表示用）、`hasPendingManagerInvite`（`by_staffId` でactive token有無）
+- `src/components/features/Dashboard/types.ts` の Staff型 + `storyMocks.ts` + `dashboard/queries.test.ts` を更新
+
+### C-4. dry-run通知抑止の店舗単位化
+
+- `convex/_lib/notificationDeliveryQueries.ts` の `isNotificationDeliverySuppressedForShop` が「最初に見つかったmanager」1人で判定している → 店舗単位ルールに変更:
+  - active member全員（take 20）のusersを引き、`emails.length > 0 && emails.every(isDryRunManagerEmail)` のときのみ抑止（実managerが1人でもいれば配信する）
+- `_scenario/notificationDelivery.test.ts` にdry-run manager + 実managerの混在ケースを追加
+- 通知fan-out本体（`loadShopManagerRecipients`）は複数manager対応済みのため修正不要
+
+### C-5. フロント: `/manager/invite`
+
+- 新規route `src/routes/_unregistered/manager.invite.tsx`（`legal.staff.consent.tsx` と同型: validateSearchでtoken、`buildMeta({ noindex: true })`。`_unregistered` は素のOutletのためログイン有無どちらでも描画可能）
+- 新規page `src/pages/manager-invite/index.tsx` + feature `src/components/features/ManagerInvite/InviteConfirm/index.tsx`（+ stories）
+- 画面状態:
+  - `expired`（無効・期限切れ・取消済み）
+  - `alreadyAccepted`（使用済み）
+  - `ok` & 未ログイン → `/login?redirect=/manager/invite?token=xxx` へ誘導（`normalizeAuthRedirect` がパス+クエリを保持するため既存機構でラウンドトリップ成立）
+  - `ok` & メール不一致 → 「この招待は {staffName} さん宛です。招待されたメールアドレスのアカウントでログインし直してください」+ SignOutButton
+  - `ok` & 一致 → 確認カード（店舗名・スタッフ名・権限の説明）+ LegalDocumentLink同意文言 + 「管理者になる」ボタン
+- 承認成功 → `setSelectedShop({ shopId, shopName })` → `/dashboard` → toast。mutationの戻りstatusでexpired/emailMismatch表示に切替（プレビューとの競合対策）
+
+### C-6. フロント: スタッフ一覧の管理者操作
+
+`src/components/features/Dashboard/StaffRoster/`（StaffRow）と `DashboardContent`:
+
+- 管理者バッジ（`isManager`）、「招待中」バッジ（`hasPendingManagerInvite`）
+- 非manager & emailあり: 「管理者に招待する」
+  - プラン判定は新規 `convex/billing/queries.ts` に `getShopEntitlements`（managerQuery）を作り `useShopQuery` で取得
+  - **free時は項目を隠さず、クリックで「この機能は有料プランで利用できます」ダイアログを表示**（隠すと機能に気付けない。最終防衛はbackendの `requirePaidFeature`）
+- 発行成功後: 新規 `ManagerInviteLinkDialog`（inviteUrlコピー + 「メールも送信しました」+ 有効期限。コピーUIは `StaffRegistrationLinkPanel` パターン流用）。招待中は「招待リンクを再発行」「招待を取り消す」
+- manager: 「管理者を解除」→ 確認ダイアログ（`isSelf` は強警告）→ `demoteManager`。最終管理者エラーはConvexErrorをtoast表示（一覧はページングで不完全なためクライアント事前判定はしない）
+
+### C-7. エッジケース
+
+- **他managerのstaff行メール編集によるusers.emailのdesync**: `staff/mutations.ts` のeditStaffはself時のみusers同期のため、manager紐付きstaff行のメール編集をバックエンドで拒否する
+- Clerk identityにemailが無いプロバイダ → `emailMismatch` 扱い
+- 招待発行後にstaffのメールが変更された場合 → accept時点の現メールと比較（tokenはstaffId紐付けのため安全側）
+- 同一メールが複数店舗のstaffに存在 → 店舗ごとにmembershipが増える（意図通り）
+- 課金ゲートシームは `createAdditionalShop` 内の1箇所のみ（`TODO[billing-gate]` でgrep可能）
+
+---
+
+## Phase D: ドキュメント更新（実装時に実施）
+
+- `doc/features/manager-shop-membership.md`: 切替UI・read-path・`createAdditionalShop` を実装済みに更新、課金ゲートシームの場所を明記
+- `doc/features/manager-billing-roles.md`: 招待/解除/切替に実装済み注記。billingManager/Stripeは未実装のまま、role Widen予定を注記
+- 新規 `doc/features/manager-invite.md`（画面/API/token仕様/配信/有料ゲート/最終管理者ガード）
+- `doc/INDEX.md` にリンク追加
+
+---
+
+## テスト方針
+
+- コマンド: `pnpm test:convex`（convex(logic) + convex(scenario)）、`pnpm test:logic`、`pnpm test:ui`、`pnpm lint` / `pnpm type-check`
+- テストは `convexTest(schema, modules)` + `_test/seed.ts`（seedManagerShop / seedShopMembership）+ `t.withIdentity` パターン（`convex/billing/service.test.ts` 参照）
+
+| テスト | 内容 |
+|---|---|
+| `convex/managerInvite/mutations.test.ts` | 期限切れ / 使用済み / revoked / メール不一致 / 他店舗staff / 削除済みstaff / freeプラン拒否 / 旧token失効 / 新規user作成・既存user・membership復活 / demote最終管理者ガード |
+| `convex/managerInvite/queries.test.ts` | プレビュー各状態、staffメール非露出 |
+| `convex/_scenario/managerInvite.test.ts` | 招待→accept→2店舗ダッシュボード到達→digestが両managerに届く |
+| `convex/dashboard/queries.test.ts`（更新） | shopId指定のIDOR、複数managerのisManager |
+| `convex/setup/mutations.test.ts`（更新） | createAdditionalShop（所属必須、ソフト上限） |
+| `convex/staff/mutations.test.ts`（更新） | manager紐付きstaffの削除拒否・メール編集拒否 |
+| `convex/_scenario/notificationDelivery.test.ts`（更新） | dry-run manager混在時の配信 |
+| Storybook | InviteConfirm全状態 / ShopSwitcher / CreateShopDialog / ManagerInviteLinkDialog / StaffRow更新 |
+
+手動確認: 2アカウントで招待→signupラウンドトリップ→承認 / 店舗切替で全セクションが切り替わる / freeゲート表示 / 最終管理者解除エラー / 自己解除後のフォールバック。
+
+## 変更ファイル一覧
+
+### 新規
+
+| ファイル | 内容 |
+|---|---|
+| `convex/setup/service.ts` | `createShopCore` 抽出 |
+| `convex/managerInvite/{schemas,queries,mutations,actions,service}.ts` | 招待スライス一式 |
+| `convex/billing/queries.ts` | `getShopEntitlements`（managerQuery、フロント配布用） |
+| `src/hooks/useShopQuery.ts` / `useShopPaginatedQuery.ts` | selectedShop注入query hook |
+| `src/components/templates/Header/ShopSwitcher/` | 店舗切替メニュー |
+| `src/components/features/ShopCreate/CreateShopDialog/` | 店舗追加ダイアログ |
+| `src/components/features/ManagerInvite/InviteConfirm/` | 招待確認画面 |
+| `src/components/features/Dashboard/ManagerInviteLinkDialog/` | 招待リンク表示ダイアログ |
+| `src/routes/_unregistered/manager.invite.tsx` + `src/pages/manager-invite/` | 招待ページ |
+| `doc/features/manager-invite.md` | 機能ドキュメント |
+
+### 修正
+
+| ファイル | 内容 |
+|---|---|
+| `convex/schema.ts` | `managerInviteTokens` 追加 |
+| `convex/constants.ts` / `convex/_lib/rateLimits.ts` | TTL定数、レートリミット、`MAX_SHOPS_PER_USER` |
+| `convex/setup/mutations.ts` | `createAdditionalShop` 追加（`TODO[billing-gate]` シーム）、`createShopCore` 利用 |
+| `convex/dashboard/queries.ts` | managerQuery化、isManager修正、isSelf / hasPendingManagerInvite追加 |
+| `convex/staff/mutations.ts` | manager紐付きstaffの削除・メール編集ガード |
+| `convex/_lib/notificationDeliveryQueries.ts` | dry-run抑止の店舗単位化 |
+| `convex/legal/documents.ts` | `LegalConsentMethod` に `"manager_invite"` 追加 |
+| `convex/notification/templates.ts` / `failureResend.ts` | 招待メールテンプレ、再送対象context追加 |
+| `src/pages/dashboard/index.tsx` | useShopQuery置換、`key={shopId}` リセット |
+| `src/components/templates/Header/index.tsx` / `UserMenu/` | ShopSwitcher配置、「店舗を追加」項目 |
+| `src/components/features/Dashboard/StaffRoster/` / `types.ts` / `storyMocks.ts` | 管理者バッジ・招待/解除操作 |
+| `doc/features/manager-shop-membership.md` / `manager-billing-roles.md` / `doc/INDEX.md` | 実装状況更新 |
+
+## 別スコープ（今回やらないこと）
+
+- 2店舗目作成の課金ゲート（契約形態の決定。`TODO[billing-gate]` シームに後日実装）
+- Stripe連携（Checkout / Customer Portal / Webhook）と `billingManager` ロール（`shopMembers.role` のWiden含む）
+- スタッフ人数上限の強制
+- 招待のLINE配信
+
+## 参考ファイル
+
+- `convex/schema.ts` — `shopMembers` / `shopBillingStates` / 既存token系テーブル
+- `convex/_lib/functions.ts` — `managerQuery` / `managerMutation` / `resolveShopForUser`
+- `convex/billing/service.ts` — `requirePaidFeature` / `getShopEntitlements`
+- `convex/setup/mutations.ts` — `setupShopAndManager`（1店舗ガード、店舗作成一式）
+- `convex/dashboard/queries.ts` — `getMyShops` / 先頭店舗フォールバック
+- `convex/_lib/shopManagerRecipients.ts` — manager通知fan-out（対応済み）
+- `convex/_lib/notificationDeliveryQueries.ts` — dry-run抑止（要修正）
+- `convex/line/actions.ts` — `sendInviteEmail`（メール送信パターン）
+- `src/stores/shop/index.ts` — `selectedShopAtom`
+- `src/hooks/useShopMutation.ts` — shopId注入パターン
+- `src/components/features/auths/AuthGuard.tsx` — selectedShop初期化/整合
+- `src/components/templates/Header/index.tsx` — 切替UI配置先
+- `doc/features/manager-billing-roles.md` — 招待・権限モデルの元設計
+- `doc/features/manager-shop-membership.md` — 所属モデルの現状
+- `doc/features/billing-plans.md` — プラン定義・entitlements方針


### PR DESCRIPTION
有料機能として複数店舗登録・複数マネージャーを導入するための仕様と変更点を整理。
課金は店舗単位契約、複数店舗の課金ゲートは別スコープ（TODO[billing-gate]シームのみ）、
manager招待は既存スタッフ昇格方式（72h一回限りトークン・メール一致必須）。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014SjVB3NSMG7AMA74J5xnfu