### PR TITLE
fix: 別端末ログイン対応とヘルプ導線の整理

### DIFF
--- a/doc/features/auth-pages.md
+++ b/doc/features/auth-pages.md
@@ -4,6 +4,8 @@
 
 管理ユーザー向けのログイン、新規登録、パスワード再設定をシフトリ独自UIで提供する。認証基盤はClerkのまま維持し、Google認証とメールアドレス/パスワード認証を扱う。
 
+別の端末やブラウザからパスワードでログインし、ClerkのClient Trustが追加確認を要求した場合は、登録メールアドレスへ確認コードを送り、シフトリ内で本人確認を完了する。
+
 ## 関連ファイルパス
 
 - `src/routes/login.tsx`
@@ -12,12 +14,30 @@
 - `src/routes/sso-callback.tsx`
 - `src/pages/auth/index.tsx`
 - `src/components/features/AuthPage/index.tsx`
+- `src/components/features/AuthPage/loginVerification.ts`：Client Trustの判定、メール確認factorの選択、表示用メールアドレスのマスク
+- `src/components/features/AuthPage/loginVerification.test.ts`
 - `src/utils/inAppBrowser.ts` — LINEアプリ内ブラウザ判定
 - `convex/_lib/lineUrl.ts` — `openExternalBrowser=1` 付与（フロントと共有）
 
 ## LINEアプリ内ブラウザ対応
 
 LINEアプリ内ブラウザ（WebView）ではGoogle OAuthがGoogle側でブロックされる（403: disallowed_useragent）。ログイン/新規登録画面ではUAでLINE内ブラウザを検出し、注意バナーを表示したうえで、Googleボタン押下時に `openExternalBrowser=1` 付きURLへ遷移して外部ブラウザで開き直す。メール/パスワード認証はLINE内ブラウザでもそのまま利用できる。
+
+## 別端末ログインの本人確認
+
+パスワードログインの結果がClient Trustの追加確認を示し、Clerkが`email_code`を提供した場合は、`prepareSecondFactor()`で確認コードを送る。
+
+利用者がコードを入力したら、`attemptSecondFactor()`で照合する。
+
+Clerkが`complete`とセッションIDを返した場合だけセッションを有効化する。
+
+現在のClerk SDKでは、Client Trustが旧形式の`needs_second_factor`として返る場合がある。
+
+Clerk側の更新状態によって`needs_client_trust`が返る場合もあるため、両方のステータスと`email_code`の組み合わせを同じ本人確認フローとして扱う。
+
+信頼済み端末の状態はシフトリのDBやlocalStorageへ保存せず、Clerkの判定を正とする。
+
+Cookieの削除、シークレットブラウザ、別ブラウザ、信頼期間の終了などでClerkが新しい端末相当と判断した場合は、同じ端末でも本人確認を再度要求する。
 
 ## 画面一覧
 
@@ -29,5 +49,7 @@ LINEアプリ内ブラウザ（WebView）ではGoogle OAuthがGoogle側でブロ
 ## API一覧
 
 - Clerk `useSignIn()` — メール/パスワードログイン、Googleログイン、パスワード再設定
+- Clerk `SignIn.prepareSecondFactor()` — 別端末ログイン用のメール確認コード送信
+- Clerk `SignIn.attemptSecondFactor()` — 別端末ログイン用のメール確認コード照合
 - Clerk `useSignUp()` — メール/パスワード登録、Google登録、メール確認
 - Clerk `useClerk().handleRedirectCallback()` — OAuthコールバック処理

