### PR TITLE
勤務時間入力デモへの導線と使い方ヘルプを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Codex and other coding agents when working with code in this repository.
 
+# Review language
+
+All pull request review comments must be written in Japanese.
+Keep explanations concise.
+
 ## プロジェクト概要
 
 店舗スタッフのシフト管理SaaSアプリケーション。

--- a/apps/analytics-dashboard/src/features/dashboard/index.tsx
+++ b/apps/analytics-dashboard/src/features/dashboard/index.tsx
@@ -777,7 +777,10 @@ function StageTrendPanel({ isLoading, snapshots }: { isLoading: boolean; snapsho
                 tickLine={false}
                 width={36}
               />
-              <Tooltip formatter={(value, name) => [`${formatNumber(Number(value))}店舗`, name]} />
+              <Tooltip
+                contentStyle={{ fontSize: 12 }}
+                formatter={(value, name) => [`${formatNumber(Number(value))}店舗`, name]}
+              />
               <Legend
                 align="center"
                 height={32}

--- a/src/components/features/Demo/DemoShiftBoardPage/DemoLauncherFab.stories.tsx
+++ b/src/components/features/Demo/DemoShiftBoardPage/DemoLauncherFab.stories.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { DemoLauncherFab } from "./DemoLauncherFab";
 
 const meta = {
@@ -22,4 +23,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole("button", { name: "操作デモを開始" })).toBeInTheDocument();
+    await expect(canvas.queryByText("はじめての方はこちら")).not.toBeInTheDocument();
+  },
+};

--- a/src/components/features/Demo/DemoShiftBoardPage/DemoLauncherFab.tsx
+++ b/src/components/features/Demo/DemoShiftBoardPage/DemoLauncherFab.tsx
@@ -46,7 +46,7 @@ export const DemoLauncherFab = ({ onStart, onDismiss }: Props) => {
         <Icon boxSize={4}>
           <LuPlay />
         </Icon>
-        <Text>はじめての方はこちら</Text>
+        <Text>操作デモを開始</Text>
       </Flex>
       <Box w="1px" bg="teal.400" opacity={0.6} />
       <Flex

--- a/src/components/features/Demo/DemoShiftBoardPage/index.stories.tsx
+++ b/src/components/features/Demo/DemoShiftBoardPage/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { DemoShiftBoardPage } from "./index";
 
 const meta = {
@@ -16,4 +17,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const PC: Story = {};
+export const PC: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole("heading", { name: "勤務時間入力デモ" })).toBeInTheDocument();
+    await expect(await canvas.findByRole("note")).toHaveTextContent(
+      "このページはデモ画面です。変更が反映されたり、シフトが送信されることはありません。",
+    );
+    await expect(await canvas.findByRole("button", { name: "操作デモを開始" })).toBeInTheDocument();
+  },
+};

