### PR TITLE
perf(lp): モバイル初期ロードを軽量化しCWVを改善

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/react-vite";
+import { markdownFrontmatterPlugin } from "../vite/markdownFrontmatterPlugin.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const storybookAppVersion = "0.0.0-vrt";
@@ -44,6 +45,7 @@ const config: StorybookConfig = {
     // convex/react 等のモック差し替えには resolveId フックを使う
     config.plugins = [
       ...(config.plugins ?? []),
+      markdownFrontmatterPlugin(),
       {
         name: "storybook-mock-modules",
         enforce: "pre" as const,

--- a/doc/features/public-pages.md
+++ b/doc/features/public-pages.md
@@ -8,8 +8,8 @@ LPの既存コンテンツを流用し、検索結果に法務ページ以外の
 - `src/routes/features.tsx` / `src/pages/features/index.tsx` — できることページ
 - `src/routes/faq.tsx` / `src/pages/faq/index.tsx` — よくある質問ページ
 - `src/routes/articles.tsx` / `src/routes/articles.$slug.tsx` / `src/routes/articles.categories.$categorySlug.tsx` — 記事一覧・記事詳細・カテゴリページ
-- `src/routes/_unregistered/demo.flow.tsx` / `src/pages/demo-flow/index.tsx` — 募集から確定通知までのフローデモ
-- `src/routes/_unregistered/demo.shiftboard.tsx` / `src/pages/demo-shift-board/index.tsx` — 店長・シフト担当者向けシフト表デモ
+- `src/routes/demo.flow.tsx` / `src/pages/demo-flow/index.tsx` — 募集から確定通知までのフローデモ（`_unregistered` 外に置き、Clerk/Convexバンドルを載せない）
+- `src/routes/demo.shiftboard.tsx` / `src/pages/demo-shift-board/index.tsx` — 店長・シフト担当者向けシフト表デモ（同上）
 - `src/components/features/Demo/` — 公開デモ用コンポーネント
 - `src/components/features/LandingPage/` — TOPのLP本体、FAQデータ、公開ページ共通フッター
 - `src/components/features/LandingPage/FeatureSection.tsx` / `BenefitsSection.tsx` / `FaqSection.tsx` — `/features`・`/faq`で流用している既存LPセクション

--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -13,7 +13,9 @@ for (const user of E2E_CLERK_USERS) {
     await clerkSetup();
 
     // Clerk の認証画面そのものはE2E対象外。以降の manager 画面検証に必要な storageState だけ作る。
-    await page.goto("/");
+    // clerk.signIn は window.Clerk が必要。LP(/)は Clerk を読み込まないため、
+    // ClerkProvider を持つ /login へ遷移してからサインインする。
+    await page.goto("/login");
     await clerk.signIn({
       page,
       signInParams: {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://shiftori.app</loc>
+    <loc>https://shiftori.app/</loc>
     <lastmod>2026-07-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>

--- a/src/components/config/AuthProviders.tsx
+++ b/src/components/config/AuthProviders.tsx
@@ -1,0 +1,18 @@
+import { ClerkProvider } from "@clerk/clerk-react";
+import { jaJP } from "@clerk/localizations";
+import type { ReactNode } from "react";
+import { ConvexClientProvider } from "@/src/components/config/ConvexProvider";
+import { CLERK_PUBLISHABLE_KEY, CONVEX_URL } from "@/src/constants/env";
+
+/**
+ * Clerk + Convex をまとめた認証系プロバイダ。
+ * LP・記事・利用規約などの公開ページに Clerk/Convex のバンドルを載せないため、
+ * main.tsx ではなく認証が必要なレイアウト/ページ単位でラップする。
+ * ConvexReactClient はモジュールシングルトン（ConvexProvider.tsx の getClient）なので、
+ * レイアウト間の遷移でプロバイダが再マウントされても WebSocket 接続は維持される。
+ */
+export const AuthProviders = ({ children }: { children: ReactNode }) => (
+  <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} localization={jaJP}>
+    <ConvexClientProvider env={CONVEX_URL}>{children}</ConvexClientProvider>
+  </ClerkProvider>
+);

--- a/src/components/features/ArticleSite/articleContent.test.ts
+++ b/src/components/features/ArticleSite/articleContent.test.ts
@@ -209,7 +209,7 @@ describe("ArticleSite markdown content", () => {
   it("structured data 用の値を作れる", () => {
     const article = parseArticleMarkdown(articleMarkdown, "line-shift-collection-guide");
 
-    expect(createArticleJsonLd(article)).toMatchObject({
+    expect(createArticleJsonLd(article.meta)).toMatchObject({
       "@type": "BlogPosting",
       headline: "LINEでシフト希望を集めるときに起きやすい困りごと",
       dateModified: "2026-05-21",
@@ -230,7 +230,7 @@ describe("ArticleSite markdown content", () => {
   it("記事ページのパンくず structured data を作れる", () => {
     const article = parseArticleMarkdown(articleMarkdown, "line-shift-collection-guide");
 
-    expect(createArticleBreadcrumbJsonLd(article)).toEqual({
+    expect(createArticleBreadcrumbJsonLd(article.meta)).toEqual({
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       itemListElement: [
@@ -249,7 +249,7 @@ describe("ArticleSite markdown content", () => {
   it("カテゴリページのパンくず structured data を作れる", () => {
     const category = parseCategoryMarkdown(categoryMarkdown, "shift-request");
 
-    expect(createCategoryBreadcrumbJsonLd(category)).toEqual({
+    expect(createCategoryBreadcrumbJsonLd(category.meta)).toEqual({
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       itemListElement: [

--- a/src/components/features/ArticleSite/articleContent.ts
+++ b/src/components/features/ArticleSite/articleContent.ts
@@ -1,12 +1,18 @@
+import { type MarkdownBlock, parseMarkdownBlocks, parseMarkdownDocument } from "@/src/helpers/markdown";
 import {
-  type MarkdownBlock,
-  parseBoundedPositiveInteger,
-  parseMarkdownBlocks,
-  parseMarkdownDocument,
-  parsePositiveInteger,
-  splitList,
-} from "@/src/helpers/markdown";
-import { SITE_URL } from "@/src/helpers/seo";
+  type ArticleMetadata,
+  type CategoryMetadata,
+  createImageSrcResolver,
+  parseArticleMetadata,
+  parseCategoryMetadata,
+  resolveArticleSlug,
+} from "./articleMeta";
+
+/**
+ * 記事サイトの「本文」層。`?raw` で Markdown 本文まで eager import するため、記事詳細・カテゴリ詳細を
+ * 描画するコード分割済みコンポーネント（`ArticleSite/index.tsx`）からのみ import すること。
+ * ルートの `head()` や LP など公開ページの入口からは、本文を含まない `articleMeta.ts` を使う。
+ */
 
 export type {
   MarkdownBlock,
@@ -14,64 +20,24 @@ export type {
   MarkdownImageAlign,
   MarkdownMediaAlign,
 } from "@/src/helpers/markdown";
-
-export type SitePageMetadata = {
-  title: string;
-  description: string;
-  breadcrumbLabel: string;
-  concernTitle: string;
-  latestTitle: string;
-  ctaTitle: string;
-  ctaDescription: string;
-  ctaPrimaryLabel: string;
-  ctaPrimaryHref: string;
-  ctaSecondaryLabel: string;
-  ctaSecondaryHref: string;
-  concernSlugs: string[];
-  landingPreviewTitle: string;
-  landingPreviewDescription: string;
-  landingPreviewLimit: number;
-  landingPreviewLinkLabel: string;
-};
-
-export type CategoryMetadata = {
-  slug: string;
-  title: string;
-  description: string;
-  breadcrumbLabel: string;
-  pointTitle: string;
-  pointDescription: string;
-  concerns: string[];
-  representativeSlug: string;
-  relatedConcernSlugs: string[];
-  ctaTitle: string;
-  ctaDescription: string;
-};
-
-export type ArticleMetadata = {
-  slug: string;
-  title: string;
-  description: string;
-  heroImage?: ArticleHeroImage;
-  publishedAt: string;
-  updatedAt?: string;
-  categorySlug: string;
-  categoryLabel: string;
-  author: string;
-  readingMinutes: number;
-  keywords: string[];
-  relatedSlugs: string[];
-  featured: boolean;
-  canonicalPath: string;
-  ogTitle: string;
-  ogDescription: string;
-};
-
-export type ArticleHeroImage = {
-  src: string;
-  alt: string;
-  width: number;
-};
+export type {
+  ArticleHeroImage,
+  ArticleJsonLd,
+  ArticleMetadata,
+  BreadcrumbJsonLd,
+  CategoryMetadata,
+  ConcernContent,
+  SitePageMetadata,
+} from "./articleMeta";
+export {
+  concerns,
+  createArticleBreadcrumbJsonLd,
+  createArticleJsonLd,
+  createCategoryBreadcrumbJsonLd,
+  getArticleOgpImagePath,
+  parseSitePageMarkdown,
+  sitePage,
+} from "./articleMeta";
 
 export type ArticleContent = {
   meta: ArticleMetadata;
@@ -84,54 +50,6 @@ export type CategoryContent = {
   blocks: MarkdownBlock[];
 };
 
-export type ConcernContent = {
-  slug: string;
-  title: string;
-  description: string;
-  href: string;
-  representativeSlug: string;
-};
-
-export type ArticleJsonLd = {
-  "@context": "https://schema.org";
-  "@type": "BlogPosting";
-  headline: string;
-  description: string;
-  image: string;
-  datePublished: string;
-  dateModified: string;
-  author: {
-    "@type": "Organization";
-    name: string;
-  };
-  publisher: {
-    "@type": "Organization";
-    name: string;
-    logo: {
-      "@type": "ImageObject";
-      url: string;
-    };
-  };
-  mainEntityOfPage: string;
-};
-
-export type BreadcrumbJsonLd = {
-  "@context": "https://schema.org";
-  "@type": "BreadcrumbList";
-  itemListElement: {
-    "@type": "ListItem";
-    position: number;
-    name: string;
-    item?: string;
-  }[];
-};
-
-const pageModules = import.meta.glob<string>("./content/pages/*.md", {
-  eager: true,
-  query: "?raw",
-  import: "default",
-});
-
 const categoryModules = import.meta.glob<string>("./content/categories/*/index.md", {
   eager: true,
   query: "?raw",
@@ -143,58 +61,6 @@ const articleModules = import.meta.glob<string>("./content/articles/*/index.md",
   query: "?raw",
   import: "default",
 });
-
-const imageModules = import.meta.glob<string>("./content/**/*.{avif,gif,jpeg,jpg,png,svg,webp}", {
-  eager: true,
-  query: "?url",
-  import: "default",
-});
-
-const pageRequiredFields = [
-  "title",
-  "description",
-  "breadcrumbLabel",
-  "concernTitle",
-  "latestTitle",
-  "ctaTitle",
-  "ctaDescription",
-  "ctaPrimaryLabel",
-  "ctaPrimaryHref",
-  "ctaSecondaryLabel",
-  "ctaSecondaryHref",
-] as const;
-
-const categoryRequiredFields = [
-  "slug",
-  "title",
-  "description",
-  "breadcrumbLabel",
-  "pointTitle",
-  "pointDescription",
-  "concerns",
-  "representativeSlug",
-  "ctaTitle",
-  "ctaDescription",
-] as const;
-
-const articleRequiredFields = [
-  "title",
-  "description",
-  "publishedAt",
-  "categorySlug",
-  "categoryLabel",
-  "author",
-  "readingMinutes",
-  "canonicalPath",
-  "ogTitle",
-  "ogDescription",
-] as const;
-
-const ARTICLE_HERO_IMAGE_DEFAULT_WIDTH = 320;
-const ARTICLE_HERO_IMAGE_MIN_WIDTH = 240;
-const ARTICLE_HERO_IMAGE_MAX_WIDTH = 360;
-
-export const sitePage = parseSitePageMarkdown(pageModules["./content/pages/articles.md"] ?? "", "articles");
 
 export const categories = Object.entries(categoryModules)
   .map(([path, source]) => {
@@ -210,27 +76,12 @@ export const articles = Object.entries(articleModules)
   })
   .sort((a, b) => b.meta.publishedAt.localeCompare(a.meta.publishedAt));
 
-const articleSlugAliases = {
-  "line-shift-collection-guide": "shiftori-line-workflow",
-} as const;
-
-export const concerns = sitePage.concernSlugs
-  .map((slug) => getCategory(slug))
-  .filter((category): category is CategoryContent => Boolean(category))
-  .map<ConcernContent>((category) => ({
-    slug: category.meta.slug,
-    title: category.meta.title,
-    description: category.meta.description,
-    href: `/articles/categories/${category.meta.slug}`,
-    representativeSlug: category.meta.representativeSlug,
-  }));
-
 export function getArticle(slug?: string): ArticleContent | undefined {
   if (!slug) {
     return articles.find((article) => article.meta.featured);
   }
 
-  const resolvedSlug = articleSlugAliases[slug as keyof typeof articleSlugAliases] ?? slug;
+  const resolvedSlug = resolveArticleSlug(slug);
   return articles.find((article) => article.meta.slug === resolvedSlug);
 }
 
@@ -266,139 +117,19 @@ export function getRepresentativeArticle(category: CategoryContent | undefined):
   return getArticle(category.meta.representativeSlug) ?? getArticlesByCategory(category.meta.slug)[0];
 }
 
-/** 記事別OGP画像のサイトルート相対パス。`pnpm ogp:articles` が同じ場所に生成する。 */
-export function getArticleOgpImagePath(slug: string): string {
-  return `/ogp/articles/${slug}.png`;
-}
-
-export function createArticleJsonLd(article: ArticleContent): ArticleJsonLd {
-  return {
-    "@context": "https://schema.org",
-    "@type": "BlogPosting",
-    headline: article.meta.ogTitle,
-    description: article.meta.ogDescription,
-    image: `${SITE_URL}${getArticleOgpImagePath(article.meta.slug)}`,
-    datePublished: article.meta.publishedAt,
-    dateModified: article.meta.updatedAt ?? article.meta.publishedAt,
-    author: {
-      "@type": "Organization",
-      name: article.meta.author,
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "シフトリ",
-      logo: {
-        "@type": "ImageObject",
-        url: `${SITE_URL}/logo512.png`,
-      },
-    },
-    mainEntityOfPage: `${SITE_URL}${article.meta.canonicalPath}`,
-  };
-}
-
-/** パンくずの先頭（記事一覧トップ）。UIの `Breadcrumbs` と同じ並びを構造化データに写す */
-function articlesRootBreadcrumbItem(): BreadcrumbJsonLd["itemListElement"][number] {
-  return { "@type": "ListItem", position: 1, name: sitePage.breadcrumbLabel, item: `${SITE_URL}/articles` };
-}
-
-export function createArticleBreadcrumbJsonLd(article: ArticleContent): BreadcrumbJsonLd {
-  return {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      articlesRootBreadcrumbItem(),
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: article.meta.categoryLabel,
-        item: `${SITE_URL}/articles/categories/${article.meta.categorySlug}`,
-      },
-      { "@type": "ListItem", position: 3, name: article.meta.title },
-    ],
-  };
-}
-
-export function createCategoryBreadcrumbJsonLd(category: CategoryContent): BreadcrumbJsonLd {
-  return {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      articlesRootBreadcrumbItem(),
-      { "@type": "ListItem", position: 2, name: category.meta.breadcrumbLabel },
-    ],
-  };
-}
-
-export function parseSitePageMarkdown(source: string, slug: string): SitePageMetadata {
-  const { frontmatter } = parseMarkdownDocument(source, slug);
-  ensureFields(frontmatter, pageRequiredFields, slug);
-
-  return {
-    title: frontmatter.title,
-    description: frontmatter.description,
-    breadcrumbLabel: frontmatter.breadcrumbLabel,
-    concernTitle: frontmatter.concernTitle,
-    latestTitle: frontmatter.latestTitle,
-    ctaTitle: frontmatter.ctaTitle,
-    ctaDescription: frontmatter.ctaDescription,
-    ctaPrimaryLabel: frontmatter.ctaPrimaryLabel,
-    ctaPrimaryHref: frontmatter.ctaPrimaryHref,
-    ctaSecondaryLabel: frontmatter.ctaSecondaryLabel,
-    ctaSecondaryHref: frontmatter.ctaSecondaryHref,
-    concernSlugs: splitList(frontmatter.concernSlugs),
-    landingPreviewTitle: frontmatter.landingPreviewTitle ?? "シフト作成のヒント",
-    landingPreviewDescription:
-      frontmatter.landingPreviewDescription ??
-      "LINE回収やExcel転記など、シフト作成でつまずきやすいポイントを整理しています。",
-    landingPreviewLimit: parsePositiveInteger(frontmatter.landingPreviewLimit, 3),
-    landingPreviewLinkLabel: frontmatter.landingPreviewLinkLabel ?? "記事一覧を見る",
-  };
-}
-
 export function parseCategoryMarkdown(source: string, slug: string, documentPath?: string): CategoryContent {
-  const { frontmatter, bodySource } = parseMarkdownDocument(source, slug);
-  ensureFields(frontmatter, categoryRequiredFields, slug);
+  const meta = parseCategoryMetadata(source, slug);
+  const { bodySource } = parseMarkdownDocument(source, slug);
 
   return {
-    meta: {
-      slug: frontmatter.slug,
-      title: frontmatter.title,
-      description: frontmatter.description,
-      breadcrumbLabel: frontmatter.breadcrumbLabel,
-      pointTitle: frontmatter.pointTitle,
-      pointDescription: frontmatter.pointDescription,
-      concerns: splitList(frontmatter.concerns),
-      representativeSlug: frontmatter.representativeSlug,
-      relatedConcernSlugs: splitList(frontmatter.relatedConcernSlugs),
-      ctaTitle: frontmatter.ctaTitle,
-      ctaDescription: frontmatter.ctaDescription,
-    },
+    meta,
     blocks: parseMarkdownBlocks(bodySource, { resolveImageSrc: createImageSrcResolver(documentPath) }),
   };
 }
 
 export function parseArticleMarkdown(source: string, slug: string, documentPath?: string): ArticleContent {
-  const { frontmatter, bodySource } = parseMarkdownDocument(source, slug);
-  ensureFields(frontmatter, articleRequiredFields, slug);
-
-  const meta: ArticleMetadata = {
-    slug,
-    title: frontmatter.title,
-    description: frontmatter.description,
-    heroImage: parseArticleHeroImage(frontmatter, documentPath, slug),
-    publishedAt: frontmatter.publishedAt,
-    updatedAt: frontmatter.updatedAt || undefined,
-    categorySlug: frontmatter.categorySlug,
-    categoryLabel: frontmatter.categoryLabel,
-    author: frontmatter.author,
-    readingMinutes: Number(frontmatter.readingMinutes),
-    keywords: splitList(frontmatter.keywords),
-    relatedSlugs: splitList(frontmatter.relatedSlugs),
-    featured: frontmatter.featured === "true",
-    canonicalPath: frontmatter.canonicalPath,
-    ogTitle: frontmatter.ogTitle,
-    ogDescription: frontmatter.ogDescription,
-  };
+  const meta = parseArticleMetadata(source, slug, documentPath);
+  const { bodySource } = parseMarkdownDocument(source, slug);
 
   const blocks = parseMarkdownBlocks(bodySource, { resolveImageSrc: createImageSrcResolver(documentPath) });
   const toc = blocks
@@ -408,76 +139,4 @@ export function parseArticleMarkdown(source: string, slug: string, documentPath?
     .map((block) => ({ id: block.id, text: block.text }));
 
   return { meta, blocks, toc };
-}
-
-function parseArticleHeroImage(
-  frontmatter: Record<string, string>,
-  documentPath: string | undefined,
-  slug: string,
-): ArticleHeroImage | undefined {
-  if (!frontmatter.heroImageSrc) {
-    return undefined;
-  }
-
-  if (!frontmatter.heroImageAlt) {
-    throw new Error(`記事 "${slug}" の heroImageSrc には heroImageAlt が必要です`);
-  }
-
-  return {
-    src: resolveMarkdownImageSrc(frontmatter.heroImageSrc, documentPath),
-    alt: frontmatter.heroImageAlt,
-    width: parseBoundedPositiveInteger(
-      frontmatter.heroImageWidth,
-      ARTICLE_HERO_IMAGE_DEFAULT_WIDTH,
-      ARTICLE_HERO_IMAGE_MIN_WIDTH,
-      ARTICLE_HERO_IMAGE_MAX_WIDTH,
-    ),
-  };
-}
-
-function ensureFields<const T extends readonly string[]>(
-  frontmatter: Record<string, string>,
-  fields: T,
-  slug: string,
-): void {
-  for (const field of fields) {
-    if (!frontmatter[field]) {
-      throw new Error(`記事 "${slug}" の frontmatter に ${field} がありません`);
-    }
-  }
-}
-
-function createImageSrcResolver(documentPath?: string): (src: string) => string {
-  return (src) => resolveMarkdownImageSrc(src, documentPath);
-}
-
-function resolveMarkdownImageSrc(src: string, documentPath?: string): string {
-  if (/^(https?:)?\/\//.test(src) || /^(data|blob):/.test(src) || src.startsWith("/")) {
-    return src;
-  }
-
-  if (!documentPath) {
-    return src;
-  }
-
-  const documentDirectory = documentPath.replace(/\/[^/]*$/, "");
-  const normalizedPath = normalizeContentPath(`${documentDirectory}/${src}`);
-  return imageModules[normalizedPath] ?? src;
-}
-
-function normalizeContentPath(path: string): string {
-  const segments: string[] = [];
-
-  for (const segment of path.split("/")) {
-    if (!segment || segment === ".") {
-      continue;
-    }
-    if (segment === "..") {
-      segments.pop();
-      continue;
-    }
-    segments.push(segment);
-  }
-
-  return `./${segments.join("/")}`;
 }

--- a/src/components/features/ArticleSite/articleMeta.ts
+++ b/src/components/features/ArticleSite/articleMeta.ts
@@ -1,0 +1,439 @@
+import {
+  parseBoundedPositiveInteger,
+  parseMarkdownDocument,
+  parsePositiveInteger,
+  splitList,
+} from "@/src/helpers/markdown";
+import { SITE_URL } from "@/src/helpers/seo";
+
+/**
+ * 記事サイトの「メタデータ」層。
+ *
+ * ここは frontmatter だけを `?frontmatter` で eager import するため、記事本文（Markdown body）を
+ * バンドルに含めない。ルートの `head()` や LP の記事プレビューなど、エントリー/公開ページ側から
+ * 参照される軽量な入口として使う。本文（blocks/toc）が必要な描画は `articleContent.ts`（コード分割
+ * されたページコンポーネントからのみ import）で扱う。
+ */
+
+export type SitePageMetadata = {
+  title: string;
+  description: string;
+  breadcrumbLabel: string;
+  concernTitle: string;
+  latestTitle: string;
+  ctaTitle: string;
+  ctaDescription: string;
+  ctaPrimaryLabel: string;
+  ctaPrimaryHref: string;
+  ctaSecondaryLabel: string;
+  ctaSecondaryHref: string;
+  concernSlugs: string[];
+  landingPreviewTitle: string;
+  landingPreviewDescription: string;
+  landingPreviewLimit: number;
+  landingPreviewLinkLabel: string;
+};
+
+export type CategoryMetadata = {
+  slug: string;
+  title: string;
+  description: string;
+  breadcrumbLabel: string;
+  pointTitle: string;
+  pointDescription: string;
+  concerns: string[];
+  representativeSlug: string;
+  relatedConcernSlugs: string[];
+  ctaTitle: string;
+  ctaDescription: string;
+};
+
+export type ArticleHeroImage = {
+  src: string;
+  alt: string;
+  width: number;
+};
+
+export type ArticleMetadata = {
+  slug: string;
+  title: string;
+  description: string;
+  heroImage?: ArticleHeroImage;
+  publishedAt: string;
+  updatedAt?: string;
+  categorySlug: string;
+  categoryLabel: string;
+  author: string;
+  readingMinutes: number;
+  keywords: string[];
+  relatedSlugs: string[];
+  featured: boolean;
+  canonicalPath: string;
+  ogTitle: string;
+  ogDescription: string;
+};
+
+export type ConcernContent = {
+  slug: string;
+  title: string;
+  description: string;
+  href: string;
+  representativeSlug: string;
+};
+
+export type ArticleJsonLd = {
+  "@context": "https://schema.org";
+  "@type": "BlogPosting";
+  headline: string;
+  description: string;
+  image: string;
+  datePublished: string;
+  dateModified: string;
+  author: {
+    "@type": "Organization";
+    name: string;
+  };
+  publisher: {
+    "@type": "Organization";
+    name: string;
+    logo: {
+      "@type": "ImageObject";
+      url: string;
+    };
+  };
+  mainEntityOfPage: string;
+};
+
+export type BreadcrumbJsonLd = {
+  "@context": "https://schema.org";
+  "@type": "BreadcrumbList";
+  itemListElement: {
+    "@type": "ListItem";
+    position: number;
+    name: string;
+    item?: string;
+  }[];
+};
+
+// frontmatter だけを含む擬似 md ソース（vite/markdownFrontmatterPlugin.ts が生成）。本文は含まれない。
+const pageFrontmatterModules = import.meta.glob<string>("./content/pages/*.md", {
+  eager: true,
+  query: "?frontmatter",
+  import: "default",
+});
+
+const categoryFrontmatterModules = import.meta.glob<string>("./content/categories/*/index.md", {
+  eager: true,
+  query: "?frontmatter",
+  import: "default",
+});
+
+const articleFrontmatterModules = import.meta.glob<string>("./content/articles/*/index.md", {
+  eager: true,
+  query: "?frontmatter",
+  import: "default",
+});
+
+// 画像は URL 文字列のみ（`?url`）なので軽量。heroImage・本文画像の解決で共有する。
+const imageModules = import.meta.glob<string>("./content/**/*.{avif,gif,jpeg,jpg,png,svg,webp}", {
+  eager: true,
+  query: "?url",
+  import: "default",
+});
+
+const pageRequiredFields = [
+  "title",
+  "description",
+  "breadcrumbLabel",
+  "concernTitle",
+  "latestTitle",
+  "ctaTitle",
+  "ctaDescription",
+  "ctaPrimaryLabel",
+  "ctaPrimaryHref",
+  "ctaSecondaryLabel",
+  "ctaSecondaryHref",
+] as const;
+
+const categoryRequiredFields = [
+  "slug",
+  "title",
+  "description",
+  "breadcrumbLabel",
+  "pointTitle",
+  "pointDescription",
+  "concerns",
+  "representativeSlug",
+  "ctaTitle",
+  "ctaDescription",
+] as const;
+
+const articleRequiredFields = [
+  "title",
+  "description",
+  "publishedAt",
+  "categorySlug",
+  "categoryLabel",
+  "author",
+  "readingMinutes",
+  "canonicalPath",
+  "ogTitle",
+  "ogDescription",
+] as const;
+
+const ARTICLE_HERO_IMAGE_DEFAULT_WIDTH = 320;
+const ARTICLE_HERO_IMAGE_MIN_WIDTH = 240;
+const ARTICLE_HERO_IMAGE_MAX_WIDTH = 360;
+
+export const sitePage = parseSitePageMarkdown(pageFrontmatterModules["./content/pages/articles.md"] ?? "", "articles");
+
+export const categoryMetas = Object.entries(categoryFrontmatterModules)
+  .map(([path, source]) => {
+    const slug = path.match(/\.\/content\/categories\/([^/]+)\/index\.md$/)?.[1] ?? path;
+    return parseCategoryMetadata(source, slug);
+  })
+  .sort((a, b) => a.title.localeCompare(b.title, "ja"));
+
+export const articleMetas = Object.entries(articleFrontmatterModules)
+  .map(([path, source]) => {
+    const slug = path.match(/\.\/content\/articles\/([^/]+)\/index\.md$/)?.[1] ?? path;
+    return parseArticleMetadata(source, slug, path);
+  })
+  .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+
+export const articleSlugAliases = {
+  "line-shift-collection-guide": "shiftori-line-workflow",
+} as const;
+
+export const concerns = sitePage.concernSlugs
+  .map((slug) => getCategoryMeta(slug))
+  .filter((category): category is CategoryMetadata => Boolean(category))
+  .map<ConcernContent>((category) => ({
+    slug: category.slug,
+    title: category.title,
+    description: category.description,
+    href: `/articles/categories/${category.slug}`,
+    representativeSlug: category.representativeSlug,
+  }));
+
+/** slug の別名（旧slug）を解決する。 */
+export function resolveArticleSlug(slug: string): string {
+  return articleSlugAliases[slug as keyof typeof articleSlugAliases] ?? slug;
+}
+
+export function getArticleMeta(slug?: string): ArticleMetadata | undefined {
+  if (!slug) {
+    return articleMetas.find((article) => article.featured);
+  }
+  const resolvedSlug = resolveArticleSlug(slug);
+  return articleMetas.find((article) => article.slug === resolvedSlug);
+}
+
+export function getCategoryMeta(categorySlug?: string): CategoryMetadata | undefined {
+  return categorySlug ? categoryMetas.find((category) => category.slug === categorySlug) : categoryMetas[0];
+}
+
+export function getArticleMetasByCategory(categorySlug: string): ArticleMetadata[] {
+  return articleMetas.filter((article) => article.categorySlug === categorySlug);
+}
+
+/** 記事別OGP画像のサイトルート相対パス。`pnpm ogp:articles` が同じ場所に生成する。 */
+export function getArticleOgpImagePath(slug: string): string {
+  return `/ogp/articles/${slug}.png`;
+}
+
+export function createArticleJsonLd(meta: ArticleMetadata): ArticleJsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: meta.ogTitle,
+    description: meta.ogDescription,
+    image: `${SITE_URL}${getArticleOgpImagePath(meta.slug)}`,
+    datePublished: meta.publishedAt,
+    dateModified: meta.updatedAt ?? meta.publishedAt,
+    author: {
+      "@type": "Organization",
+      name: meta.author,
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "シフトリ",
+      logo: {
+        "@type": "ImageObject",
+        url: `${SITE_URL}/logo512.png`,
+      },
+    },
+    mainEntityOfPage: `${SITE_URL}${meta.canonicalPath}`,
+  };
+}
+
+/** パンくずの先頭（記事一覧トップ）。UIの `Breadcrumbs` と同じ並びを構造化データに写す */
+function articlesRootBreadcrumbItem(): BreadcrumbJsonLd["itemListElement"][number] {
+  return { "@type": "ListItem", position: 1, name: sitePage.breadcrumbLabel, item: `${SITE_URL}/articles` };
+}
+
+export function createArticleBreadcrumbJsonLd(meta: ArticleMetadata): BreadcrumbJsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      articlesRootBreadcrumbItem(),
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: meta.categoryLabel,
+        item: `${SITE_URL}/articles/categories/${meta.categorySlug}`,
+      },
+      { "@type": "ListItem", position: 3, name: meta.title },
+    ],
+  };
+}
+
+export function createCategoryBreadcrumbJsonLd(meta: CategoryMetadata): BreadcrumbJsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [articlesRootBreadcrumbItem(), { "@type": "ListItem", position: 2, name: meta.breadcrumbLabel }],
+  };
+}
+
+export function parseSitePageMarkdown(source: string, slug: string): SitePageMetadata {
+  const { frontmatter } = parseMarkdownDocument(source, slug);
+  ensureFields(frontmatter, pageRequiredFields, slug);
+
+  return {
+    title: frontmatter.title,
+    description: frontmatter.description,
+    breadcrumbLabel: frontmatter.breadcrumbLabel,
+    concernTitle: frontmatter.concernTitle,
+    latestTitle: frontmatter.latestTitle,
+    ctaTitle: frontmatter.ctaTitle,
+    ctaDescription: frontmatter.ctaDescription,
+    ctaPrimaryLabel: frontmatter.ctaPrimaryLabel,
+    ctaPrimaryHref: frontmatter.ctaPrimaryHref,
+    ctaSecondaryLabel: frontmatter.ctaSecondaryLabel,
+    ctaSecondaryHref: frontmatter.ctaSecondaryHref,
+    concernSlugs: splitList(frontmatter.concernSlugs),
+    landingPreviewTitle: frontmatter.landingPreviewTitle ?? "シフト作成のヒント",
+    landingPreviewDescription:
+      frontmatter.landingPreviewDescription ??
+      "LINE回収やExcel転記など、シフト作成でつまずきやすいポイントを整理しています。",
+    landingPreviewLimit: parsePositiveInteger(frontmatter.landingPreviewLimit, 3),
+    landingPreviewLinkLabel: frontmatter.landingPreviewLinkLabel ?? "記事一覧を見る",
+  };
+}
+
+export function parseCategoryMetadata(source: string, slug: string): CategoryMetadata {
+  const { frontmatter } = parseMarkdownDocument(source, slug);
+  ensureFields(frontmatter, categoryRequiredFields, slug);
+
+  return {
+    slug: frontmatter.slug,
+    title: frontmatter.title,
+    description: frontmatter.description,
+    breadcrumbLabel: frontmatter.breadcrumbLabel,
+    pointTitle: frontmatter.pointTitle,
+    pointDescription: frontmatter.pointDescription,
+    concerns: splitList(frontmatter.concerns),
+    representativeSlug: frontmatter.representativeSlug,
+    relatedConcernSlugs: splitList(frontmatter.relatedConcernSlugs),
+    ctaTitle: frontmatter.ctaTitle,
+    ctaDescription: frontmatter.ctaDescription,
+  };
+}
+
+export function parseArticleMetadata(source: string, slug: string, documentPath?: string): ArticleMetadata {
+  const { frontmatter } = parseMarkdownDocument(source, slug);
+  ensureFields(frontmatter, articleRequiredFields, slug);
+
+  return {
+    slug,
+    title: frontmatter.title,
+    description: frontmatter.description,
+    heroImage: parseArticleHeroImage(frontmatter, documentPath, slug),
+    publishedAt: frontmatter.publishedAt,
+    updatedAt: frontmatter.updatedAt || undefined,
+    categorySlug: frontmatter.categorySlug,
+    categoryLabel: frontmatter.categoryLabel,
+    author: frontmatter.author,
+    readingMinutes: Number(frontmatter.readingMinutes),
+    keywords: splitList(frontmatter.keywords),
+    relatedSlugs: splitList(frontmatter.relatedSlugs),
+    featured: frontmatter.featured === "true",
+    canonicalPath: frontmatter.canonicalPath,
+    ogTitle: frontmatter.ogTitle,
+    ogDescription: frontmatter.ogDescription,
+  };
+}
+
+function parseArticleHeroImage(
+  frontmatter: Record<string, string>,
+  documentPath: string | undefined,
+  slug: string,
+): ArticleHeroImage | undefined {
+  if (!frontmatter.heroImageSrc) {
+    return undefined;
+  }
+
+  if (!frontmatter.heroImageAlt) {
+    throw new Error(`記事 "${slug}" の heroImageSrc には heroImageAlt が必要です`);
+  }
+
+  return {
+    src: resolveMarkdownImageSrc(frontmatter.heroImageSrc, documentPath),
+    alt: frontmatter.heroImageAlt,
+    width: parseBoundedPositiveInteger(
+      frontmatter.heroImageWidth,
+      ARTICLE_HERO_IMAGE_DEFAULT_WIDTH,
+      ARTICLE_HERO_IMAGE_MIN_WIDTH,
+      ARTICLE_HERO_IMAGE_MAX_WIDTH,
+    ),
+  };
+}
+
+function ensureFields<const T extends readonly string[]>(
+  frontmatter: Record<string, string>,
+  fields: T,
+  slug: string,
+): void {
+  for (const field of fields) {
+    if (!frontmatter[field]) {
+      throw new Error(`記事 "${slug}" の frontmatter に ${field} がありません`);
+    }
+  }
+}
+
+export function createImageSrcResolver(documentPath?: string): (src: string) => string {
+  return (src) => resolveMarkdownImageSrc(src, documentPath);
+}
+
+export function resolveMarkdownImageSrc(src: string, documentPath?: string): string {
+  if (/^(https?:)?\/\//.test(src) || /^(data|blob):/.test(src) || src.startsWith("/")) {
+    return src;
+  }
+
+  if (!documentPath) {
+    return src;
+  }
+
+  const documentDirectory = documentPath.replace(/\/[^/]*$/, "");
+  const normalizedPath = normalizeContentPath(`${documentDirectory}/${src}`);
+  return imageModules[normalizedPath] ?? src;
+}
+
+function normalizeContentPath(path: string): string {
+  const segments: string[] = [];
+
+  for (const segment of path.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  return `./${segments.join("/")}`;
+}

--- a/src/components/features/LandingPage/FaqArticlesSection/index.tsx
+++ b/src/components/features/LandingPage/FaqArticlesSection/index.tsx
@@ -1,14 +1,14 @@
 import { Accordion, Badge, Box, Container, Flex, Icon, Image, Link, SimpleGrid, Text, VStack } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { LuArrowRight, LuBookOpen, LuFileSpreadsheet, LuMessageCircle, LuMonitorCheck } from "react-icons/lu";
-import type { ArticleContent } from "@/src/components/features/ArticleSite/articleContent";
-import { articles } from "@/src/components/features/ArticleSite/articleContent";
+import type { ArticleMetadata } from "@/src/components/features/ArticleSite/articleMeta";
+import { articleMetas } from "@/src/components/features/ArticleSite/articleMeta";
 import { LANDING_HEADER_SCROLL_MARGIN_TOP } from "../constants";
 import { landingFaqs } from "../faqs";
 import { SectionHeading } from "../SectionHeading";
 
 const articleIcons = [LuMessageCircle, LuMonitorCheck, LuFileSpreadsheet, LuBookOpen];
-const previewArticles = articles.slice(0, 4);
+const previewArticles = articleMetas.slice(0, 4);
 
 export const FaqArticlesSection = () => (
   <Box as="section" bg="#fbfefe" py={16}>
@@ -70,7 +70,7 @@ export const FaqArticlesSection = () => (
 
           <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
             {previewArticles.map((article, index) => (
-              <ArticleCard key={article.meta.slug} article={article} icon={articleIcons[index % articleIcons.length]} />
+              <ArticleCard key={article.slug} article={article} icon={articleIcons[index % articleIcons.length]} />
             ))}
           </SimpleGrid>
         </Box>
@@ -79,9 +79,9 @@ export const FaqArticlesSection = () => (
   </Box>
 );
 
-const ArticleCard = ({ article, icon }: { article: ArticleContent; icon: IconType }) => (
+const ArticleCard = ({ article, icon }: { article: ArticleMetadata; icon: IconType }) => (
   <Link
-    href={article.meta.canonicalPath}
+    href={article.canonicalPath}
     color="inherit"
     display="block"
     textDecoration="none"
@@ -102,10 +102,10 @@ const ArticleCard = ({ article, icon }: { article: ArticleContent; icon: IconTyp
       <ArticleThumbnail article={article} icon={icon} />
       <Flex direction="column" flex="1" p={5}>
         <Badge alignSelf="start" colorPalette="green" variant="subtle" borderRadius="full" px={2.5}>
-          {article.meta.categoryLabel}
+          {article.categoryLabel}
         </Badge>
         <Text mt={3} color="gray.950" fontSize="md" fontWeight="black" lineHeight="1.55" lineClamp={2}>
-          {article.meta.title}
+          {article.title}
         </Text>
         <Flex align="center" gap={2} mt="auto" pt={4} color="teal.700" fontSize="sm" fontWeight="bold">
           詳しく見る
@@ -116,12 +116,12 @@ const ArticleCard = ({ article, icon }: { article: ArticleContent; icon: IconTyp
   </Link>
 );
 
-const ArticleThumbnail = ({ article, icon }: { article: ArticleContent; icon: IconType }) => {
-  if (article.meta.heroImage) {
+const ArticleThumbnail = ({ article, icon }: { article: ArticleMetadata; icon: IconType }) => {
+  if (article.heroImage) {
     return (
       <Image
-        src={article.meta.heroImage.src}
-        alt={article.meta.heroImage.alt}
+        src={article.heroImage.src}
+        alt={article.heroImage.alt}
         h="112px"
         w="full"
         objectFit="cover"

--- a/src/components/features/LandingPage/HeroSection/index.tsx
+++ b/src/components/features/LandingPage/HeroSection/index.tsx
@@ -165,7 +165,10 @@ const HeroVisual = () => (
         src={heroPcImage}
         alt="シフトリのPCシフト表画面"
         w="full"
+        aspectRatio={2048 / 1365}
         objectFit="contain"
+        fetchPriority="high"
+        decoding="async"
         filter="drop-shadow(0 24px 32px rgba(15, 23, 42, 0.18))"
       />
     </Box>
@@ -174,7 +177,10 @@ const HeroVisual = () => (
         src={heroSpImage}
         alt="スマホで希望シフトを提出する画面"
         w="full"
+        aspectRatio={720 / 1280}
         objectFit="contain"
+        fetchPriority="high"
+        decoding="async"
         filter="drop-shadow(0 22px 30px rgba(15, 23, 42, 0.22))"
       />
     </Box>

--- a/src/components/templates/Header/index.tsx
+++ b/src/components/templates/Header/index.tsx
@@ -1,9 +1,14 @@
 import type { BoxProps, ContainerProps, FlexProps, ImageProps, TextProps } from "@chakra-ui/react";
 import { Box, Container, Flex, Image, Link, Text } from "@chakra-ui/react";
 import { Link as RouterLink } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import { lazy, type ReactNode, Suspense } from "react";
 import { Button } from "@/src/components/ui/Button";
-import { UserMenu, type UserMenuDeleteShopAction } from "./UserMenu";
+import type { UserMenuDeleteShopAction } from "./UserMenu";
+
+// UserMenu は @clerk/clerk-react（SignOutButton）に依存する。静的 import すると
+// variant="public" の LP など Clerk を使わない公開ページのチャンクにも Clerk が
+// 巻き込まれるため、user variant でだけ読み込む遅延 import にしている。
+const UserMenu = lazy(() => import("./UserMenu").then((m) => ({ default: m.UserMenu })));
 
 export const HEADER_HEIGHT = { base: "64px", md: "68px" } as const;
 export const STAFF_CONTENT_MAX_W = "1024px";
@@ -80,7 +85,11 @@ export const Header = (props: HeaderProps = {}) => {
   return (
     <HeaderShell position={props.position ?? "fixed"}>
       <HeaderBrand to="/dashboard" ariaLabel="ダッシュボードへ" showTagline />
-      {props.showUserMenu !== false && <UserMenu tone="light" deleteShopAction={props.deleteShopAction} />}
+      {props.showUserMenu !== false && (
+        <Suspense fallback={null}>
+          <UserMenu tone="light" deleteShopAction={props.deleteShopAction} />
+        </Suspense>
+      )}
     </HeaderShell>
   );
 };

--- a/src/helpers/gtm/index.test.ts
+++ b/src/helpers/gtm/index.test.ts
@@ -86,10 +86,21 @@ describe("GTM ヘルパー", () => {
       );
     });
 
-    it("未初期化ならpushされない", () => {
+    it("未初期化ならdataLayerへ直接pushされない（バッファに退避）", () => {
       window.dataLayer = [];
       sendPageView("/dashboard");
       expect(window.dataLayer).toEqual([]);
+    });
+
+    it("遅延読み込み前にバッファしたpage_viewはinitGTM時に流し込まれる", () => {
+      window.dataLayer = [];
+      sendPageView("/before-init");
+      expect(window.dataLayer).toEqual([]);
+
+      initGTM("GTM-TEST123");
+      expect(window.dataLayer).toEqual(
+        expect.arrayContaining([expect.objectContaining({ event: "page_view", page_path: "/before-init" })]),
+      );
     });
   });
 
@@ -110,10 +121,24 @@ describe("GTM ヘルパー", () => {
       );
     });
 
-    it("未初期化ならpushされない", () => {
+    it("未初期化ならdataLayerへ直接pushされない（バッファに退避）", () => {
       window.dataLayer = [];
       sendEvent("click_button");
       expect(window.dataLayer).toEqual([]);
+    });
+
+    it("バッファしたイベントは登録順にinitGTM時へ流し込まれる", () => {
+      window.dataLayer = [];
+      sendPageView("/first");
+      sendEvent("second_event", { foo: "bar" });
+
+      initGTM("GTM-TEST123");
+
+      const events = window.dataLayer.filter((e) => e.event === "page_view" || e.event === "second_event");
+      expect(events).toEqual([
+        { event: "page_view", page_path: "/first" },
+        { event: "second_event", foo: "bar" },
+      ]);
     });
   });
 });

--- a/src/helpers/gtm/index.ts
+++ b/src/helpers/gtm/index.ts
@@ -8,6 +8,11 @@ declare global {
 
 let initialized = false;
 
+// GTM の読み込みは初期描画後（requestIdleCallback）まで遅延するため、それより前に
+// 発生した page_view / カスタムイベントを取りこぼさないよう一時バッファに退避し、
+// initGTM 時に dataLayer へ順序どおり流し込む。
+let pendingEvents: Record<string, unknown>[] = [];
+
 const getScriptSrc = (gtmId: string): string => `https://www.googletagmanager.com/gtm.js?id=${gtmId}`;
 const getNoscriptSrc = (gtmId: string): string => `https://www.googletagmanager.com/ns.html?id=${gtmId}`;
 
@@ -34,6 +39,12 @@ export const initGTM = (gtmId: string): void => {
   window.dataLayer = window.dataLayer || [];
   window.dataLayer.push({ "gtm.start": Date.now(), event: "gtm.js" });
 
+  // 遅延読み込み前にバッファした page_view / イベントを順序どおり流し込む
+  for (const event of pendingEvents) {
+    window.dataLayer.push(event);
+  }
+  pendingEvents = [];
+
   const scriptSrc = getScriptSrc(gtmId);
   if (!hasScript(gtmId)) {
     const script = document.createElement("script");
@@ -56,15 +67,24 @@ export const initGTM = (gtmId: string): void => {
 };
 
 export const sendPageView = (path: string): void => {
-  if (!initialized) return;
-  window.dataLayer?.push({ event: "page_view", page_path: path });
+  const payload = { event: "page_view", page_path: path };
+  if (!initialized) {
+    pendingEvents.push(payload);
+    return;
+  }
+  window.dataLayer?.push(payload);
 };
 
 export const sendEvent = (event: string, params?: Record<string, unknown>): void => {
-  if (!initialized) return;
-  window.dataLayer?.push({ event, ...params });
+  const payload = { event, ...params };
+  if (!initialized) {
+    pendingEvents.push(payload);
+    return;
+  }
+  window.dataLayer?.push(payload);
 };
 
 export const resetGTM = (): void => {
   initialized = false;
+  pendingEvents = [];
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,24 @@
-import { ClerkProvider } from "@clerk/clerk-react";
-import { jaJP } from "@clerk/localizations";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { type ReactNode, StrictMode } from "react";
+import { flushSync } from "react-dom";
 import ReactDOM from "react-dom/client";
 import z from "zod";
 import { ChakraProvider } from "@/src/components/config/ChakraProvider.tsx";
-import { ConvexClientProvider } from "@/src/components/config/ConvexProvider.tsx";
 import { RouteErrorFallback } from "@/src/components/ui/ErrorBoundary";
 import { customErrorMap } from "@/src/configs/zod/zop-setup.ts";
-import { CLERK_PUBLISHABLE_KEY, CONVEX_URL, GTM_ID } from "@/src/constants/env";
+import { GTM_ID } from "@/src/constants/env";
 import { initGTM } from "@/src/helpers/gtm";
 import { isPrerendering } from "@/src/helpers/seo";
 import reportWebVitals from "./reportWebVitals.ts";
 import { routeTree } from "./routeTree.gen.ts";
 
-initGTM(GTM_ID);
+// GTM(→GA4/Clarity)の読み込みを初期描画後まで遅延し、LCP/TBTと帯域を奪い合わないようにする。
+// 遅延中のイベントは gtm helper が dataLayer にバッファし、GTM 読み込み時にまとめて処理される。
+const scheduleGtmInit =
+  typeof window.requestIdleCallback === "function"
+    ? (cb: () => void) => window.requestIdleCallback(cb, { timeout: 5000 })
+    : (cb: () => void) => window.setTimeout(cb, 3000);
+scheduleGtmInit(() => initGTM(GTM_ID));
 
 // Create a new router instance
 const router = createRouter({
@@ -48,8 +52,13 @@ async function mountPrerenderedApp(element: HTMLElement, tree: ReactNode): Promi
   // replace the baked DOM with the live app to avoid React hydration mismatches.
   await router.load({ sync: true });
   removePrerenderedPortals();
+  // replaceChildren と React の初回コミットを flushSync で同一タスク内に収め、
+  // 焼き込みDOM除去→再描画の間にブラウザが空白フレームを描く「ちらつき」を防ぐ。
+  const root = ReactDOM.createRoot(element);
   element.replaceChildren();
-  ReactDOM.createRoot(element).render(tree);
+  flushSync(() => {
+    root.render(tree);
+  });
   // SPAフォールバック時のスプラッシュ（index.html 参照）を、Reactの初回コミット後に解除する
   requestAnimationFrame(() => {
     document.documentElement.removeAttribute("data-spa-fallback");
@@ -60,14 +69,12 @@ async function mountPrerenderedApp(element: HTMLElement, tree: ReactNode): Promi
 // Render the app
 const rootElement = document.getElementById("app");
 if (rootElement) {
+  // Clerk / Convex は認証が必要なレイアウト側（AuthProviders）でラップする。
+  // ここに置くとLPなどの公開ページのバンドル・起動コストに乗ってしまう。
   const tree = (
     <StrictMode>
       <ChakraProvider>
-        <ClerkProvider publishableKey={CLERK_PUBLISHABLE_KEY} localization={jaJP}>
-          <ConvexClientProvider env={CONVEX_URL}>
-            <RouterProvider router={router} />
-          </ConvexClientProvider>
-        </ClerkProvider>
+        <RouterProvider router={router} />
       </ChakraProvider>
     </StrictMode>
   );

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -1,3 +1,4 @@
+import { AuthProviders } from "@/src/components/config/AuthProviders";
 import { AuthPage, SsoCallbackPage } from "@/src/components/features/AuthPage";
 
 type AuthRoutePageProps = {
@@ -5,17 +6,33 @@ type AuthRoutePageProps = {
 };
 
 export function LoginPage({ redirect }: AuthRoutePageProps) {
-  return <AuthPage mode="login" redirect={redirect} />;
+  return (
+    <AuthProviders>
+      <AuthPage mode="login" redirect={redirect} />
+    </AuthProviders>
+  );
 }
 
 export function SignupPage({ redirect }: AuthRoutePageProps) {
-  return <AuthPage mode="signup" redirect={redirect} />;
+  return (
+    <AuthProviders>
+      <AuthPage mode="signup" redirect={redirect} />
+    </AuthProviders>
+  );
 }
 
 export function ForgotPasswordPage({ redirect }: AuthRoutePageProps) {
-  return <AuthPage mode="forgot-password" redirect={redirect} />;
+  return (
+    <AuthProviders>
+      <AuthPage mode="forgot-password" redirect={redirect} />
+    </AuthProviders>
+  );
 }
 
 export function SsoCallbackRoutePage() {
-  return <SsoCallbackPage />;
+  return (
+    <AuthProviders>
+      <SsoCallbackPage />
+    </AuthProviders>
+  );
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -25,6 +25,8 @@ import { Route as TermsStaffRouteImport } from './routes/terms_.staff'
 import { Route as TermsManagerRouteImport } from './routes/terms_.manager'
 import { Route as PrivacyStaffRouteImport } from './routes/privacy_.staff'
 import { Route as PrivacyManagerRouteImport } from './routes/privacy_.manager'
+import { Route as DemoShiftboardRouteImport } from './routes/demo.shiftboard'
+import { Route as DemoFlowRouteImport } from './routes/demo.flow'
 import { Route as ArticlesSlugRouteImport } from './routes/articles.$slug'
 import { Route as AuthDashboardRouteImport } from './routes/_auth/dashboard'
 import { Route as ArticlesCategoriesCategorySlugRouteImport } from './routes/articles.categories.$categorySlug'
@@ -33,8 +35,6 @@ import { Route as UnregisteredShiftsViewRouteImport } from './routes/_unregister
 import { Route as UnregisteredShiftsSubmitRouteImport } from './routes/_unregistered/shifts.submit'
 import { Route as UnregisteredShiftsReissueRouteImport } from './routes/_unregistered/shifts.reissue'
 import { Route as UnregisteredLineCallbackRouteImport } from './routes/_unregistered/line.callback'
-import { Route as UnregisteredDemoShiftboardRouteImport } from './routes/_unregistered/demo.shiftboard'
-import { Route as UnregisteredDemoFlowRouteImport } from './routes/_unregistered/demo.flow'
 import { Route as AuthShiftboardRecruitmentIdRouteImport } from './routes/_auth/shiftboard.$recruitmentId'
 import { Route as UnregisteredShiftsSubmitCompletedRouteImport } from './routes/_unregistered/shifts.submit_.completed'
 import { Route as UnregisteredLegalStaffConsentRouteImport } from './routes/_unregistered/legal.staff.consent'
@@ -117,6 +117,16 @@ const PrivacyManagerRoute = PrivacyManagerRouteImport.update({
   path: '/privacy/manager',
   getParentRoute: () => rootRouteImport,
 } as any)
+const DemoShiftboardRoute = DemoShiftboardRouteImport.update({
+  id: '/demo/shiftboard',
+  path: '/demo/shiftboard',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DemoFlowRoute = DemoFlowRouteImport.update({
+  id: '/demo/flow',
+  path: '/demo/flow',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ArticlesSlugRoute = ArticlesSlugRouteImport.update({
   id: '/$slug',
   path: '/$slug',
@@ -162,17 +172,6 @@ const UnregisteredLineCallbackRoute =
     path: '/line/callback',
     getParentRoute: () => UnregisteredRoute,
   } as any)
-const UnregisteredDemoShiftboardRoute =
-  UnregisteredDemoShiftboardRouteImport.update({
-    id: '/demo/shiftboard',
-    path: '/demo/shiftboard',
-    getParentRoute: () => UnregisteredRoute,
-  } as any)
-const UnregisteredDemoFlowRoute = UnregisteredDemoFlowRouteImport.update({
-  id: '/demo/flow',
-  path: '/demo/flow',
-  getParentRoute: () => UnregisteredRoute,
-} as any)
 const AuthShiftboardRecruitmentIdRoute =
   AuthShiftboardRecruitmentIdRouteImport.update({
     id: '/shiftboard/$recruitmentId',
@@ -205,13 +204,13 @@ export interface FileRoutesByFullPath {
   '/terms': typeof TermsRoute
   '/dashboard': typeof AuthDashboardRoute
   '/articles/$slug': typeof ArticlesSlugRoute
+  '/demo/flow': typeof DemoFlowRoute
+  '/demo/shiftboard': typeof DemoShiftboardRoute
   '/privacy/manager': typeof PrivacyManagerRoute
   '/privacy/staff': typeof PrivacyStaffRoute
   '/terms/manager': typeof TermsManagerRoute
   '/terms/staff': typeof TermsStaffRoute
   '/shiftboard/$recruitmentId': typeof AuthShiftboardRecruitmentIdRoute
-  '/demo/flow': typeof UnregisteredDemoFlowRoute
-  '/demo/shiftboard': typeof UnregisteredDemoShiftboardRoute
   '/line/callback': typeof UnregisteredLineCallbackRoute
   '/shifts/reissue': typeof UnregisteredShiftsReissueRoute
   '/shifts/submit': typeof UnregisteredShiftsSubmitRoute
@@ -234,13 +233,13 @@ export interface FileRoutesByTo {
   '/terms': typeof TermsRoute
   '/dashboard': typeof AuthDashboardRoute
   '/articles/$slug': typeof ArticlesSlugRoute
+  '/demo/flow': typeof DemoFlowRoute
+  '/demo/shiftboard': typeof DemoShiftboardRoute
   '/privacy/manager': typeof PrivacyManagerRoute
   '/privacy/staff': typeof PrivacyStaffRoute
   '/terms/manager': typeof TermsManagerRoute
   '/terms/staff': typeof TermsStaffRoute
   '/shiftboard/$recruitmentId': typeof AuthShiftboardRecruitmentIdRoute
-  '/demo/flow': typeof UnregisteredDemoFlowRoute
-  '/demo/shiftboard': typeof UnregisteredDemoShiftboardRoute
   '/line/callback': typeof UnregisteredLineCallbackRoute
   '/shifts/reissue': typeof UnregisteredShiftsReissueRoute
   '/shifts/submit': typeof UnregisteredShiftsSubmitRoute
@@ -266,13 +265,13 @@ export interface FileRoutesById {
   '/terms': typeof TermsRoute
   '/_auth/dashboard': typeof AuthDashboardRoute
   '/articles/$slug': typeof ArticlesSlugRoute
+  '/demo/flow': typeof DemoFlowRoute
+  '/demo/shiftboard': typeof DemoShiftboardRoute
   '/privacy_/manager': typeof PrivacyManagerRoute
   '/privacy_/staff': typeof PrivacyStaffRoute
   '/terms_/manager': typeof TermsManagerRoute
   '/terms_/staff': typeof TermsStaffRoute
   '/_auth/shiftboard/$recruitmentId': typeof AuthShiftboardRecruitmentIdRoute
-  '/_unregistered/demo/flow': typeof UnregisteredDemoFlowRoute
-  '/_unregistered/demo/shiftboard': typeof UnregisteredDemoShiftboardRoute
   '/_unregistered/line/callback': typeof UnregisteredLineCallbackRoute
   '/_unregistered/shifts/reissue': typeof UnregisteredShiftsReissueRoute
   '/_unregistered/shifts/submit': typeof UnregisteredShiftsSubmitRoute
@@ -297,13 +296,13 @@ export interface FileRouteTypes {
     | '/terms'
     | '/dashboard'
     | '/articles/$slug'
+    | '/demo/flow'
+    | '/demo/shiftboard'
     | '/privacy/manager'
     | '/privacy/staff'
     | '/terms/manager'
     | '/terms/staff'
     | '/shiftboard/$recruitmentId'
-    | '/demo/flow'
-    | '/demo/shiftboard'
     | '/line/callback'
     | '/shifts/reissue'
     | '/shifts/submit'
@@ -326,13 +325,13 @@ export interface FileRouteTypes {
     | '/terms'
     | '/dashboard'
     | '/articles/$slug'
+    | '/demo/flow'
+    | '/demo/shiftboard'
     | '/privacy/manager'
     | '/privacy/staff'
     | '/terms/manager'
     | '/terms/staff'
     | '/shiftboard/$recruitmentId'
-    | '/demo/flow'
-    | '/demo/shiftboard'
     | '/line/callback'
     | '/shifts/reissue'
     | '/shifts/submit'
@@ -357,13 +356,13 @@ export interface FileRouteTypes {
     | '/terms'
     | '/_auth/dashboard'
     | '/articles/$slug'
+    | '/demo/flow'
+    | '/demo/shiftboard'
     | '/privacy_/manager'
     | '/privacy_/staff'
     | '/terms_/manager'
     | '/terms_/staff'
     | '/_auth/shiftboard/$recruitmentId'
-    | '/_unregistered/demo/flow'
-    | '/_unregistered/demo/shiftboard'
     | '/_unregistered/line/callback'
     | '/_unregistered/shifts/reissue'
     | '/_unregistered/shifts/submit'
@@ -387,6 +386,8 @@ export interface RootRouteChildren {
   SignupRoute: typeof SignupRoute
   SsoCallbackRoute: typeof SsoCallbackRoute
   TermsRoute: typeof TermsRoute
+  DemoFlowRoute: typeof DemoFlowRoute
+  DemoShiftboardRoute: typeof DemoShiftboardRoute
   PrivacyManagerRoute: typeof PrivacyManagerRoute
   PrivacyStaffRoute: typeof PrivacyStaffRoute
   TermsManagerRoute: typeof TermsManagerRoute
@@ -507,6 +508,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PrivacyManagerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/demo/shiftboard': {
+      id: '/demo/shiftboard'
+      path: '/demo/shiftboard'
+      fullPath: '/demo/shiftboard'
+      preLoaderRoute: typeof DemoShiftboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/demo/flow': {
+      id: '/demo/flow'
+      path: '/demo/flow'
+      fullPath: '/demo/flow'
+      preLoaderRoute: typeof DemoFlowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/articles/$slug': {
       id: '/articles/$slug'
       path: '/$slug'
@@ -563,20 +578,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UnregisteredLineCallbackRouteImport
       parentRoute: typeof UnregisteredRoute
     }
-    '/_unregistered/demo/shiftboard': {
-      id: '/_unregistered/demo/shiftboard'
-      path: '/demo/shiftboard'
-      fullPath: '/demo/shiftboard'
-      preLoaderRoute: typeof UnregisteredDemoShiftboardRouteImport
-      parentRoute: typeof UnregisteredRoute
-    }
-    '/_unregistered/demo/flow': {
-      id: '/_unregistered/demo/flow'
-      path: '/demo/flow'
-      fullPath: '/demo/flow'
-      preLoaderRoute: typeof UnregisteredDemoFlowRouteImport
-      parentRoute: typeof UnregisteredRoute
-    }
     '/_auth/shiftboard/$recruitmentId': {
       id: '/_auth/shiftboard/$recruitmentId'
       path: '/shiftboard/$recruitmentId'
@@ -614,8 +615,6 @@ const AuthRouteChildren: AuthRouteChildren = {
 const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
 
 interface UnregisteredRouteChildren {
-  UnregisteredDemoFlowRoute: typeof UnregisteredDemoFlowRoute
-  UnregisteredDemoShiftboardRoute: typeof UnregisteredDemoShiftboardRoute
   UnregisteredLineCallbackRoute: typeof UnregisteredLineCallbackRoute
   UnregisteredShiftsReissueRoute: typeof UnregisteredShiftsReissueRoute
   UnregisteredShiftsSubmitRoute: typeof UnregisteredShiftsSubmitRoute
@@ -626,8 +625,6 @@ interface UnregisteredRouteChildren {
 }
 
 const UnregisteredRouteChildren: UnregisteredRouteChildren = {
-  UnregisteredDemoFlowRoute: UnregisteredDemoFlowRoute,
-  UnregisteredDemoShiftboardRoute: UnregisteredDemoShiftboardRoute,
   UnregisteredLineCallbackRoute: UnregisteredLineCallbackRoute,
   UnregisteredShiftsReissueRoute: UnregisteredShiftsReissueRoute,
   UnregisteredShiftsSubmitRoute: UnregisteredShiftsSubmitRoute,
@@ -669,6 +666,8 @@ const rootRouteChildren: RootRouteChildren = {
   SignupRoute: SignupRoute,
   SsoCallbackRoute: SsoCallbackRoute,
   TermsRoute: TermsRoute,
+  DemoFlowRoute: DemoFlowRoute,
+  DemoShiftboardRoute: DemoShiftboardRoute,
   PrivacyManagerRoute: PrivacyManagerRoute,
   PrivacyStaffRoute: PrivacyStaffRoute,
   TermsManagerRoute: TermsManagerRoute,

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { AuthProviders } from "@/src/components/config/AuthProviders";
 import { AuthenticatedHeader } from "@/src/components/features/auths/AuthenticatedHeader";
 import { AuthGuard } from "@/src/components/features/auths/AuthGuard";
 import { UnauthenticatedBoundary } from "@/src/components/features/auths/UnauthenticatedBoundary";
@@ -11,11 +12,13 @@ export const Route = createFileRoute("/_auth")({
 
 function RouteComponent() {
   return (
-    <AuthGuard>
-      <UnauthenticatedBoundary>
-        <AuthenticatedLayout />
-      </UnauthenticatedBoundary>
-    </AuthGuard>
+    <AuthProviders>
+      <AuthGuard>
+        <UnauthenticatedBoundary>
+          <AuthenticatedLayout />
+        </UnauthenticatedBoundary>
+      </AuthGuard>
+    </AuthProviders>
   );
 }
 

--- a/src/routes/_unregistered.tsx
+++ b/src/routes/_unregistered.tsx
@@ -1,9 +1,14 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { AuthProviders } from "@/src/components/config/AuthProviders";
 
 export const Route = createFileRoute("/_unregistered")({
   component: RouteComponent,
 });
 
 function RouteComponent() {
-  return <Outlet />;
+  return (
+    <AuthProviders>
+      <Outlet />
+    </AuthProviders>
+  );
 }

--- a/src/routes/articles.$slug.tsx
+++ b/src/routes/articles.$slug.tsx
@@ -3,14 +3,14 @@ import { ArticlePage } from "@/src/components/features/ArticleSite";
 import {
   createArticleBreadcrumbJsonLd,
   createArticleJsonLd,
-  getArticle,
+  getArticleMeta,
   getArticleOgpImagePath,
-} from "@/src/components/features/ArticleSite/articleContent";
+} from "@/src/components/features/ArticleSite/articleMeta";
 import { buildLinks, buildMeta, jsonLdMeta } from "@/src/helpers/seo";
 
 export const Route = createFileRoute("/articles/$slug")({
   head: ({ params }) => {
-    const article = getArticle(params.slug);
+    const article = getArticleMeta(params.slug);
 
     if (!article) {
       return {
@@ -19,14 +19,14 @@ export const Route = createFileRoute("/articles/$slug")({
     }
 
     return {
-      links: buildLinks({ canonical: article.meta.canonicalPath }),
+      links: buildLinks({ canonical: article.canonicalPath }),
       meta: [
         ...buildMeta({
-          title: article.meta.ogTitle,
-          description: article.meta.ogDescription,
-          canonical: article.meta.canonicalPath,
+          title: article.ogTitle,
+          description: article.ogDescription,
+          canonical: article.canonicalPath,
           ogType: "article",
-          ogImage: { path: getArticleOgpImagePath(article.meta.slug), alt: article.meta.title },
+          ogImage: { path: getArticleOgpImagePath(article.slug), alt: article.title },
         }),
         ...jsonLdMeta(createArticleJsonLd(article)),
         ...jsonLdMeta(createArticleBreadcrumbJsonLd(article)),

--- a/src/routes/articles.categories.$categorySlug.tsx
+++ b/src/routes/articles.categories.$categorySlug.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ArticleCategoryPage } from "@/src/components/features/ArticleSite";
-import { createCategoryBreadcrumbJsonLd, getCategory } from "@/src/components/features/ArticleSite/articleContent";
+import { createCategoryBreadcrumbJsonLd, getCategoryMeta } from "@/src/components/features/ArticleSite/articleMeta";
 import { buildLinks, buildMeta, jsonLdMeta } from "@/src/helpers/seo";
 
 export const Route = createFileRoute("/articles/categories/$categorySlug")({
   head: ({ params }) => {
-    const category = getCategory(params.categorySlug);
+    const category = getCategoryMeta(params.categorySlug);
 
     if (!category) {
       return {
@@ -13,13 +13,13 @@ export const Route = createFileRoute("/articles/categories/$categorySlug")({
       };
     }
 
-    const canonical = `/articles/categories/${category.meta.slug}`;
+    const canonical = `/articles/categories/${category.slug}`;
     return {
       links: buildLinks({ canonical }),
       meta: [
         ...buildMeta({
-          title: `${category.meta.title}｜シフト作成ガイド`,
-          description: category.meta.description,
+          title: `${category.title}｜シフト作成ガイド`,
+          description: category.description,
           canonical,
         }),
         ...jsonLdMeta(createCategoryBreadcrumbJsonLd(category)),

--- a/src/routes/articles.tsx
+++ b/src/routes/articles.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { ArticleListPage } from "@/src/components/features/ArticleSite";
-import { sitePage } from "@/src/components/features/ArticleSite/articleContent";
+import { sitePage } from "@/src/components/features/ArticleSite/articleMeta";
 import { buildLinks, buildMeta } from "@/src/helpers/seo";
 
 export const Route = createFileRoute("/articles")({

--- a/src/routes/demo.flow.tsx
+++ b/src/routes/demo.flow.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { buildLinks, buildMeta } from "@/src/helpers/seo";
 import { DemoFlowRoutePage } from "@/src/pages/demo-flow";
 
-export const Route = createFileRoute("/_unregistered/demo/flow")({
+export const Route = createFileRoute("/demo/flow")({
   head: () => ({
     links: buildLinks({ canonical: "/demo/flow" }),
     meta: buildMeta({

--- a/src/routes/demo.shiftboard.tsx
+++ b/src/routes/demo.shiftboard.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { buildLinks, buildMeta } from "@/src/helpers/seo";
 import { DemoShiftBoardRoutePage } from "@/src/pages/demo-shift-board";
 
-export const Route = createFileRoute("/_unregistered/demo/shiftboard")({
+export const Route = createFileRoute("/demo/shiftboard")({
   head: () => ({
     // 採用案: 登録なしで試せる無料デモ｜店長・シフト担当者視点でシフト管理を体験
     //   狙い: 「シフト管理 デモ」「シフト管理 試す」「シフト管理 登録なし」

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,10 @@ import viteReact from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import pkg from "./package.json" with { type: "json" };
+import { markdownFrontmatterPlugin } from "./vite/markdownFrontmatterPlugin";
 
 export default defineConfig({
-  plugins: [tanstackRouter({ autoCodeSplitting: true }), viteReact(), tsconfigPaths()],
+  plugins: [markdownFrontmatterPlugin(), tanstackRouter({ autoCodeSplitting: true }), viteReact(), tsconfigPaths()],
   server: {
     allowedHosts: [".ngrok.app", ".ngrok-free.app"],
   },

--- a/vite/markdownFrontmatterPlugin.ts
+++ b/vite/markdownFrontmatterPlugin.ts
@@ -1,0 +1,33 @@
+import { readFile } from "node:fs/promises";
+import type { Plugin } from "vite";
+
+/**
+ * `*.md?frontmatter` のインポートを、frontmatter だけを含む擬似 md ソース文字列に変換する Vite プラグイン。
+ *
+ * 記事本文（Markdown body）はサイズが大きく、`?raw` で eager import すると
+ * ルートの `head()` や LP の記事プレビューが参照するメタデータモジュール経由で
+ * エントリーチャンクに焼き込まれてしまう。frontmatter（数百バイト）だけを返すことで、
+ * メタデータ専用モジュールに本文をバンドルさせない。
+ *
+ * 返す文字列は `---\n{frontmatter}\n---\n` 形式なので、実行時に既存の
+ * `parseMarkdownDocument`（body 空扱い）でそのままパースでき、解析ロジックを二重化しない。
+ */
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---/;
+
+export function markdownFrontmatterPlugin(): Plugin {
+  return {
+    name: "markdown-frontmatter",
+    enforce: "pre",
+    async load(id) {
+      const [filepath, query] = id.split("?");
+      if (!query || !filepath.endsWith(".md")) return null;
+      if (!new URLSearchParams(query).has("frontmatter")) return null;
+
+      const source = (await readFile(filepath, "utf-8")).replace(/\r\n/g, "\n");
+      const match = source.match(FRONTMATTER_RE);
+      const frontmatter = match?.[1] ?? "";
+      const stub = `---\n${frontmatter}\n---\n`;
+      return `export default ${JSON.stringify(stub)};`;
+    },
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,12 +5,14 @@ import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig, defineProject } from "vitest/config";
+import { markdownFrontmatterPlugin } from "./vite/markdownFrontmatterPlugin";
 
 const dirname = typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 const storybookAppVersion = "0.0.0-vrt";
 
 const logicProject = defineConfig({
   plugins: [
+    markdownFrontmatterPlugin(),
     // biome-ignore lint/suspicious/noExplicitAny: temp
     tsconfigPaths() as any,
   ],


### PR DESCRIPTION
SP検索順位対策として、LP初回ロードのJS実行量とちらつきを削減する。

- Clerk/ConvexプロバイダをルートからAuthProviders(_auth/_unregistered/認証ページ)へ移動し、公開ページのバンドルから除外
- HeaderのUserMenuを遅延importにし、public variant経由でClerkを巻き込まないよう修正
- デモページを_unregistered外の独立ルートへ移動(Clerk/Convex不要)
- GTM初期化をrequestIdleCallbackまで遅延し、遅延前イベントはバッファしてinit時にflush
- prerender済みDOMの差し替えをflushSyncで同期コミットし、空白フレームのちらつきを解消
- 記事Markdown本文をエントリーチャンクから分離: ?frontmatterプラグイン + articleMeta(メタ専用)を新設し、ルートhead/LPプレビューは本文を読み込まない
- ヒーロー画像にfetchPriority=high/decoding/aspectRatioを付与しLCP前倒し・CLS抑止
- sitemapのルートURLをcanonical(末尾スラッシュ)に統一

エントリーチャンク: 1,236KB→951KB (gzip 338KB→261KB)。Clerk/Convexクライアント/記事本文はLP初期ロードから分離。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WTxw4oP6WTo5JDAZr66hy2