### PR TITLE
fix: ログアウト時にdashboard系queryがUnauthenticatedエラーを投げないようにする

### DIFF
--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -200,11 +200,11 @@ describe("dashboard/queries", () => {
   });
 
   describe("getDashboardRecruitments", () => {
-    it("未認証の場合、エラーをthrowする", async () => {
+    it("未認証の場合、空ページを返す（ログアウト時の再実行でエラーにしない）", async () => {
       const t = convexTest(schema, modules);
-      await expect(t.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE)).rejects.toThrow(
-        "Unauthenticated",
-      );
+      const result = await t.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+      expect(result.page).toEqual([]);
+      expect(result.isDone).toBe(true);
     });
 
     it("認証済みだが店舗未登録の場合、空ページを返す", async () => {
@@ -717,11 +717,11 @@ describe("dashboard/queries", () => {
   });
 
   describe("getDashboardStaffs", () => {
-    it("未認証の場合、エラーをthrowする", async () => {
+    it("未認証の場合、空ページを返す（ログアウト時の再実行でエラーにしない）", async () => {
       const t = convexTest(schema, modules);
-      await expect(t.query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE)).rejects.toThrow(
-        "Unauthenticated",
-      );
+      const result = await t.query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+      expect(result.page).toEqual([]);
+      expect(result.isDone).toBe(true);
     });
 
     it("認証済みだが店舗未登録の場合、空ページを返す", async () => {

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -10,7 +10,8 @@ import {
 } from "../constants";
 import { getStaffLineAccount } from "../line/service";
 
-// shop未登録のsetup中に paginated query が走ってもエラーログを出さないための空結果
+// shop未登録のsetup中や、ログアウト直後に購読中queryが未認証で再実行された場合でも
+// エラーログを出さないための空結果（queryはthrowせず空を返す規約）
 const EMPTY_PAGE = { page: [], isDone: true, continueCursor: "" } as {
   page: never[];
   isDone: boolean;

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -1,6 +1,5 @@
 import type { GenericDatabaseReader } from "convex/server";
 import { paginationOptsValidator } from "convex/server";
-import { ConvexError } from "convex/values";
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { todayJST } from "../_lib/dateFormat";
 import { authenticatedQuery } from "../_lib/functions";
@@ -196,7 +195,6 @@ export const getActiveDashboardAnnouncement = authenticatedQuery({
 export const getDashboardRecruitments = authenticatedQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    if (!ctx.identity) throw new ConvexError("Unauthenticated");
     const shop = await getManagerShop(ctx);
     if (!shop) return EMPTY_PAGE;
 
@@ -219,7 +217,6 @@ export const getDashboardRecruitments = authenticatedQuery({
 export const hasDashboardPastRecruitments = authenticatedQuery({
   args: {},
   handler: async (ctx) => {
-    if (!ctx.identity) throw new ConvexError("Unauthenticated");
     const shop = await getManagerShop(ctx);
     if (!shop) return false;
 
@@ -238,7 +235,6 @@ export const hasDashboardPastRecruitments = authenticatedQuery({
 export const getDashboardPastRecruitments = authenticatedQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    if (!ctx.identity) throw new ConvexError("Unauthenticated");
     const shop = await getManagerShop(ctx);
     if (!shop) return EMPTY_PAGE;
 
@@ -266,7 +262,6 @@ export const getDashboardPastRecruitments = authenticatedQuery({
 export const getDashboardCurrentRecruitments = authenticatedQuery({
   args: {},
   handler: async (ctx) => {
-    if (!ctx.identity) throw new ConvexError("Unauthenticated");
     const shop = await getManagerShop(ctx);
     if (!shop) return [];
 
@@ -282,7 +277,6 @@ export const getDashboardCurrentRecruitments = authenticatedQuery({
 export const getDashboardStaffs = authenticatedQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    if (!ctx.identity) throw new ConvexError("Unauthenticated");
     const shop = await getManagerShop(ctx);
     if (!shop) return EMPTY_PAGE;
 

--- a/src/components/features/auths/AuthGuard.tsx
+++ b/src/components/features/auths/AuthGuard.tsx
@@ -53,18 +53,20 @@ export const AuthGuard = ({ children }: Props) => {
     }
   }, [myShops, selectedShop, setSelectedShop]);
 
+  // ログアウト・セッション失効時は userAtom が残っていても必ずログインへ戻す。
+  // （queryは未認証時にthrowせず空を返すため、エラー経由のリダイレクトは発生しない）
+  if (isLoaded && !isSignedIn) {
+    return (
+      <Navigate to="/login" search={{ redirect: normalizeAuthRedirect(`${location.pathname}${location.searchStr}`) }} />
+    );
+  }
+
   if (user.authId) {
     return children;
   }
 
   if (!isLoaded) {
     return <FullPageSpinner showHeader />;
-  }
-
-  if (!isSignedIn) {
-    return (
-      <Navigate to="/login" search={{ redirect: normalizeAuthRedirect(`${location.pathname}${location.searchStr}`) }} />
-    );
   }
 
   if (currentUser === undefined) {


### PR DESCRIPTION
ログアウトでClerkトークンが失効すると、クライアントの購読解除より先に
Convexサーバーが購読中のqueryを未認証状態で再実行し、
ConvexError("Unauthenticated") がエラーとして表面化していた。

queriesはthrowせずnull/空を返す規約に合わせ、dashboard系5つのqueryの
未認証throwを削除して空結果（EMPTY_PAGE / false / []）を返すようにした。
getManagerShopがidentityなしでnullを返すため、既存の空返却パスに合流する。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U3A8KVyTaNQL4WSCheJN3A