--- a/src/components/features/Demo/DemoShiftBoardPage/index.tsx
+++ b/src/components/features/Demo/DemoShiftBoardPage/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Icon, Text } from "@chakra-ui/react";
+import { Box, Flex, Grid, Heading, Icon, Text } from "@chakra-ui/react";
 import dayjs from "dayjs";
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { LuCircleCheck } from "react-icons/lu";
@@ -110,31 +110,57 @@ export const DemoShiftBoardPage = ({ baseDate, headerStart, height = "100dvh" }:
 
   return (
     <Flex direction="column" h={height} minH={0}>
-      <Flex align="center" justify="space-between" bg="white" px={{ base: 4, lg: 6 }} py={2} flexShrink={0}>
-        {headerStart ?? (
-          <Heading as="h1" fontSize={{ base: "xs", lg: "sm" }} fontWeight={600} color="gray.700" whiteSpace="nowrap">
-            シフトリ デモ
+      <Grid
+        templateColumns="minmax(0, 1fr) auto minmax(0, 1fr)"
+        alignItems="center"
+        bg="white"
+        px={{ base: 4, lg: 6 }}
+        py={2}
+        gap={4}
+        flexShrink={0}
+      >
+        <Flex align="center" gap={4} minW={0}>
+          {headerStart}
+          <Heading as="h1" fontSize={{ base: "xs", lg: "sm" }} fontWeight={700} color="gray.800" whiteSpace="nowrap">
+            勤務時間入力デモ
           </Heading>
-        )}
-        <Text fontSize={{ base: "sm", lg: "md" }} fontWeight={600} color="gray.900">
+        </Flex>
+        <Text fontSize={{ base: "sm", lg: "md" }} fontWeight={600} color="gray.900" textAlign="center">
           {periodLabel}
         </Text>
-        {isConfirmed ? (
-          <Flex align="center" gap={1}>
-            <Icon color="green.600" boxSize={3.5}>
-              <LuCircleCheck />
-            </Icon>
-            <Text fontSize="xs" color="green.600" display={{ base: "none", lg: "inline" }}>
-              確定済み（{formatDateTime(new Date(confirmedAt))}）
+        <Flex align="center" justify="flex-end" gap={3} minW={0}>
+          {isConfirmed && (
+            <Flex align="center" gap={1} flexShrink={0}>
+              <Icon color="green.600" boxSize={3.5}>
+                <LuCircleCheck />
+              </Icon>
+              <Text fontSize="xs" color="green.600" display={{ base: "none", lg: "inline" }}>
+                確定済み（{formatDateTime(new Date(confirmedAt))}）
+              </Text>
+              <Text fontSize="2xs" color="green.600" display={{ base: "inline", lg: "none" }}>
+                確定済み
+              </Text>
+            </Flex>
+          )}
+          <Box
+            role="note"
+            w="420px"
+            maxW="100%"
+            px={3}
+            py={1.5}
+            bg="orange.50"
+            borderWidth="1px"
+            borderColor="orange.300"
+            borderRadius="md"
+          >
+            <Text color="orange.900" fontSize="xs" fontWeight={700} lineHeight="1.5">
+              このページはデモ画面です。
+              <br />
+              変更が反映されたり、シフトが送信されることはありません。
             </Text>
-            <Text fontSize="2xs" color="green.600" display={{ base: "inline", lg: "none" }}>
-              確定済み
-            </Text>
-          </Flex>
-        ) : (
-          <Box w={{ base: "40px", lg: "80px" }} />
-        )}
-      </Flex>
+          </Box>
+        </Flex>
+      </Grid>
 
       <Box flex={1} minH={0}>
         <ShiftForm

--- a/src/components/features/HowToSite/content/build-shift-from-requests.mdx
+++ b/src/components/features/HowToSite/content/build-shift-from-requests.mdx
@@ -11,6 +11,7 @@ features:
   - shift-board
   - shift-submission
 related:
+  - input-work-time
   - check-submission-status
   - save-shift-draft
   - assignment-warnings-and-errors

--- a/src/components/features/HowToSite/content/input-work-time.mdx
+++ b/src/components/features/HowToSite/content/input-work-time.mdx
@@ -1,0 +1,28 @@
+---
+title: 勤務時間の入力方法がわからない
+description: PCのシフト表で勤務時間を追加、変更する方法です
+category: shift-operation-trouble
+keywords:
+  - 勤務時間の入力
+  - 時間入力
+  - 操作方法
+  - ドラッグ
+  - 未提出スタッフ
+  - シフトを追加
+features:
+  - shift-board
+related:
+  - build-shift-from-requests
+  - assignment-warnings-and-errors
+order: 5
+---
+
+希望シフトの集め方が「時間指定」の場合は、PCのシフト表で勤務時間をドラッグして入力できます。
+
+ダッシュボードの「シフト一覧」で募集を開き、「日ごと」を表示してください。
+
+「未提出」と表示されたスタッフにも、スタッフの行を勤務の開始時刻から終了時刻まで横にドラッグすると勤務時間を追加できます。
+
+入力済みの勤務時間は、バーの左右の端をドラッグして変更できます。
+
+<ShiftBoardDemoLink />

--- a/src/components/features/HowToSite/helpContent.test.ts
+++ b/src/components/features/HowToSite/helpContent.test.ts
@@ -23,6 +23,7 @@ describe("HowToヘルプ記事", () => {
       "confirm-shift-effects",
       "edit-confirmed-shift",
       "notify-confirmed-shift-changes",
+      "input-work-time",
       "fix-recruitment-mistake",
       "delete-recruitment",
       "edit-past-shift",
@@ -43,6 +44,9 @@ describe("HowToヘルプ記事", () => {
     ]);
     expect(searchHelpArticles(helpArticles, "メッセージ 来ない").map((article) => article.slug)).toEqual([
       "line-notification-not-delivered",
+    ]);
+    expect(searchHelpArticles(helpArticles, "未提出 ドラッグ").map((article) => article.slug)).toEqual([
+      "input-work-time",
     ]);
   });
 

--- a/src/components/features/HowToSite/index.stories.tsx
+++ b/src/components/features/HowToSite/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
 import { HowToSite } from ".";
 import { helpArticles } from "./helpContent";
 
@@ -8,6 +9,7 @@ const layoutArticleSlugs = new Set([
   "add-staff",
   "automatic-reminder",
   "assignment-warnings-and-errors",
+  "input-work-time",
   "delete-recruitment",
   "submission-link-unavailable",
   "resend-failed-notifications",
@@ -56,7 +58,16 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Desktop: Story = {};
+export const Desktop: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const demoLink = await canvas.findByRole("link", { name: "デモで操作を確認する（別タブで開きます）" });
+
+    await expect(demoLink).toHaveAttribute("href", "/demo/shiftboard");
+    await expect(demoLink).toHaveAttribute("target", "_blank");
+    await expect(demoLink).toHaveAttribute("rel", "noopener noreferrer");
+  },
+};
 
 export const Mobile: Story = {
   tags: ["vrt-mobile2"],

--- a/src/components/features/HowToSite/mdxComponents.tsx
+++ b/src/components/features/HowToSite/mdxComponents.tsx
@@ -1,6 +1,7 @@
 import { Badge, Box, Flex, Image, Link, List, Stack, Text } from "@chakra-ui/react";
 import type { ComponentProps, PropsWithChildren } from "react";
-import { LuArrowRight, LuMail, LuMessageCircle } from "react-icons/lu";
+import { LuArrowRight, LuExternalLink, LuMail, LuMessageCircle } from "react-icons/lu";
+import { Button } from "@/src/components/ui/Button";
 import type { HelpMdxComponents } from "./helpContent";
 
 function HelpNote({ children }: PropsWithChildren) {
@@ -61,6 +62,22 @@ function NotificationChannelExample() {
   );
 }
 
+function ShiftBoardDemoLink() {
+  return (
+    <Button asChild size="sm" variant="outline" colorPalette="teal">
+      <a
+        href="/demo/shiftboard"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="デモで操作を確認する（別タブで開きます）"
+      >
+        デモで操作を確認する
+        <LuExternalLink aria-hidden="true" focusable="false" />
+      </a>
+    </Button>
+  );
+}
+
 export const helpMdxComponents = {
   p: (props: ComponentProps<"p">) => <Text as="p" color="gray.800" lineHeight="1.9" {...props} />,
   ul: (props: ComponentProps<"ul">) => <List.Root as="ul" gap={2} ps={5} color="gray.800" {...props} />,
@@ -73,4 +90,5 @@ export const helpMdxComponents = {
   strong: (props: ComponentProps<"strong">) => <Box as="strong" fontWeight="bold" color="gray.900" {...props} />,
   HelpNote,
   NotificationChannelExample,
+  ShiftBoardDemoLink,
 } satisfies HelpMdxComponents;

--- a/src/components/features/LandingPage/FooterSection/index.tsx
+++ b/src/components/features/LandingPage/FooterSection/index.tsx
@@ -5,7 +5,7 @@ type FooterColLink = { label: string; href: string };
 const productLinks: FooterColLink[] = [{ label: "できること", href: "/features" }];
 
 const supportLinks: FooterColLink[] = [
-  // { label: "使い方・ヘルプ", href: "/howto" },
+  { label: "使い方・ヘルプ", href: "/howto" },
   { label: "よくある質問", href: "/faq" },
   { label: "お問い合わせ", href: "/contact" },
 ];

--- a/src/components/features/ShiftBoard/ShiftBoardPage/index.stories.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardPage/index.stories.tsx
@@ -172,7 +172,61 @@ const describeElement = (element: Element | null) => {
   return `${tag}${id}${classes}${attrs ? ` ${attrs}` : ""}`;
 };
 
-export const PC: Story = {};
+export const PC: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const demoLink = await canvas.findByRole("link", { name: "勤務時間の入力方法（別タブで開きます）" });
+
+    await expect(demoLink).toHaveAttribute("href", "/demo/shiftboard");
+    await expect(demoLink).toHaveAttribute("target", "_blank");
+    await expect(demoLink).toHaveAttribute("rel", "noopener noreferrer");
+  },
+};
+
+export const PCDateOnly: Story = {
+  name: "PC Date Only",
+  args: {
+    data: {
+      ...mockData,
+      submissionPattern: { kind: "dateOnly" },
+      requestedSlots: [],
+    },
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.queryByRole("link", { name: "勤務時間の入力方法（別タブで開きます）" }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const PCShiftType: Story = {
+  name: "PC Shift Type",
+  args: {
+    data: {
+      ...mockData,
+      submissionPattern: {
+        kind: "shiftType",
+        options: [{ id: "early", name: "早番", startTime: "09:00", endTime: "17:00", sortOrder: 0 }],
+      },
+      requestedSlots: [],
+    },
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.queryByRole("link", { name: "勤務時間の入力方法（別タブで開きます）" }),
+    ).not.toBeInTheDocument();
+  },
+};
 
 export const PCWithInitialWarnings: Story = {
   name: "PC With Initial Warnings",
@@ -213,6 +267,11 @@ export const SP: Story = {
     viewport: { value: "mobile2", isRotated: false },
   },
   play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.queryByRole("link", { name: "勤務時間の入力方法（別タブで開きます）" }),
+    ).not.toBeInTheDocument();
+
     await clickButtonByText(canvasElement, "鈴木太郎");
 
     await waitForElement(() => document.querySelector('[role="dialog"]'), "スタッフのシフトDialogが開きませんでした");

--- a/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
+++ b/src/components/features/ShiftBoard/ShiftBoardPage/index.tsx
@@ -1,7 +1,7 @@
-import { Box, Flex, Icon, Text } from "@chakra-ui/react";
+import { Box, Flex, Grid, Icon, Text } from "@chakra-ui/react";
 import { Link, useBlocker } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { LuChevronLeft, LuCircleCheck } from "react-icons/lu";
+import { LuChevronLeft, LuCircleCheck, LuExternalLink } from "react-icons/lu";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import {
@@ -12,6 +12,7 @@ import {
 import { ShiftForm } from "@/src/components/features/Shift/ShiftForm";
 import type { ReminderStatus } from "@/src/components/features/Shift/ShiftForm/components";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
+import { Button } from "@/src/components/ui/Button";
 import { Dialog, useDialog } from "@/src/components/ui/Dialog";
 import { showErrorToast, showSuccessToast, toaster } from "@/src/components/ui/toaster";
 import { toDisplayIssues } from "@/src/domains/shift/assignmentIssues";
@@ -520,34 +521,63 @@ export const ShiftBoardPage = ({ data, recruitmentId }: Props) => {
       }}
       minH={0}
     >
-      <Flex align="center" justify="space-between" bg="white" px={{ base: 4, lg: 6 }} py={2} flexShrink={0}>
-        <Link to="/dashboard">
-          <Flex align="center" gap={1} color="gray.500" _hover={{ color: "gray.700" }} cursor="pointer">
-            <Icon boxSize={4}>
-              <LuChevronLeft />
-            </Icon>
-            <Text fontSize="sm">戻る</Text>
-          </Flex>
-        </Link>
-        <Text fontSize={{ base: "sm", lg: "md" }} fontWeight={600} color="gray.900">
+      <Grid
+        templateColumns={{ base: "40px minmax(0, 1fr) 40px", lg: "minmax(0, 1fr) auto minmax(0, 1fr)" }}
+        alignItems="center"
+        bg="white"
+        px={{ base: 4, lg: 6 }}
+        py={2}
+        flexShrink={0}
+      >
+        <Box justifySelf="start">
+          <Link to="/dashboard">
+            <Flex align="center" gap={1} color="gray.500" _hover={{ color: "gray.700" }} cursor="pointer">
+              <Icon boxSize={4}>
+                <LuChevronLeft />
+              </Icon>
+              <Text fontSize="sm">戻る</Text>
+            </Flex>
+          </Link>
+        </Box>
+        <Text fontSize={{ base: "sm", lg: "md" }} fontWeight={600} color="gray.900" textAlign="center">
           {periodLabel}
         </Text>
-        {isConfirmed && confirmedAt ? (
-          <Flex align="center" gap={1}>
-            <Icon color="green.600" boxSize={3.5}>
-              <LuCircleCheck />
-            </Icon>
-            <Text fontSize="xs" color="green.600" display={{ base: "none", lg: "inline" }}>
-              確定済み（{formatDateTime(confirmedAt)}）
-            </Text>
-            <Text fontSize="2xs" color="green.600" display={{ base: "inline", lg: "none" }}>
-              確定済み
-            </Text>
-          </Flex>
-        ) : (
-          <Box w={{ base: "40px", lg: "80px" }} />
-        )}
-      </Flex>
+        <Flex justifySelf="end" align="center" gap={3} minW={0}>
+          {isConfirmed && confirmedAt && (
+            <Flex align="center" gap={1} flexShrink={0}>
+              <Icon color="green.600" boxSize={3.5}>
+                <LuCircleCheck />
+              </Icon>
+              <Text fontSize="xs" color="green.600" display={{ base: "none", lg: "inline" }}>
+                確定済み（{formatDateTime(confirmedAt)}）
+              </Text>
+              <Text fontSize="2xs" color="green.600" display={{ base: "inline", lg: "none" }}>
+                確定済み
+              </Text>
+            </Flex>
+          )}
+          {data.submissionPattern.kind === "time" && (
+            <Button
+              asChild
+              size="sm"
+              variant="ghost"
+              colorPalette="teal"
+              display={{ base: "none", lg: "inline-flex" }}
+              flexShrink={0}
+            >
+              <a
+                href="/demo/shiftboard"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="勤務時間の入力方法（別タブで開きます）"
+              >
+                勤務時間の入力方法
+                <LuExternalLink aria-hidden="true" focusable="false" />
+              </a>
+            </Button>
+          )}
+        </Flex>
+      </Grid>
 
       <Box flex={1} minH={0}>
         <ShiftForm

--- a/src/components/templates/Header/UserMenu/index.tsx
+++ b/src/components/templates/Header/UserMenu/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Icon, Menu, Portal, Text } from "@chakra-ui/react";
 import { SignOutButton } from "@clerk/clerk-react";
 import { useAtomValue } from "jotai";
-import { LuChevronDown, LuLogOut, LuMailQuestion, LuUserRound } from "react-icons/lu";
+import { LuBookOpen, LuChevronDown, LuLogOut, LuMailQuestion, LuUserRound } from "react-icons/lu";
 import { userAtom } from "@/src/stores/user";
 
 export type UserMenuDeleteShopAction = {
@@ -74,12 +74,12 @@ export const UserMenu = ({ tone = "dark" }: Props) => {
               </Text>
             </Box>
             <Menu.Separator />
-            {/*<Menu.Item asChild value="howto">
+            <Menu.Item asChild value="howto" cursor="pointer">
               <a href="/howto" target="_blank" rel="noreferrer">
                 <LuBookOpen />
                 使い方・ヘルプ
               </a>
-            </Menu.Item>*/}
+            </Menu.Item>
             <Menu.Item asChild value="contact" cursor="pointer">
               <a href="/contact" target="_blank" rel="noreferrer">
                 <LuMailQuestion />

--- a/src/components/templates/Header/UserMenu/index.tsx
+++ b/src/components/templates/Header/UserMenu/index.tsx
@@ -80,7 +80,7 @@ export const UserMenu = ({ tone = "dark" }: Props) => {
                 使い方・ヘルプ
               </a>
             </Menu.Item>*/}
-            <Menu.Item asChild value="contact">
+            <Menu.Item asChild value="contact" cursor="pointer">
               <a href="/contact" target="_blank" rel="noreferrer">
                 <LuMailQuestion />
                 お問い合わせ

--- a/src/pages/demo-shift-board/index.tsx
+++ b/src/pages/demo-shift-board/index.tsx
@@ -20,7 +20,7 @@ export function DemoShiftBoardRoutePage() {
         <Box display={{ base: "block", lg: "none" }} px={6} pb={10} maxW="640px" mx="auto">
           <VStack align="stretch" gap={6}>
             <Heading as="h1" size="xl">
-              シフトリの無料デモ
+              勤務時間入力デモ
             </Heading>
 
             <Alert.Root status="warning" borderRadius="md">

--- a/src/routes/demo.shiftboard.tsx
+++ b/src/routes/demo.shiftboard.tsx
@@ -4,15 +4,11 @@ import { DemoShiftBoardRoutePage } from "@/src/pages/demo-shift-board";
 
 export const Route = createFileRoute("/demo/shiftboard")({
   head: () => ({
-    // 採用案: 登録なしで試せる無料デモ｜店長・シフト作成担当者視点でシフト管理を体験
-    //   狙い: 「シフト管理 デモ」「シフト管理 試す」「シフト管理 登録なし」
-    // 候補A: 無料デモ｜店長・シフト作成担当者視点で操作できるシフト管理サンドボックス（伝わりにくい）
-    // 候補B: 資料請求なしで触れる｜飲食店向けシフト管理シフトリのデモ（差別化明確だが検索数小）
     links: buildLinks({ canonical: "/demo/shiftboard" }),
     meta: buildMeta({
-      title: "登録なしで試せる無料デモ｜店長・シフト作成担当者視点でシフト管理を体験",
+      title: "勤務時間入力デモ",
       description:
-        "シフトリの店長・シフト作成担当者画面を会員登録なしで試せる無料デモです。希望の集約から確定通知までブラウザで2分で体験できます。資料請求も商談も不要、すぐ触れます。",
+        "スタッフの勤務時間をドラッグして追加、変更する操作をPCで試せるデモです。変更は保存されず、スタッフへシフトは送信されません。",
       canonical: "/demo/shiftboard",
     }),
   }),


### PR DESCRIPTION
## Summary

PCの時間指定シフトで勤務時間の入力方法が伝わりにくい問題に対し、実際のドラッグ操作を試せるデモとHowToへの導線を追加します。
あわせて、デモで実データが変更または送信されないことを画面内で明示し、既存のヘルプ導線と分析グラフの補助表示を調整します。

## Changes

- **シフト表から勤務時間入力デモを開ける**：PCかつ「時間指定」のシフト表では、募集期間ヘッダー右端からデモを別タブで開けます。

<details>
<summary>確認項目</summary>

- PCで「時間指定」のシフト表を表示したとき、デモリンクが表示され、`/demo/shiftboard`を別タブで開く属性を持つことをStorybookで確認した。
- スマホ、「日ごと」、「勤務区分」のシフト表を表示したとき、デモリンクが表示されないことをStorybookで確認した。

</details>

- **勤務時間入力デモで操作範囲を明示する**：タイトルを「勤務時間入力デモ」に変更し、変更が反映または送信されないことを期間ヘッダーに表示します。ツアーの開始ラベルは「操作デモを開始」とします。

<details>
<summary>確認項目</summary>

- 固定日付のデモを表示したとき、「勤務時間入力デモ」の見出し、デモ画面であることを示す注意、操作デモの開始ボタンが表示されることをStorybookで確認した。
- 操作デモの起動ボタンを表示したとき、旧ラベルがなく「操作デモを開始」と表示されることをStorybookで確認した。

</details>

- **使い方・ヘルプから操作方法を確認できる**：「勤務時間の入力方法がわからない」を追加し、HowTo、Footer、ユーザーメニューからヘルプへ移動できるようにします。

<details>
<summary>確認項目</summary>

- HowTo記事が読み込まれているとき、「未提出 ドラッグ」で検索すると勤務時間入力の記事が見つかることをロジックテストで確認した。
- HowToをPCで表示したとき、操作デモへのリンクが別タブで開く属性を持つことをStorybookで確認した。
- Footerとユーザーメニューの導線には専用の操作テストを追加していない。既存アンカーの有効化としてlintと型検査を通した。

</details>

- **店舗推移グラフのTooltipを読みやすくする**：分析ダッシュボードのTooltipへ12pxの文字サイズを指定します。

<details>
<summary>確認項目</summary>

- Tooltipの実表示は未確認。既存の値と店舗単位の表示を変えず、文字サイズ指定だけを追加したことを差分で確認した。

</details>
