### PR TITLE
chore(analytics-dashboard): keep dashboard vars on deploy

### DIFF
--- a/apps/analytics-dashboard/wrangler.jsonc
+++ b/apps/analytics-dashboard/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "shiftori-analytics-dashboard",
   "main": "./src/worker.ts",
   "compatibility_date": "2026-07-05",
+  "keep_vars": true,
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",


### PR DESCRIPTION
wrangler deployがダッシュボードで設定した平文変数を毎回削除してしまう問題への対応。
keep_vars: true でデプロイ時にダッシュボード側の環境変数を保持する。