--- a/doc/plans/2026-07-11_別端末ログイン本人確認_実装計画.md
+++ b/doc/plans/2026-07-11_別端末ログイン本人確認_実装計画.md
@@ -1,0 +1,310 @@
+# 別端末ログイン本人確認 実装計画
+
+**ステータス：実装完了**
+
+別の端末やブラウザからメールアドレスとパスワードでログインしたときに、Clerkが要求するメール確認コードの入力をシフトリ内で完了できるようにする。
+
+同じブラウザがClerkから信頼済みと判定される間は、次回以降のログインで確認コードを要求しない。
+
+Cookieの削除、シークレットブラウザ、別ブラウザ、信頼期間の終了などによってClerkが新しい端末相当と判定した場合は、同じ端末でも本人確認を再度要求する。
+
+---
+
+## 1. ゴールと対象範囲
+
+### 1.1 ゴール
+
+- 新しい端末から正しいメールアドレスとパスワードを入力した利用者が、メール確認コードを使ってログインを完了できる。
+- 確認済みのブラウザでは、Clerkが追加確認を要求しない限り従来どおりログインできる。
+- Clerkの内部状態を利用者へ見せず、シフトリとメールの往復だけで次の行動が分かる。
+- Client Trustを無効化せず、認証強度を維持する。
+
+### 1.2 対象外
+
+- ClerkのClient Trustを無効化すること。
+- SMS、認証アプリ、バックアップコードを使うMFA画面。
+- Clerk SDKのメジャーバージョン更新。
+- 管理者招待と複数管理者機能。
+- Convexのschema、API、認可処理の変更。
+
+### 1.3 実装前に確認するClerk設定
+
+- 本番Clerk環境のAttack protectionでClient Trustが有効になっていること。
+- Client Trustの追加確認に`email_code`が提供されること。
+- Clerk DashboardのClient Trust Status updateが有効かを確認し、実行時に`needs_client_trust`と旧形式の`needs_second_factor`のどちらが返るかを把握すること。
+
+現在の`@clerk/clerk-react`は`5.61.3`であり、ローカルの型定義には`needs_client_trust`が含まれていない。
+
+一方、Clerk側の更新状態によっては実行時に`needs_client_trust`が返る可能性があるため、実装では新旧両方のステータスを正規化して扱う。
+
+Client Trustによる追加確認は、ステータスが`needs_client_trust`または`needs_second_factor`であり、`supportedSecondFactors`に`email_code`が存在することを条件に判定する。
+
+---
+
+## 2. 利用者とシステムの流れ
+
+```text
+利用者
+  -> シフトリでメールアドレスとパスワードを入力
+  -> シフトリがClerkへパスワードログインを依頼
+  -> Clerkが新しい端末と判定し、追加確認を要求
+  -> シフトリがClerkへメール確認コードの送信を依頼
+  -> 利用者がメールで確認コードを見る
+  -> 利用者がシフトリへ確認コードを入力
+  -> シフトリがClerkへコードを渡す
+  -> Clerkが本人確認を完了し、セッションを作成
+  -> シフトリがダッシュボードへ遷移
+```
+
+確認済みブラウザでは、パスワードログインの結果が最初から`complete`になるため、確認コード画面を表示しない。
+
+信頼済みかどうかはシフトリのDBやlocalStorageで管理せず、Clerkの判定を正とする。
+
+---
+
+## 3. 画面と状態
+
+### 3.1 ログイン画面
+
+現在のメールアドレス、パスワード、Googleログインを維持する。
+
+パスワードログインの結果で表示を分岐する。
+
+| Clerkの結果 | シフトリの動作 |
+|---|---|
+| `complete` | セッションを有効化して遷移する |
+| `needs_client_trust`または`needs_second_factor`で`email_code`を利用可能 | メールコードを準備して本人確認画面へ進む |
+| `needs_second_factor`で`email_code`を利用できない | 未対応MFAとして専用エラーを表示する |
+| その他 | 状態に対応した回復可能なエラーを表示する |
+
+現在のように、`complete`以外を一律で「Googleログインを使うか、時間をおいて」と案内しない。
+
+### 3.2 本人確認画面
+
+ログインカード内を次の表示へ切り替える。
+
+| 要素 | 文言または動作 |
+|---|---|
+| タイトル | 本人確認 |
+| 説明 | 新しい端末からのログインを確認します。登録メールアドレスに確認コードを送りました。 |
+| 補助表示 | 入力済みメールアドレスを部分的に伏せて表示する |
+| フィールド | 確認コード |
+| 主ボタン | 確認してログイン |
+| 再送 | 確認コードを再送 |
+| 戻る | ログイン画面に戻る |
+
+プライマリータスクは確認コードを入力してログインすることだけとする。
+
+Googleログインや新規登録への導線は、このステップには重ねない。
+
+### 3.3 既存画面の流用
+
+新規登録時のメール確認画面と、確認コードの入力フィールド、Zod schema、React Hook Formによる入力エラー表示、レイアウトを共有する。
+
+Clerk呼び出しは共有しない。
+
+- 新規登録：`signUp.attemptEmailAddressVerification()`を使う。
+- 別端末ログイン：`signIn.attemptSecondFactor()`を使う。
+
+共通部分は、確認コードフォームの表示と入力検証を担当する`EmailCodeVerificationForm`として切り出す。
+
+新規登録と別端末ログインは、それぞれ専用の説明文、ボタン文言、送信処理、戻る処理を渡す。
+
+### 3.4 エラーと再送
+
+| 状態 | 表示 |
+|---|---|
+| コードが違う | 確認コードが正しくありません。 |
+| コードの期限切れ | 確認コードの有効期限が切れています。新しいコードを送ってください。 |
+| 再送成功 | 新しい確認コードを送りました。 |
+| 試行回数超過 | 試行回数が多すぎます。時間をおいてもう一度お試しください。 |
+| メールコードを利用できない | この方法では本人確認を続けられません。お問い合わせください。 |
+| 通信失敗 | 本人確認ができませんでした。通信状況を確認してもう一度お試しください。 |
+
+再送は`useSingleFlight`で連打を防ぎ、送信後は短いクールダウンを表示する。
+
+クライアントのクールダウンをセキュリティ境界とは見なさず、送信頻度の最終判定はClerkのレート制限に任せる。
+
+---
+
+## 4. 実装方針
+
+### 4.1 ログイン状態
+
+`AuthPage`へログイン専用の状態を追加する。
+
+```ts
+type LoginStep = "credentials" | "verify-email-code";
+```
+
+保持する情報は、現在のステップ、表示用にマスクするメールアドレス、選択した`email_code` factorに限定する。
+
+確認コード、パスワード、Clerkレスポンス全体をlocalStorageやアプリDBへ保存しない。
+
+### 4.2 確認コードの送信
+
+`signIn.create({ strategy: "password", ... })`がClient Trustの追加確認を返したら、`supportedSecondFactors`から`email_code`を探す。
+
+取得した`emailAddressId`を使って、次を呼ぶ。
+
+```ts
+await signIn.prepareSecondFactor({
+  strategy: "email_code",
+  emailAddressId,
+});
+```
+
+準備に成功してから本人確認画面へ切り替える。
+
+準備に失敗した場合は、コードを送ったと案内しない。
+
+### 4.3 確認コードの照合
+
+利用者が入力したコードを次のAPIへ渡す。
+
+```ts
+const result = await signIn.attemptSecondFactor({
+  strategy: "email_code",
+  code,
+});
+```
+
+`result.status === "complete"`かつ`createdSessionId`が存在する場合だけ、既存の`completeWithSession()`でセッションを有効化する。
+
+それ以外の状態ではログイン済みとして扱わず、確認画面にエラーを表示する。
+
+### 4.4 ロジックの分離
+
+`src/components/features/AuthPage/loginVerification.ts`を追加し、次の判断を`AuthPage`のJSXから分離する。
+
+- Client Trustの追加確認かを判定する。
+- Clerkが返す新旧ステータスを内部の判定値へ正規化する。
+- `supportedSecondFactors`からメールコードfactorを選択する。
+- `prepareSecondFactor()`へ正しい引数を渡す。
+- `attemptSecondFactor()`の完了状態を判定する。
+
+Clerk型の必要部分だけを受け取る小さいインターフェースにし、テストで外部メール送信を発生させずに分岐と呼び出しを検証できるようにする。
+
+### 4.5 SDK更新との境界
+
+今回の修正は現在のSDKで実装し、型定義にある`needs_second_factor`に加えて、実行時に返る可能性がある`needs_client_trust`も文字列として安全に正規化する。
+
+将来Clerk SDKを更新して`needs_client_trust`が正式な型に含まれた際は、互換用の型正規化を削除し、画面コンポーネントと文言は維持する。
+
+---
+
+## 5. Security Lens
+
+- **Actor**：登録済み管理ユーザー。攻撃者はパスワードを入手した第三者や、確認コードを総当たりする第三者。
+- **Asset**：管理ユーザーのClerkセッションと、所属店舗の管理画面へのアクセス。
+- **Trust boundary**：ブラウザから入力されたパスワードと確認コードがClerkへ渡る境界。
+- **Abuse case**：盗まれたパスワードだけで新端末からログインする。確認コードを連続試行する。再送を連打してメールを大量送信する。
+- **Server-side check**：パスワード、Client Trust、確認コード、試行回数はClerkを正として検証する。シフトリの画面状態だけでログイン完了にしない。
+- **Rate limit / idempotency**：UIは`useSingleFlight`と再送クールダウンを使う。最終的な試行回数と送信頻度はClerkの制限に従う。
+- **Logs / PII**：パスワード、確認コード、完全なメールアドレス、Clerkレスポンス全体をログへ出さない。画面ではメールアドレスを部分的に伏せる。
+- **Regression test**：Client Trustの判定、メールfactor選択、コード準備、コード照合、未完了時にセッションを有効化しないことを自動テストで保証する。
+
+---
+
+## 6. テスト計画
+
+### 6.1 Logic UT
+
+`src/components/features/AuthPage/loginVerification.test.ts`を追加する。
+
+- `needs_client_trust`と旧形式の`needs_second_factor`をClient Trustの追加確認として扱う。
+- 通常の`complete`を追加確認として扱わない。
+- `email_code`がない`needs_second_factor`を今回のメール確認へ混同しない。
+- 複数factorから`email_code`と`emailAddressId`を選ぶ。
+- `email_code`がない場合は未対応として返す。
+- コード準備時に正しいstrategyと`emailAddressId`を渡す。
+- コード照合時に入力コードを渡す。
+- 照合結果が`complete`の場合だけ完了として返す。
+- コード準備と照合の二重実行を呼び出し側の`useSingleFlight`で防ぐ。
+
+### 6.2 StorybookとBehavior Test
+
+`src/components/features/AuthPage/index.stories.tsx`へ次を追加する。
+
+- `LoginVerification`：本人確認画面の通常状態。PCとモバイルのVRT対象にする。
+- `LoginVerificationError`：コード誤入力の表示状態。
+- `LoginVerificationResend`：再送後の案内とクールダウン。
+- `LoginVerificationBack`：ログイン画面へ戻れることをplay functionで確認する。
+- 既存`SignupVerification`：共通フォームへ切り出した後も表示と登録方法の変更が維持されることを確認する。
+
+出現する要素は`findBy...`で待ち、`expect(...)`でユーザーに見える文言と遷移を検証する。
+
+外部のClerk環境と実メール配送はStorybookで検証しない。
+
+### 6.3 E2E
+
+Client Trustの発動はClerk側の端末判定とメール配送に依存し、通常のE2Eでは安定して再現できないため、今回の自動E2Eには追加しない。
+
+SDKとの接続は型チェックと、Clerk呼び出しをfake化したLogic UTで保証する。
+
+リリース前には本番と同じClient Trust設定の環境で、新しいブラウザプロファイルから確認コードを受信し、ログイン完了後に同じプロファイルで再ログインできることを受け入れ確認する。
+
+---
+
+## 7. 変更予定ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `src/components/features/AuthPage/index.tsx` | ログインステップ、コード送信、コード照合、本人確認画面を追加する |
+| `src/components/features/AuthPage/loginVerification.ts` | Client Trust判定とClerk第二要素API呼び出しを分離する |
+| `src/components/features/AuthPage/loginVerification.test.ts` | Client Trustとメールコード処理のLogic UTを追加する |
+| `src/components/features/AuthPage/index.stories.tsx` | 本人確認の代表状態、エラー、再送、戻る動作を追加する |
+| `doc/features/auth-pages.md` | 別端末ログインとメール本人確認の仕様を追記する |
+
+`doc/INDEX.md`は認証画面の既存項目をそのまま使うため変更しない。
+
+Convexコード、schema、migration、環境変数の変更はない。
+
+---
+
+## 8. 実装順序
+
+1. 本番相当Clerk環境のClient Trust、メールfactor、ステータス更新設定を確認する。
+2. `loginVerification.ts`とLogic UTを追加する。
+3. 確認コードフォームを共通コンポーネントへ切り出し、既存の新規登録確認を維持する。
+4. `AuthPage`へClient Trustの分岐、コード準備、照合、再送、戻る処理を追加する。
+5. StoryとBehavior Testを追加する。
+6. `doc/features/auth-pages.md`を更新する。
+7. lint、型チェック、Logic UT、UIテストを実行する。
+8. コードレビューと不要な重複の整理を行う。
+9. 本番相当設定の新しいブラウザプロファイルで受け入れ確認する。
+
+---
+
+## 9. 検証コマンド
+
+```bash
+pnpm vitest --project=logic src/components/features/AuthPage/loginVerification.test.ts
+pnpm type-check
+pnpm lint
+pnpm test:ui
+```
+
+`pnpm lint`と`pnpm test:ui`は、Codexから実行する場合は最初から権限付きで実行する。
+
+---
+
+## 10. 参考資料
+
+- `src/components/features/AuthPage/index.tsx`
+- `src/components/features/AuthPage/index.stories.tsx`
+- `src/components/features/AuthPage/redirect.ts`
+- `src/hooks/useSingleFlight.ts`
+- `src/hooks/useSingleFlight.test.ts`
+- `src/components/config/AuthProviders.tsx`
+- `src/constants/env.ts`
+- `package.json`
+- `doc/features/auth-pages.md`
+- `doc/rules/testing-strategy.md`
+- `doc/rules/security-strategy.md`
+- `.agents/skills/shiftori-coding/SKILL.md`
+- `.agents/skills/shiftori-security-review/SKILL.md`
+- `.agents/skills/test-strategy/SKILL.md`
+- `.agents/skills/ui-architect/SKILL.md`
+- [Clerk Client Trust](https://clerk.com/docs/guides/secure/client-trust)
+- [Clerk custom Client Trust flow](https://clerk.com/docs/guides/development/custom-flows/authentication/client-trust)

--- a/e2e/pages/DashboardPage.ts
+++ b/e2e/pages/DashboardPage.ts
@@ -298,7 +298,7 @@ export class DashboardPage {
   async openLineQr(staffName: string) {
     await this.openStaffDetail(staffName);
     const dialog = this.staffDetailDialog();
-    await dialog.getByRole("tab", { name: "LINE連携" }).click();
+    await dialog.getByRole("tab", { name: "LINE" }).click();
     await dialog.getByRole("button", { name: "LINE連携リンクを表示" }).click();
     await expect(dialog.getByText(`${staffName}さんにLINE連携リンクを共有してください。`)).toBeVisible();
   }
@@ -307,7 +307,7 @@ export class DashboardPage {
     await this.openStaffDetail(staffName);
     const dialog = this.staffDetailDialog();
     await expect(dialog).toBeVisible();
-    await dialog.getByRole("tab", { name: "LINE連携" }).click();
+    await dialog.getByRole("tab", { name: "LINE" }).click();
     await dialog.getByRole("button", { name: "メールでLINE連携リンクを送る" }).click();
     await expect(dialog.getByText("LINE連携リンクをメールで送る")).toBeVisible();
     await dialog.getByRole("button", { name: "送信" }).click();

--- a/src/components/features/AuthPage/index.stories.tsx
+++ b/src/components/features/AuthPage/index.stories.tsx
@@ -17,6 +17,9 @@ const meta = {
     mode: "login",
     onGoogle: noop,
     onLogin: noop,
+    onVerifyLogin: noop,
+    onResendLoginCode: noop,
+    onRestartLogin: noop,
     onSignup: noop,
     onVerifyEmail: noop,
     onRestartSignup: noop,
@@ -49,6 +52,44 @@ const SignupVerificationRestartContent = (args: AuthContentArgs) => {
       isVerificationStep={isVerificationStep}
       onRestartSignup={() => setIsVerificationStep(false)}
     />
+  );
+};
+
+const LoginVerificationBackContent = (args: AuthContentArgs) => {
+  const [loginStep, setLoginStep] = useState<AuthContentArgs["loginStep"]>("verify-email-code");
+
+  return (
+    <AuthContent {...args} mode="login" loginStep={loginStep} onRestartLogin={() => setLoginStep("credentials")} />
+  );
+};
+
+const LoginVerificationResendContent = (args: AuthContentArgs) => {
+  const [infoMessage, setInfoMessage] = useState<string>();
+
+  return (
+    <AuthContent
+      {...args}
+      mode="login"
+      loginStep="verify-email-code"
+      verificationInfoMessage={infoMessage}
+      onResendLoginCode={() => setInfoMessage("新しい確認コードを送りました。")}
+    />
+  );
+};
+
+const LoginVerificationSubmitContent = (args: AuthContentArgs) => {
+  const [submittedCode, setSubmittedCode] = useState<string>();
+
+  return (
+    <>
+      <AuthContent
+        {...args}
+        mode="login"
+        loginStep="verify-email-code"
+        onVerifyLogin={({ code }) => setSubmittedCode(code)}
+      />
+      {submittedCode && <output>確認コードを送信しました: {submittedCode}</output>}
+    </>
   );
 };
 
@@ -102,6 +143,84 @@ export const SignupVerification: Story = {
   args: {
     mode: "signup",
     isVerificationStep: true,
+  },
+};
+
+export const LoginVerification: Story = {
+  args: {
+    mode: "login",
+    loginStep: "verify-email-code",
+    loginSafeIdentifier: "ma***@example.com",
+    resendCooldownSeconds: 30,
+  },
+};
+
+export const LoginVerificationMobile: Story = {
+  tags: ["vrt-mobile2"],
+  args: {
+    mode: "login",
+    loginStep: "verify-email-code",
+    loginSafeIdentifier: "ma***@example.com",
+    resendCooldownSeconds: 30,
+  },
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
+};
+
+export const LoginVerificationError: Story = {
+  args: {
+    mode: "login",
+    loginStep: "verify-email-code",
+    loginSafeIdentifier: "ma***@example.com",
+    errorMessage: "確認コードが正しくありません。",
+  },
+};
+
+export const LoginVerificationResend: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: {
+    mode: "login",
+    loginSafeIdentifier: "ma***@example.com",
+  },
+  render: (args) => <LoginVerificationResendContent {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(await canvas.findByRole("button", { name: "確認コードを再送" }));
+    await expect(await canvas.findByText("新しい確認コードを送りました。")).toBeInTheDocument();
+  },
+};
+
+export const LoginVerificationBack: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: {
+    mode: "login",
+    loginSafeIdentifier: "ma***@example.com",
+  },
+  render: (args) => <LoginVerificationBackContent {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole("heading", { name: "本人確認" })).toBeInTheDocument();
+    await userEvent.click(await canvas.findByRole("button", { name: "ログイン画面に戻る" }));
+    await expect(await canvas.findByRole("heading", { name: "シフトリにログイン" })).toBeInTheDocument();
+  },
+};
+
+export const LoginVerificationSubmit: Story = {
+  parameters: { chromatic: { disableSnapshot: true } },
+  args: {
+    mode: "login",
+    loginSafeIdentifier: "ma***@example.com",
+  },
+  render: (args) => <LoginVerificationSubmitContent {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(await canvas.findByLabelText("確認コード"), "123456");
+    await userEvent.click(await canvas.findByRole("button", { name: "確認してログイン" }));
+    await expect(await canvas.findByText("確認コードを送信しました: 123456")).toBeInTheDocument();
   },
 };
 

--- a/src/components/features/AuthPage/index.tsx
+++ b/src/components/features/AuthPage/index.tsx
@@ -32,10 +32,20 @@ import { FullPageSpinner } from "@/src/components/ui/FullPageSpinner";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import { isLineInAppBrowser } from "@/src/utils/inAppBrowser";
 import loginIllustration from "./login.webp";
+import {
+  findClientTrustEmailCodeFactor,
+  isCompletedSignIn,
+  maskEmailAddress,
+  prepareClientTrustEmailCode,
+  verifyClientTrustEmailCode,
+} from "./loginVerification";
 import { normalizeAuthRedirect } from "./redirect";
 
 type AuthMode = "login" | "signup" | "forgot-password";
 type ForgotStep = "request" | "reset";
+type LoginStep = "credentials" | "verify-email-code";
+
+const RESEND_COOLDOWN_SECONDS = 30;
 
 type AuthPageProps = {
   mode: AuthMode;
@@ -80,6 +90,17 @@ type LoginFormProps = {
   onSubmit: (values: LoginValues) => void | Promise<void>;
 };
 
+type LoginVerificationFormProps = {
+  errorMessage?: string;
+  infoMessage?: string;
+  isSubmitting?: boolean;
+  resendCooldownSeconds?: number;
+  safeIdentifier?: string;
+  onBack: () => void | Promise<void>;
+  onResend: () => void | Promise<void>;
+  onSubmit: (values: EmailVerificationValues) => void | Promise<void>;
+};
+
 type SignupFormProps = {
   errorMessage?: string;
   isSubmitting?: boolean;
@@ -110,6 +131,11 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
   const { isLoaded: signUpLoaded, signUp, setActive: setSignUpActive } = useSignUp();
   const redirectTo = useMemo(() => normalizeAuthRedirect(redirect), [redirect]);
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [loginStep, setLoginStep] = useState<LoginStep>("credentials");
+  const [loginEmailAddressId, setLoginEmailAddressId] = useState<string>();
+  const [loginSafeIdentifier, setLoginSafeIdentifier] = useState<string>();
+  const [verificationInfoMessage, setVerificationInfoMessage] = useState<string>();
+  const [resendCooldownSeconds, setResendCooldownSeconds] = useState(0);
   const [isVerificationStep, setIsVerificationStep] = useState(false);
   const [forgotStep, setForgotStep] = useState<ForgotStep>("request");
   const [forgotEmail, setForgotEmail] = useState("");
@@ -131,6 +157,16 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
     await action();
   });
 
+  useEffect(() => {
+    if (resendCooldownSeconds <= 0) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setResendCooldownSeconds((current) => Math.max(0, current - 1));
+    }, 1_000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [resendCooldownSeconds]);
+
   if (!authLoaded) {
     return (
       <AuthContent
@@ -139,6 +175,9 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
         redirectTo={redirectTo}
         onGoogle={() => {}}
         onLogin={() => {}}
+        onVerifyLogin={() => {}}
+        onResendLoginCode={() => {}}
+        onRestartLogin={() => {}}
         onSignup={() => {}}
         onVerifyEmail={() => {}}
         onRestartSignup={() => {}}
@@ -190,16 +229,83 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
           password: values.password,
         });
 
-        if (result.status === "complete") {
+        if (isCompletedSignIn(result)) {
           await completeWithSession(result.createdSessionId);
           return;
         }
 
-        setErrorMessage("追加の確認が必要です。Googleログインを使うか、時間をおいてもう一度お試しください。");
+        const emailCodeFactor = findClientTrustEmailCodeFactor({
+          status: result.status,
+          supportedSecondFactors: result.supportedSecondFactors,
+        });
+        if (emailCodeFactor) {
+          await prepareClientTrustEmailCode(result, emailCodeFactor.emailAddressId);
+          setLoginEmailAddressId(emailCodeFactor.emailAddressId);
+          setLoginSafeIdentifier(emailCodeFactor.safeIdentifier ?? maskEmailAddress(values.email));
+          setVerificationInfoMessage(undefined);
+          setResendCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+          setLoginStep("verify-email-code");
+          return;
+        }
+
+        const status = result.status as string | null;
+        setErrorMessage(
+          status === "needs_client_trust" || status === "needs_second_factor"
+            ? "この方法では本人確認を続けられません。お問い合わせください。"
+            : "ログインを完了できませんでした。時間をおいてもう一度お試しください。",
+        );
       } catch (error) {
         setErrorMessage(getClerkErrorMessage(error));
       }
     });
