### PR TITLE
feat(analytics): 詳細ボタンを廃止し行クリックでモーダルを開く

### DIFF
--- a/apps/analytics-dashboard/src/features/dashboard/ActivationTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/ActivationTabContent.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Tooltip as ChakraTooltip,
   Flex,
   Grid,
@@ -324,15 +323,12 @@ function ActivationTable({
                   sortKey="firstRecruitmentDurationDays"
                   textAlign="right"
                 />
-                <Table.ColumnHeader color="gray.600" fontWeight="bold" textAlign="right">
-                  詳細
-                </Table.ColumnHeader>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {rows.length === 0 ? (
                 <Table.Row>
-                  <Table.Cell colSpan={10}>
+                  <Table.Cell colSpan={9}>
                     <Flex align="center" h="80px" justify="center">
                       <Text color="gray.500" fontSize="sm">
                         立ち上げの店舗はありません
@@ -344,7 +340,12 @@ function ActivationTable({
                 sortedRows.map((row) => {
                   const firstRecruitmentDurationDays = getFirstRecruitmentDurationDays(row);
                   return (
-                    <Table.Row key={row.shopId}>
+                    <Table.Row
+                      key={row.shopId}
+                      _hover={{ bg: "gray.50" }}
+                      cursor="pointer"
+                      onClick={() => onOpenShopRecruitments(row.shopId)}
+                    >
                       <Table.Cell color="gray.950" fontWeight="bold">
                         {row.shopName}
                       </Table.Cell>
@@ -367,16 +368,6 @@ function ActivationTable({
                         {firstRecruitmentDurationDays === null
                           ? "-"
                           : `${formatNumber(firstRecruitmentDurationDays)}日`}
-                      </Table.Cell>
-                      <Table.Cell textAlign="right">
-                        <Button
-                          colorPalette="blue"
-                          onClick={() => onOpenShopRecruitments(row.shopId)}
-                          size="xs"
-                          variant="outline"
-                        >
-                          詳細
-                        </Button>
                       </Table.Cell>
                     </Table.Row>
                   );

--- a/apps/analytics-dashboard/src/features/dashboard/BeforeStartTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/BeforeStartTabContent.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Button, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
+import { Badge, Box, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
 import { useState } from "react";
 import type { ShopStageRowDto, ShopStagesResponse } from "@/api/analyticsTypes";
 import {
@@ -269,15 +269,12 @@ function BeforeStartTable({
                 />
                 <SortableColumnHeader label="登録日" onSortChange={setSort} sort={sort} sortKey="registeredAt" />
                 <SortableColumnHeader label="到達ステップ" onSortChange={setSort} sort={sort} sortKey="step" />
-                <Table.ColumnHeader color="gray.600" fontWeight="bold" textAlign="right">
-                  詳細
-                </Table.ColumnHeader>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {rows.length === 0 ? (
                 <Table.Row>
-                  <Table.Cell colSpan={4}>
+                  <Table.Cell colSpan={3}>
                     <Flex align="center" h="80px" justify="center">
                       <Text color="gray.500" fontSize="sm">
                         開始前の店舗はありません
@@ -289,23 +286,18 @@ function BeforeStartTable({
                 sortedRows.map((row) => {
                   const step = resolveBeforeStartTutorialStep(row);
                   return (
-                    <Table.Row key={row.shopId}>
+                    <Table.Row
+                      key={row.shopId}
+                      _hover={{ bg: "gray.50" }}
+                      cursor="pointer"
+                      onClick={() => onOpenShopRecruitments(row.shopId)}
+                    >
                       <Table.Cell color="gray.950" fontWeight="bold">
                         {row.shopName}
                       </Table.Cell>
                       <Table.Cell color="gray.700">{formatDate(getShopCreatedAt(row))}</Table.Cell>
                       <Table.Cell>
                         <StepLabel step={step} />
-                      </Table.Cell>
-                      <Table.Cell textAlign="right">
-                        <Button
-                          colorPalette="blue"
-                          onClick={() => onOpenShopRecruitments(row.shopId)}
-                          size="xs"
-                          variant="outline"
-                        >
-                          詳細
-                        </Button>
                       </Table.Cell>
                     </Table.Row>
                   );

--- a/apps/analytics-dashboard/src/features/dashboard/DormantTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/DormantTabContent.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
+import { Box, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
 import { useState } from "react";
 import type { ShopStageRowDto, ShopStagesResponse } from "@/api/analyticsTypes";
 import {
@@ -247,15 +247,12 @@ function DormantTable({
                   sortKey="daysSinceLastShiftCreated"
                   textAlign="right"
                 />
-                <Table.ColumnHeader color="gray.600" fontWeight="bold" textAlign="right">
-                  詳細
-                </Table.ColumnHeader>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {rows.length === 0 ? (
                 <Table.Row>
-                  <Table.Cell colSpan={9}>
+                  <Table.Cell colSpan={8}>
                     <Flex align="center" h="80px" justify="center">
                       <Text color="gray.500" fontSize="sm">
                         休眠の店舗はありません
@@ -265,7 +262,12 @@ function DormantTable({
                 </Table.Row>
               ) : (
                 sortedRows.map((row) => (
-                  <Table.Row key={row.shopId}>
+                  <Table.Row
+                    key={row.shopId}
+                    _hover={{ bg: "gray.50" }}
+                    cursor="pointer"
+                    onClick={() => onOpenShopRecruitments(row.shopId)}
+                  >
                     <Table.Cell color="gray.950" fontWeight="bold">
                       {row.shopName}
                     </Table.Cell>
@@ -289,16 +291,6 @@ function DormantTable({
                     </Table.Cell>
                     <Table.Cell color="gray.700" textAlign="right">
                       {formatWithUnit(getDaysSinceLastShiftCreated(row), "日")}
-                    </Table.Cell>
-                    <Table.Cell textAlign="right">
-                      <Button
-                        colorPalette="blue"
-                        onClick={() => onOpenShopRecruitments(row.shopId)}
-                        size="xs"
-                        variant="outline"
-                      >
-                        詳細
-                      </Button>
                     </Table.Cell>
                   </Table.Row>
                 ))

--- a/apps/analytics-dashboard/src/features/dashboard/RetainedTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/RetainedTabContent.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
+import { Box, Flex, Grid, HStack, Skeleton, Stack, Table, Text } from "@chakra-ui/react";
 import { useState } from "react";
 import type { ShopStageRowDto, ShopStagesResponse } from "@/api/analyticsTypes";
 import { formatNumber, formatPercent } from "@/domains/analytics/format";
@@ -259,15 +259,12 @@ function RetainedTable({
                   sort={sort}
                   sortKey="lastRecruitmentConfirmedAt"
                 />
-                <Table.ColumnHeader color="gray.600" fontWeight="bold" textAlign="right">
-                  詳細
-                </Table.ColumnHeader>
               </Table.Row>
             </Table.Header>
             <Table.Body>
               {rows.length === 0 ? (
                 <Table.Row>
-                  <Table.Cell colSpan={11}>
+                  <Table.Cell colSpan={10}>
                     <Flex align="center" h="80px" justify="center">
                       <Text color="gray.500" fontSize="sm">
                         運用中の店舗はありません
@@ -277,7 +274,12 @@ function RetainedTable({
                 </Table.Row>
               ) : (
                 sortedRows.map((row) => (
-                  <Table.Row key={row.shopId}>
+                  <Table.Row
+                    key={row.shopId}
+                    _hover={{ bg: "gray.50" }}
+                    cursor="pointer"
+                    onClick={() => onOpenShopRecruitments(row.shopId)}
+                  >
                     <Table.Cell color="gray.950" fontWeight="bold">
                       {row.shopName}
                     </Table.Cell>
@@ -306,16 +308,6 @@ function RetainedTable({
                       {formatWithUnit(row.averageDeadlineToConfirmationDays, "日", 1)}
                     </Table.Cell>
                     <Table.Cell color="gray.700">{formatDate(row.lastRecruitmentConfirmedAt)}</Table.Cell>
-                    <Table.Cell textAlign="right">
-                      <Button
-                        colorPalette="blue"
-                        onClick={() => onOpenShopRecruitments(row.shopId)}
-                        size="xs"
-                        variant="outline"
-                      >
-                        詳細
-                      </Button>
-                    </Table.Cell>
                   </Table.Row>
                 ))
               )}

--- a/apps/analytics-dashboard/src/features/dashboard/ShopListTabContent.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/ShopListTabContent.tsx
@@ -161,15 +161,12 @@ export function ShopListTabContent({
                     sortKey="recruitmentCount"
                     textAlign="right"
                   />
-                  <Table.ColumnHeader color="gray.600" fontWeight="bold" textAlign="right">
-                    詳細
-                  </Table.ColumnHeader>
                 </Table.Row>
               </Table.Header>
               <Table.Body>
                 {rows.length === 0 ? (
                   <Table.Row>
-                    <Table.Cell colSpan={7}>
+                    <Table.Cell colSpan={6}>
                       <Flex align="center" h="96px" justify="center">
                         <Text color="gray.500" fontSize="sm">
                           該当する店舗はありません
@@ -179,7 +176,12 @@ export function ShopListTabContent({
                   </Table.Row>
                 ) : (
                   rows.map((row) => (
-                    <Table.Row key={row.shopId}>
+                    <Table.Row
+                      key={row.shopId}
+                      _hover={{ bg: "gray.50" }}
+                      cursor="pointer"
+                      onClick={() => onOpenShopRecruitments(row.shopId)}
+                    >
                       <Table.Cell color="gray.700">{formatNullableDateTime(row.shopCreatedAt)}</Table.Cell>
                       <Table.Cell color="gray.950" fontWeight="bold" maxW="160px" w="160px">
                         <Text
@@ -204,16 +206,6 @@ export function ShopListTabContent({
                       </Table.Cell>
                       <Table.Cell color="gray.700" textAlign="right">
                         {formatRecruitmentCount(row.recruitmentCount)}
-                      </Table.Cell>
-                      <Table.Cell textAlign="right">
-                        <Button
-                          colorPalette="blue"
-                          onClick={() => onOpenShopRecruitments(row.shopId)}
-                          size="xs"
-                          variant="outline"
-                        >
-                          詳細
-                        </Button>
                       </Table.Cell>
                     </Table.Row>
                   ))


### PR DESCRIPTION
各テーブルの詳細カラム/ボタンを削除し、行全体の押下で
同じシフト詳細モーダルが開くように変更。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LMfTYkm7TPaNCdgVLLAN8T