### PR TITLE
本人確認画面のメールアドレスをマスクする

### DIFF
--- a/.agents/skills/shiftori-security-review/references/review-checklist.md
+++ b/.agents/skills/shiftori-security-review/references/review-checklist.md
@@ -72,6 +72,7 @@ Use this checklist for both pre-implementation plans and code review. Focus on t
 - [ ] Logs include safe who/what/where/when context when useful.
 - [ ] Logs exclude secrets, raw tokens, full email addresses, full webhook payloads, and sensitive third-party response bodies.
 - [ ] Client-facing errors do not reveal internal configuration, provider secrets, or object existence.
+- [ ] Auth UI masks email addresses and phone numbers at the rendering boundary, even when an identity provider labels a returned value as safe or masked.
 
 ## Test Mapping
 

--- a/src/components/features/AuthPage/index.stories.tsx
+++ b/src/components/features/AuthPage/index.stories.tsx
@@ -150,8 +150,14 @@ export const LoginVerification: Story = {
   args: {
     mode: "login",
     loginStep: "verify-email-code",
-    loginSafeIdentifier: "ma***@example.com",
+    loginSafeIdentifier: "yn1323+07112@gmail.com",
     resendCooldownSeconds: 30,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText("yn***@gmail.com", { exact: false })).toBeInTheDocument();
+    await expect(canvas.queryByText("yn1323+07112@gmail.com", { exact: false })).not.toBeInTheDocument();
   },
 };
 

--- a/src/components/features/AuthPage/index.tsx
+++ b/src/components/features/AuthPage/index.tsx
@@ -241,7 +241,7 @@ export function AuthPage({ mode, redirect }: AuthPageProps) {
         if (emailCodeFactor) {
           await prepareClientTrustEmailCode(result, emailCodeFactor.emailAddressId);
           setLoginEmailAddressId(emailCodeFactor.emailAddressId);
-          setLoginSafeIdentifier(emailCodeFactor.safeIdentifier ?? maskEmailAddress(values.email));
+          setLoginSafeIdentifier(maskEmailAddress(emailCodeFactor.safeIdentifier ?? values.email));
           setVerificationInfoMessage(undefined);
           setResendCooldownSeconds(RESEND_COOLDOWN_SECONDS);
           setLoginStep("verify-email-code");
@@ -649,6 +649,7 @@ export function LoginVerificationForm({
   onSubmit,
 }: LoginVerificationFormProps) {
   const resendLabel = resendCooldownSeconds > 0 ? `${resendCooldownSeconds}秒後に再送できます` : "確認コードを再送";
+  const maskedIdentifier = maskEmailAddress(safeIdentifier);
 
   return (
     <EmailCodeVerificationForm
@@ -659,7 +660,7 @@ export function LoginVerificationForm({
         <>
           新しい端末からのログインを確認します。
           <br />
-          {safeIdentifier} に確認コードを送りました。
+          {maskedIdentifier} に確認コードを送りました。
         </>
       }
       submitLabel="確認してログイン"

--- a/src/components/features/AuthPage/loginVerification.test.ts
+++ b/src/components/features/AuthPage/loginVerification.test.ts
@@ -72,7 +72,9 @@ describe("Client Trustのメール確認", () => {
 
   it("画面表示用のメールアドレスを部分的に伏せる", () => {
     expect(maskEmailAddress("manager@example.com")).toBe("ma***@example.com");
+    expect(maskEmailAddress("yn1323+07112@gmail.com")).toBe("yn***@gmail.com");
     expect(maskEmailAddress("a@example.com")).toBe("a***@example.com");
+    expect(maskEmailAddress("ma***@example.com")).toBe("ma***@example.com");
     expect(maskEmailAddress("invalid-email")).toBe("登録メールアドレス");
   });
 });

--- a/src/components/features/AuthPage/loginVerification.ts
+++ b/src/components/features/AuthPage/loginVerification.ts
@@ -65,7 +65,7 @@ export function maskEmailAddress(email: string): string {
 
   const localPart = email.slice(0, atIndex);
   const domain = email.slice(atIndex + 1);
-  const visiblePrefix = localPart.slice(0, Math.min(2, localPart.length));
+  const visiblePrefix = localPart.replaceAll("*", "").slice(0, 2);
 
   return `${visiblePrefix}***@${domain}`;
 }


### PR DESCRIPTION
## Summary

ClerkのClient Trustで本人確認を求められた際、確認コードの送信先メールアドレスが完全表示される問題を修正します。
認証画面で個人情報が露出しないよう、シフトリ側の描画境界で必ずマスクします。

## Changes

- **確認コードの送信先をマスク表示**：Clerkから完全なメールアドレスが返された場合も、先頭2文字とドメインだけを表示します。

<details>
<summary>確認項目</summary>

- Clerkから yn1323+07112@gmail.com が返されたとき、本人確認画面を表示すると、yn***@gmail.com と表示され、完全なメールアドレスが表示されないことを確認した。
- すでにマスクされたメールアドレスが渡されたとき、再度マスクすると、表示形式が崩れないことを確認した。

</details>

- **認証UIのセキュリティチェックを追加**：外部の認証サービスが安全な値として返した識別子でも、画面の描画境界でマスクするルールをレビュー項目に追加します。

<details>
<summary>確認項目</summary>

- 認証UIをレビューするとき、セキュリティチェックリストを確認すると、メールアドレスと電話番号を描画境界でマスクする項目が含まれることを確認した。

</details>