+
+  const handleVerifyLogin = (values: EmailVerificationValues) =>
+    runAuthAction(async () => {
+      if (!signInLoaded) return;
+
+      setErrorMessage(undefined);
+      setVerificationInfoMessage(undefined);
+      try {
+        const result = await verifyClientTrustEmailCode(signIn, values.code);
+        if (isCompletedSignIn(result)) {
+          await completeWithSession(result.createdSessionId);
+          return;
+        }
+
+        setErrorMessage("本人確認が完了しませんでした。コードを確認してもう一度お試しください。");
+      } catch (error) {
+        setErrorMessage(getClerkErrorMessage(error));
+      }
+    });
+
+  const handleResendLoginCode = () =>
+    runAuthAction(async () => {
+      if (!signInLoaded || resendCooldownSeconds > 0) return;
+
+      setErrorMessage(undefined);
+      setVerificationInfoMessage(undefined);
+      if (!loginEmailAddressId) {
+        setErrorMessage("確認コードを再送できませんでした。ログイン画面に戻ってもう一度お試しください。");
+        return;
+      }
+
+      try {
+        await prepareClientTrustEmailCode(signIn, loginEmailAddressId);
+        setVerificationInfoMessage("新しい確認コードを送りました。");
+        setResendCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+      } catch (error) {
+        setErrorMessage(getClerkErrorMessage(error));
+      }
+    });
+
+  const handleRestartLogin = () => {
+    setErrorMessage(undefined);
+    setVerificationInfoMessage(undefined);
+    setResendCooldownSeconds(0);
+    setLoginEmailAddressId(undefined);
+    setLoginSafeIdentifier(undefined);
+    setLoginStep("credentials");
+  };
 
   const handleSignup = (values: SignupValues) =>
     runAuthAction(async () => {
@@ -300,6 +406,10 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
       mode={mode}
       errorMessage={errorMessage}
       isSubmitting={isSubmitting}
+      loginStep={loginStep}
+      loginSafeIdentifier={loginSafeIdentifier}
+      verificationInfoMessage={verificationInfoMessage}
+      resendCooldownSeconds={resendCooldownSeconds}
       isVerificationStep={isVerificationStep}
       forgotStep={forgotStep}
       forgotEmail={forgotEmail}
@@ -307,6 +417,9 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
       isLineBrowser={isLineBrowser}
       onGoogle={handleGoogle}
       onLogin={handleLogin}
+      onVerifyLogin={handleVerifyLogin}
+      onResendLoginCode={handleResendLoginCode}
+      onRestartLogin={handleRestartLogin}
       onSignup={handleSignup}
       onVerifyEmail={handleVerifyEmail}
       onRestartSignup={handleRestartSignup}
@@ -321,6 +434,10 @@ type AuthContentProps = {
   errorMessage?: string;
   isInitialLoading?: boolean;
   isSubmitting?: boolean;
+  loginStep?: LoginStep;
+  loginSafeIdentifier?: string;
+  verificationInfoMessage?: string;
+  resendCooldownSeconds?: number;
   isVerificationStep?: boolean;
   forgotStep?: ForgotStep;
   forgotEmail?: string;
@@ -328,6 +445,9 @@ type AuthContentProps = {
   isLineBrowser?: boolean;
   onGoogle: () => void | Promise<void>;
   onLogin: (values: LoginValues) => void | Promise<void>;
+  onVerifyLogin: (values: EmailVerificationValues) => void | Promise<void>;
+  onResendLoginCode: () => void | Promise<void>;
+  onRestartLogin: () => void | Promise<void>;
   onSignup: (values: SignupValues) => void | Promise<void>;
   onVerifyEmail: (values: EmailVerificationValues) => void | Promise<void>;
   onRestartSignup: () => void | Promise<void>;
@@ -340,6 +460,10 @@ export function AuthContent({
   errorMessage,
   isInitialLoading,
   isSubmitting,
+  loginStep = "credentials",
+  loginSafeIdentifier,
+  verificationInfoMessage,
+  resendCooldownSeconds,
   isVerificationStep,
   forgotStep,
   forgotEmail,
@@ -347,6 +471,9 @@ export function AuthContent({
   isLineBrowser,
   onGoogle,
   onLogin,
+  onVerifyLogin,
+  onResendLoginCode,
+  onRestartLogin,
   onSignup,
   onVerifyEmail,
   onRestartSignup,
@@ -354,7 +481,13 @@ export function AuthContent({
   onResetPassword,
 }: AuthContentProps) {
   const title =
-    mode === "login" ? "シフトリにログイン" : mode === "signup" ? "シフトリをはじめる" : "パスワードを再設定";
+    mode === "login"
+      ? loginStep === "verify-email-code"
+        ? "本人確認"
+        : "シフトリにログイン"
+      : mode === "signup"
+        ? "シフトリをはじめる"
+        : "パスワードを再設定";
   const description = mode === "forgot-password" ? "登録済みメールアドレスに再設定コードを送信します。" : undefined;
 
   return (
@@ -402,7 +535,7 @@ export function AuthContent({
 
                 {isInitialLoading && <AuthInitialLoading />}
 
-                {!isInitialLoading && mode === "login" && (
+                {!isInitialLoading && mode === "login" && loginStep === "credentials" && (
                   <LoginForm
                     errorMessage={errorMessage}
                     isSubmitting={isSubmitting}
@@ -410,6 +543,18 @@ export function AuthContent({
                     redirectTo={redirectTo}
                     onGoogle={onGoogle}
                     onSubmit={onLogin}
+                  />
+                )}
+                {!isInitialLoading && mode === "login" && loginStep === "verify-email-code" && (
+                  <LoginVerificationForm
+                    errorMessage={errorMessage}
+                    infoMessage={verificationInfoMessage}
+                    isSubmitting={isSubmitting}
+                    resendCooldownSeconds={resendCooldownSeconds}
+                    safeIdentifier={loginSafeIdentifier}
+                    onBack={onRestartLogin}
+                    onResend={onResendLoginCode}
+                    onSubmit={onVerifyLogin}
                   />
                 )}
                 {!isInitialLoading && mode === "signup" && (
@@ -493,6 +638,53 @@ export function LoginForm({
   );
 }
 
+export function LoginVerificationForm({
+  errorMessage,
+  infoMessage,
+  isSubmitting,
+  resendCooldownSeconds = 0,
+  safeIdentifier = "登録メールアドレス",
+  onBack,
+  onResend,
+  onSubmit,
+}: LoginVerificationFormProps) {
+  const resendLabel = resendCooldownSeconds > 0 ? `${resendCooldownSeconds}秒後に再送できます` : "確認コードを再送";
+
+  return (
+    <EmailCodeVerificationForm
+      errorMessage={errorMessage}
+      infoMessage={infoMessage}
+      isSubmitting={isSubmitting}
+      description={
+        <>
+          新しい端末からのログインを確認します。
+          <br />
+          {safeIdentifier} に確認コードを送りました。
+        </>
+      }
+      submitLabel="確認してログイン"
+      submittingLabel="確認中"
+      onSubmit={onSubmit}
+      secondaryActions={
+        <Stack gap={1}>
+          <Button
+            type="button"
+            variant="ghost"
+            colorPalette="teal"
+            disabled={isSubmitting || resendCooldownSeconds > 0}
+            onClick={onResend}
+          >
+            {resendLabel}
+          </Button>
+          <Button type="button" variant="ghost" color="gray.700" disabled={isSubmitting} onClick={onBack}>
+            ログイン画面に戻る
+          </Button>
+        </Stack>
+      }
+    />
+  );
+}
+
 export function SignupForm({
   errorMessage,
   isSubmitting,
@@ -509,43 +701,33 @@ export function SignupForm({
     handleSubmit,
     formState: { errors },
   } = useForm<SignupValues>({ resolver: zodResolver(signupSchema) });
-  const {
-    register: registerCode,
-    handleSubmit: handleCodeSubmit,
-    formState: { errors: codeErrors },
-  } = useForm<EmailVerificationValues>({ resolver: zodResolver(emailVerificationSchema) });
 
   if (isVerificationStep) {
     return (
-      <Stack as="form" gap={5} onSubmit={handleCodeSubmit(onVerifyEmail)}>
-        <AuthError message={errorMessage} />
-        <Alert.Root status="info" borderRadius="lg">
-          <Alert.Indicator />
-          <Alert.Description>メールに届いた確認コードを入力してください。</Alert.Description>
-        </Alert.Root>
-        <Field.Root invalid={!!codeErrors.code}>
-          <Field.Label>確認コード</Field.Label>
-          <Input inputMode="numeric" autoComplete="one-time-code" placeholder="123456" {...registerCode("code")} />
-          <Field.ErrorText>{codeErrors.code?.message}</Field.ErrorText>
-        </Field.Root>
-        <Button type="submit" colorPalette="teal" size="lg" loading={isSubmitting} loadingText="確認中">
-          登録を完了する
-        </Button>
-        <Text color="gray.700" textAlign="center" textStyle="sm">
-          登録方法を変える場合は{" "}
-          <Link
-            asChild
-            color="teal.700"
-            fontWeight="bold"
-            cursor="pointer"
-            _hover={{ color: "teal.800", textDecoration: "underline" }}
-          >
-            <button type="button" onClick={onRestartSignup}>
-              最初からやり直す
-            </button>
-          </Link>
-        </Text>
-      </Stack>
+      <EmailCodeVerificationForm
+        errorMessage={errorMessage}
+        isSubmitting={isSubmitting}
+        description="メールに届いた確認コードを入力してください。"
+        submitLabel="登録を完了する"
+        submittingLabel="確認中"
+        onSubmit={onVerifyEmail}
+        secondaryActions={
+          <Text color="gray.700" textAlign="center" textStyle="sm">
+            登録方法を変える場合は{" "}
+            <Link
+              asChild
+              color="teal.700"
+              fontWeight="bold"
+              cursor="pointer"
+              _hover={{ color: "teal.800", textDecoration: "underline" }}
+            >
+              <button type="button" onClick={onRestartSignup}>
+                最初からやり直す
+              </button>
+            </Link>
+          </Text>
+        }
+      />
     );
   }
 
@@ -578,6 +760,59 @@ export function SignupForm({
     </Stack>
   );
 }
+
+type EmailCodeVerificationFormProps = {
+  description: ReactNode;
+  errorMessage?: string;
+  infoMessage?: string;
+  isSubmitting?: boolean;
+  secondaryActions?: ReactNode;
+  submitLabel: string;
+  submittingLabel: string;
+  onSubmit: (values: EmailVerificationValues) => void | Promise<void>;
+};
+
+const EmailCodeVerificationForm = ({
+  description,
+  errorMessage,
+  infoMessage,
+  isSubmitting,
+  secondaryActions,
+  submitLabel,
+  submittingLabel,
+  onSubmit,
+}: EmailCodeVerificationFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<EmailVerificationValues>({ resolver: zodResolver(emailVerificationSchema) });
+
+  return (
+    <Stack as="form" gap={5} onSubmit={handleSubmit(onSubmit)}>
+      <AuthError message={errorMessage} />
+      <Alert.Root status="info" borderRadius="lg">
+        <Alert.Indicator />
+        <Alert.Description>{description}</Alert.Description>
+      </Alert.Root>
+      {infoMessage && (
+        <Alert.Root status="success" borderRadius="lg">
+          <Alert.Indicator />
+          <Alert.Description>{infoMessage}</Alert.Description>
+        </Alert.Root>
+      )}
+      <Field.Root invalid={!!errors.code}>
+        <Field.Label>確認コード</Field.Label>
+        <Input inputMode="numeric" autoComplete="one-time-code" placeholder="123456" {...register("code")} />
+        <Field.ErrorText>{errors.code?.message}</Field.ErrorText>
+      </Field.Root>
+      <Button type="submit" colorPalette="teal" size="lg" loading={isSubmitting} loadingText={submittingLabel}>
+        {submitLabel}
+      </Button>
+      {secondaryActions}
+    </Stack>
+  );
+};
 
 export function ForgotPasswordForm({
   errorMessage,
@@ -683,6 +918,9 @@ export function SsoCallbackPage() {
       isSubmitting={false}
       onGoogle={() => {}}
       onLogin={() => {}}
+      onVerifyLogin={() => {}}
+      onResendLoginCode={() => {}}
+      onRestartLogin={() => {}}
       onSignup={() => {}}
       onVerifyEmail={() => {}}
       onRestartSignup={() => {}}

--- a/src/components/features/AuthPage/loginVerification.test.ts
+++ b/src/components/features/AuthPage/loginVerification.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  findClientTrustEmailCodeFactor,
+  isCompletedSignIn,
+  maskEmailAddress,
+  prepareClientTrustEmailCode,
+  verifyClientTrustEmailCode,
+} from "./loginVerification";
+
+describe("Client Trustのメール確認", () => {
+  const emailFactor = {
+    strategy: "email_code" as const,
+    emailAddressId: "idn_email",
+    safeIdentifier: "ma***@example.com",
+  };
+
+  it.each(["needs_client_trust", "needs_second_factor"])("%sではメール確認用factorを選ぶ", (status) => {
+    expect(
+      findClientTrustEmailCodeFactor({
+        status,
+        supportedSecondFactors: [{ strategy: "totp" }, emailFactor],
+      }),
+    ).toEqual(emailFactor);
+  });
+
+  it("ログイン完了や未対応MFAではメール確認へ進めない", () => {
+    expect(
+      findClientTrustEmailCodeFactor({ status: "complete", supportedSecondFactors: [emailFactor] }),
+    ).toBeUndefined();
+    expect(
+      findClientTrustEmailCodeFactor({
+        status: "needs_second_factor",
+        supportedSecondFactors: [{ strategy: "totp" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("メールアドレスIDがないfactorは使わない", () => {
+    expect(
+      findClientTrustEmailCodeFactor({
+        status: "needs_client_trust",
+        supportedSecondFactors: [{ strategy: "email_code", safeIdentifier: "ma***@example.com" }],
+      }),
+    ).toBeUndefined();
+    expect(
+      findClientTrustEmailCodeFactor({
+        status: "needs_client_trust",
+        supportedSecondFactors: [{ strategy: "email_code", emailAddressId: "idn_email", safeIdentifier: 123 }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("completeかつセッションIDがある場合だけログイン完了とする", () => {
+    expect(isCompletedSignIn({ status: "complete", createdSessionId: "sess_123" })).toBe(true);
+    expect(isCompletedSignIn({ status: "complete", createdSessionId: null })).toBe(false);
+    expect(isCompletedSignIn({ status: "needs_second_factor", createdSessionId: "sess_123" })).toBe(false);
+  });
+
+  it("確認コードの送信先と入力コードをClerkへ渡す", async () => {
+    const prepareSecondFactor = vi.fn().mockResolvedValue(undefined);
+    const attemptSecondFactor = vi.fn().mockResolvedValue({ status: "complete", createdSessionId: "sess_123" });
+
+    await prepareClientTrustEmailCode({ prepareSecondFactor }, "idn_email");
+    const result = await verifyClientTrustEmailCode({ attemptSecondFactor }, "123456");
+
+    expect(prepareSecondFactor).toHaveBeenCalledOnce();
+    expect(prepareSecondFactor).toHaveBeenCalledWith({ strategy: "email_code", emailAddressId: "idn_email" });
+    expect(attemptSecondFactor).toHaveBeenCalledOnce();
+    expect(attemptSecondFactor).toHaveBeenCalledWith({ strategy: "email_code", code: "123456" });
+    expect(result).toEqual({ status: "complete", createdSessionId: "sess_123" });
+  });
+
+  it("画面表示用のメールアドレスを部分的に伏せる", () => {
+    expect(maskEmailAddress("manager@example.com")).toBe("ma***@example.com");
+    expect(maskEmailAddress("a@example.com")).toBe("a***@example.com");
+    expect(maskEmailAddress("invalid-email")).toBe("登録メールアドレス");
+  });
+});

--- a/src/components/features/AuthPage/loginVerification.ts
+++ b/src/components/features/AuthPage/loginVerification.ts
@@ -1,0 +1,71 @@
+const CLIENT_TRUST_STATUSES = new Set(["needs_client_trust", "needs_second_factor"]);
+
+export type EmailCodeFactor = {
+  strategy: "email_code";
+  emailAddressId: string;
+  safeIdentifier?: string;
+};
+
+type SignInAttempt = {
+  status: string | null;
+  supportedSecondFactors?: readonly unknown[] | null;
+};
+
+type ClientTrustSignInApi = {
+  prepareSecondFactor: (params: { strategy: "email_code"; emailAddressId: string }) => Promise<unknown>;
+  attemptSecondFactor: (params: {
+    strategy: "email_code";
+    code: string;
+  }) => Promise<{ status: string | null; createdSessionId: string | null }>;
+};
+
+function isEmailCodeFactor(factor: unknown): factor is EmailCodeFactor {
+  if (!factor || typeof factor !== "object" || !("strategy" in factor)) return false;
+
+  return (
+    factor.strategy === "email_code" &&
+    "emailAddressId" in factor &&
+    typeof factor.emailAddressId === "string" &&
+    factor.emailAddressId.length > 0 &&
+    (!("safeIdentifier" in factor) || factor.safeIdentifier === undefined || typeof factor.safeIdentifier === "string")
+  );
+}
+
+/**
+ * Clerkの旧SDKではClient Trustもneeds_second_factorとして返る。
+ * email_codeはClient Trust用のfactorなので、通常のMFAと混同せずに選べる。
+ */
+export function findClientTrustEmailCodeFactor(attempt: SignInAttempt): EmailCodeFactor | undefined {
+  if (!attempt.status || !CLIENT_TRUST_STATUSES.has(attempt.status)) return undefined;
+
+  return attempt.supportedSecondFactors?.find(isEmailCodeFactor);
+}
+
+export function isCompletedSignIn(attempt: { status: string | null; createdSessionId: string | null }): boolean {
+  return attempt.status === "complete" && Boolean(attempt.createdSessionId);
+}
+
+export async function prepareClientTrustEmailCode(
+  signIn: Pick<ClientTrustSignInApi, "prepareSecondFactor">,
+  emailAddressId: string,
+): Promise<void> {
+  await signIn.prepareSecondFactor({ strategy: "email_code", emailAddressId });
+}
+
+export async function verifyClientTrustEmailCode(
+  signIn: Pick<ClientTrustSignInApi, "attemptSecondFactor">,
+  code: string,
+): Promise<{ status: string | null; createdSessionId: string | null }> {
+  return await signIn.attemptSecondFactor({ strategy: "email_code", code });
+}
+
+export function maskEmailAddress(email: string): string {
+  const atIndex = email.lastIndexOf("@");
+  if (atIndex <= 0 || atIndex === email.length - 1) return "登録メールアドレス";
+
+  const localPart = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+  const visiblePrefix = localPart.slice(0, Math.min(2, localPart.length));
+
+  return `${visiblePrefix}***@${domain}`;
+}

--- a/src/components/features/LandingPage/FooterSection/index.tsx
+++ b/src/components/features/LandingPage/FooterSection/index.tsx
@@ -5,7 +5,7 @@ type FooterColLink = { label: string; href: string };
 const productLinks: FooterColLink[] = [{ label: "できること", href: "/features" }];
 
 const supportLinks: FooterColLink[] = [
-  { label: "使い方・ヘルプ", href: "/howto" },
+  // { label: "使い方・ヘルプ", href: "/howto" },
   { label: "よくある質問", href: "/faq" },
   { label: "お問い合わせ", href: "/contact" },
 ];

--- a/src/components/templates/Header/UserMenu/index.tsx
+++ b/src/components/templates/Header/UserMenu/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Icon, Menu, Portal, Text } from "@chakra-ui/react";
 import { SignOutButton } from "@clerk/clerk-react";
 import { useAtomValue } from "jotai";
-import { LuBookOpen, LuChevronDown, LuLogOut, LuMailQuestion, LuUserRound } from "react-icons/lu";
+import { LuChevronDown, LuLogOut, LuMailQuestion, LuUserRound } from "react-icons/lu";
 import { userAtom } from "@/src/stores/user";
 
 export type UserMenuDeleteShopAction = {

--- a/src/components/templates/Header/UserMenu/index.tsx
+++ b/src/components/templates/Header/UserMenu/index.tsx
@@ -74,12 +74,12 @@ export const UserMenu = ({ tone = "dark" }: Props) => {
               </Text>
             </Box>
             <Menu.Separator />
-            <Menu.Item asChild value="howto">
+            {/*<Menu.Item asChild value="howto">
               <a href="/howto" target="_blank" rel="noreferrer">
                 <LuBookOpen />
                 使い方・ヘルプ
               </a>
-            </Menu.Item>
+            </Menu.Item>*/}
             <Menu.Item asChild value="contact">
               <a href="/contact" target="_blank" rel="noreferrer">
                 <LuMailQuestion />


### PR DESCRIPTION
## Summary

別端末からのパスワードログインでClerkの追加確認を完了できない問題を修正します。
公開済みの使い方ページは残したまま、管理画面とフッターからの導線を一時的に非表示にします。

## Changes

- **別端末ログインの本人確認**：ClerkのClient Trustが要求された場合に、メール確認コードの送信、入力、再送をシフトリ内で完了できるようにしました。

<details>
<summary>確認項目</summary>

- Clerkが`needs_client_trust`または旧形式の`needs_second_factor`を返すとき、メールコード要素を選択すると、確認コードの送信先と入力コードがClerkへ渡ることを確認した。
- 本人確認画面を表示してコード送信、再送、ログイン画面へ戻る操作を行うと、各操作後の案内と画面状態が更新されることを確認した。
- Clerkが`complete`とセッションIDを返すときだけ、ログイン完了として扱うことを確認した。

</details>

- **LINE連携のPlaywright追従**：スタッフ詳細のタブ名変更に合わせ、LINE連携リンクの表示とメール送信で使うPage Objectのセレクターを更新しました。

<details>
<summary>確認項目</summary>

- スタッフ詳細モーダルが開いているとき、`LINE`タブを選択すると、LINE連携リンクの表示操作とメール送信操作が表示されることをUIブラウザテストで確認した。
- Playwright E2E本体はローカルのViteが未起動だったため未実行。CIで最終確認する。

</details>

- **使い方・ヘルプ導線の一時非表示**：`/howto`とコンテンツは維持し、ユーザーメニューと公開フッターのリンクだけをコメントアウトしました。

<details>
<summary>確認項目</summary>

- ヘルプ記事が登録されているとき、記事読み込み、検索、表記正規化のテストが通ることを確認した。
- ユーザーメニューと公開フッターの表示確認は今回未実施。

</details>

## Notes

- lintと型チェックは成功した。
- 全Vitestは並列実行時に変更範囲外のConvexテストが5秒でタイムアウトした。該当テストは各ファイルの単独再実行で成功した。