### PR TITLE
fix(analytics-dashboard): SPでカードを2列レイアウトに変更

### DIFF
--- a/apps/analytics-dashboard/src/features/dashboard/ActivationTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/ActivationTabContent.tsx
@@ -419,7 +419,7 @@ export function ActivationTabContent({
         <Text color="gray.950" fontSize={{ base: "md", md: "lg" }} fontWeight="bold" mb={4}>
           立ち上げのサマリー
         </Text>
-        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)", xl: "repeat(5, 1fr)" }}>
+        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "repeat(2, 1fr)", xl: "repeat(5, 1fr)" }}>
           <MetricCard
             delta={numberDelta(rows.length, previousRows.length)}
             isLoading={isLoading}

--- a/apps/analytics-dashboard/src/features/dashboard/DormantTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/DormantTabContent.tsx
@@ -335,7 +335,7 @@ export function DormantTabContent({
         <Text color="gray.950" fontSize={{ base: "md", md: "lg" }} fontWeight="bold" mb={4}>
           休眠のサマリー
         </Text>
-        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)", xl: "repeat(3, 1fr)" }}>
+        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "repeat(2, 1fr)", xl: "repeat(3, 1fr)" }}>
           <MetricCard
             delta={numberDelta(rows.length, previousRows.length)}
             deltaUnit="店舗"

--- a/apps/analytics-dashboard/src/features/dashboard/RetainedTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/RetainedTabContent.tsx
@@ -359,7 +359,7 @@ export function RetainedTabContent({
         <Text color="gray.950" fontSize={{ base: "md", md: "lg" }} fontWeight="bold" mb={4}>
           運用中のサマリー
         </Text>
-        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)", xl: "repeat(4, 1fr)" }}>
+        <Grid gap={{ base: 3, xl: 4 }} templateColumns={{ base: "repeat(2, 1fr)", xl: "repeat(4, 1fr)" }}>
           <MetricCard
             delta={numberDelta(rows.length, previousRows.length)}
             deltaUnit="店舗"

--- a/apps/analytics-dashboard/src/features/dashboard/index.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/index.tsx
@@ -210,7 +210,7 @@ const STAGE_ICONS: Record<StageIconName, IconType> = {
 };
 
 function StageIcon({ name }: { name: StageIconName }) {
-  return <Icon aria-hidden as={STAGE_ICONS[name]} boxSize={7} strokeWidth={2} />;
+  return <Icon aria-hidden as={STAGE_ICONS[name]} boxSize={{ base: 5, md: 7 }} strokeWidth={2} />;
 }
 
 function StageKpiCard({
@@ -242,18 +242,18 @@ function StageKpiCard({
       minW={0}
       p={{ base: 4, md: 5 }}
     >
-      <Flex align="start" gap={4}>
+      <Flex align="start" gap={{ base: 3, md: 4 }}>
         <Flex
           align="center"
           bg={colors.soft}
           borderRadius="full"
           color={colors.fg}
           flexShrink={0}
-          fontSize="2xl"
+          fontSize={{ base: "lg", md: "2xl" }}
           fontWeight="bold"
-          h="56px"
+          h={{ base: "40px", md: "56px" }}
           justify="center"
-          w="56px"
+          w={{ base: "40px", md: "56px" }}
         >
           <StageIcon name={icon} />
         </Flex>
@@ -305,7 +305,7 @@ function StageCards({
     retained: activeView === "retention",
   };
   return (
-    <Grid gap={{ base: 3, xl: 5 }} templateColumns={{ base: "1fr", sm: "repeat(2, 1fr)", xl: "repeat(4, 1fr)" }}>
+    <Grid gap={{ base: 3, xl: 5 }} templateColumns={{ base: "repeat(2, 1fr)", xl: "repeat(4, 1fr)" }}>
       <StageKpiCard
         delta={numberDelta(counts?.beforeStart, previousCounts?.beforeStart)}
         icon="flag"


### PR DESCRIPTION
全体サマリーのステージカード、立ち上げ・運用中・休眠タブのメトリクスカードを
SP（base）で1列から2列に変更。全体サマリーカードのアイコンもSPでは縮小。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bpsk2KTQr7sfhTQMm4GT43