### PR TITLE
Convexの店舗コンテキストと重複処理を共通化

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -102,6 +102,7 @@ import type * as notificationOutbox_types from "../notificationOutbox/types.js";
 import type * as position_service from "../position/service.js";
 import type * as recruitment_mutations from "../recruitment/mutations.js";
 import type * as recruitment_schemas from "../recruitment/schemas.js";
+import type * as recruitment_service from "../recruitment/service.js";
 import type * as setup_mutations from "../setup/mutations.js";
 import type * as setup_schemas from "../setup/schemas.js";
 import type * as shiftBoard_mutations from "../shiftBoard/mutations.js";
@@ -232,6 +233,7 @@ declare const fullApi: ApiFromModules<{
   "position/service": typeof position_service;
   "recruitment/mutations": typeof recruitment_mutations;
   "recruitment/schemas": typeof recruitment_schemas;
+  "recruitment/service": typeof recruitment_service;
   "setup/mutations": typeof setup_mutations;
   "setup/schemas": typeof setup_schemas;
   "shiftBoard/mutations": typeof shiftBoard_mutations;

--- a/convex/_lib/functions.ts
+++ b/convex/_lib/functions.ts
@@ -4,7 +4,7 @@ import { customMutation, customQuery } from "convex-helpers/server/customFunctio
 import type { Doc, Id } from "../_generated/dataModel";
 import { type MutationCtx, mutation, type QueryCtx, query } from "../_generated/server";
 import { isShiftTargetStaff } from "../staff/service";
-import { sessionMatchesAccessKind, staffAccessKindValidator } from "./staffAccess";
+import { type StaffAccessKind, sessionMatchesAccessKind, staffAccessKindValidator } from "./staffAccess";
 
 type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
 
@@ -22,29 +22,26 @@ async function getUserByIdentity(ctx: DbCtx, identity: UserIdentity) {
   return null;
 }
 
-async function getShopByUser(ctx: DbCtx, user: Doc<"users">) {
-  const memberships = ctx.db
-    .query("shopMembers")
-    .withIndex("by_userId_and_isDeleted", (q) => q.eq("userId", user._id).eq("isDeleted", false));
-
-  for await (const membership of memberships) {
-    const shop = await ctx.db.get(membership.shopId);
-    if (shop && !shop.isDeleted) return shop;
-  }
-  return null;
-}
-
 /**
  * 操作対象の店舗を解決する。
- * - shopId 指定あり: その店舗にユーザーが所属しているかを検証して返す（未所属なら null）
- * - shopId 未指定: 先頭の所属店舗にフォールバック（後方互換）
+ * - shopId 指定あり: 指定店舗への active membership を検証する。
+ * - shopId 未指定: 旧クライアントとの段階リリース互換のため、先頭の active 所属店舗を返す。
  *
- * 複数店舗に所属するマネージャーが、フロントから操作対象店舗を明示できるようにするための入口。
+ * 現行フロントは必ず shopId を送る。未指定経路はフロント配布後の別リリースで削除する。
  */
 async function resolveShopForUser(ctx: DbCtx, user: Doc<"users">, shopId?: Id<"shops">) {
   if (!shopId) {
-    return await getShopByUser(ctx, user);
+    const memberships = ctx.db
+      .query("shopMembers")
+      .withIndex("by_userId_and_isDeleted", (q) => q.eq("userId", user._id).eq("isDeleted", false));
+
+    for await (const membership of memberships) {
+      const shop = await ctx.db.get(membership.shopId);
+      if (shop && !shop.isDeleted) return shop;
+    }
+    return null;
   }
+
   const membership = await ctx.db
     .query("shopMembers")
     .withIndex("by_userId_and_shopId_and_isDeleted", (q) =>
@@ -112,6 +109,7 @@ export const authenticatedMutation = customMutation(mutation, {
  * - 用途: createRecruitment, addStaffs 等の shop スコープ操作
  */
 export const managerQuery = customQuery(query, {
+  // optional は旧フロントとの段階リリース互換。現行フロントは必ず shopId を指定する。
   args: { shopId: v.optional(v.id("shops")) },
   input: async (ctx, { shopId }): Promise<{ ctx: ManagerQueryCtx; args: Record<string, never> }> => {
     const identity = await ctx.auth.getUserIdentity();
@@ -128,6 +126,7 @@ export const managerQuery = customQuery(query, {
 });
 
 export const managerMutation = customMutation(mutation, {
+  // optional は旧フロントとの段階リリース互換。現行フロントは必ず shopId を指定する。
   args: { shopId: v.optional(v.id("shops")) },
   input: async (ctx, { shopId }): Promise<{ ctx: ManagerMutationCtx; args: Record<string, never> }> => {
     const identity = await ctx.auth.getUserIdentity();
@@ -153,6 +152,44 @@ type StaffSessionQueryCtx = {
   session: Doc<"sessions"> | null;
 };
 
+type StaffSessionCtx = {
+  staff: Doc<"staffs">;
+  shop: Doc<"shops">;
+  session: Doc<"sessions">;
+};
+
+type StaffSessionResolution =
+  | { status: "ok"; ctx: StaffSessionCtx }
+  | { status: "sessionExpired" }
+  | { status: "notFound" };
+
+async function resolveStaffSession(
+  ctx: DbCtx,
+  sessionToken: string,
+  accessKind: StaffAccessKind,
+): Promise<StaffSessionResolution> {
+  const session = await ctx.db
+    .query("sessions")
+    .withIndex("by_sessionToken", (q) => q.eq("sessionToken", sessionToken))
+    .first();
+  if (
+    !session ||
+    session.revokedAt ||
+    session.expiresAt < Date.now() ||
+    !sessionMatchesAccessKind(session, accessKind)
+  ) {
+    return { status: "sessionExpired" };
+  }
+
+  const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
+  // シフト対象外スタッフは、削除済みスタッフと同じくシフト画面の認証境界で拒否する。
+  if (!staff || !isShiftTargetStaff(staff) || staff.shopId !== session.shopId || !shop || shop.isDeleted) {
+    return { status: "notFound" };
+  }
+
+  return { status: "ok", ctx: { staff, shop, session } };
+}
+
 /**
  * staffSessionQuery
  * - sessionToken でスタッフセッションを検証
@@ -165,32 +202,13 @@ export const staffSessionQuery = customQuery(query, {
     ctx,
     { sessionToken, accessKind },
   ): Promise<{ ctx: StaffSessionQueryCtx; args: Record<string, never> }> => {
-    const session = await ctx.db
-      .query("sessions")
-      .withIndex("by_sessionToken", (q) => q.eq("sessionToken", sessionToken))
-      .first();
-    if (
-      !session ||
-      session.revokedAt ||
-      session.expiresAt < Date.now() ||
-      !sessionMatchesAccessKind(session, accessKind)
-    ) {
+    const result = await resolveStaffSession(ctx, sessionToken, accessKind);
+    if (result.status !== "ok") {
       return { ctx: { staff: null, shop: null, session: null }, args: {} };
     }
-    const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
-    // シフト対象外スタッフはシフト画面へアクセスさせない（削除同様に境界で弾く）。
-    if (!staff || !isShiftTargetStaff(staff) || staff.shopId !== session.shopId || !shop || shop.isDeleted) {
-      return { ctx: { staff: null, shop: null, session: null }, args: {} };
-    }
-    return { ctx: { staff, shop, session }, args: {} };
+    return { ctx: result.ctx, args: {} };
   },
 });
-
-type StaffSessionMutationCtx = {
-  staff: Doc<"staffs">;
-  shop: Doc<"shops">;
-  session: Doc<"sessions">;
-};
 
 /**
  * staffSessionMutation
@@ -199,27 +217,14 @@ type StaffSessionMutationCtx = {
  */
 export const staffSessionMutation = customMutation(mutation, {
   args: { sessionToken: v.string(), accessKind: staffAccessKindValidator },
-  input: async (
-    ctx,
-    { sessionToken, accessKind },
-  ): Promise<{ ctx: StaffSessionMutationCtx; args: Record<string, never> }> => {
-    const session = await ctx.db
-      .query("sessions")
-      .withIndex("by_sessionToken", (q) => q.eq("sessionToken", sessionToken))
-      .first();
-    if (
-      !session ||
-      session.revokedAt ||
-      session.expiresAt < Date.now() ||
-      !sessionMatchesAccessKind(session, accessKind)
-    ) {
+  input: async (ctx, { sessionToken, accessKind }): Promise<{ ctx: StaffSessionCtx; args: Record<string, never> }> => {
+    const result = await resolveStaffSession(ctx, sessionToken, accessKind);
+    if (result.status === "sessionExpired") {
       throw new ConvexError("Session expired");
     }
-    const [staff, shop] = await Promise.all([ctx.db.get(session.staffId), ctx.db.get(session.shopId)]);
-    // シフト対象外スタッフはシフト希望提出等をさせない。
-    if (!staff || !isShiftTargetStaff(staff) || staff.shopId !== session.shopId || !shop || shop.isDeleted) {
+    if (result.status === "notFound") {
       throw new ConvexError("Not found");
     }
-    return { ctx: { staff, shop, session }, args: {} };
+    return { ctx: result.ctx, args: {} };
   },
 });

--- a/convex/_lib/submissionPattern.test.ts
+++ b/convex/_lib/submissionPattern.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { getSubmissionPatternTimeRange, type ShiftSubmissionPattern } from "./submissionPattern";
+
+describe("getSubmissionPatternTimeRange", () => {
+  it("時間指定は設定された時間範囲を返す", () => {
+    expect(getSubmissionPatternTimeRange({ kind: "time", startTime: "08:30", endTime: "23:30" })).toEqual({
+      startTime: "08:30",
+      endTime: "23:30",
+    });
+  });
+
+  it("勤務区分は並び順に関係なく最小開始時刻から最大終了時刻までを返す", () => {
+    const pattern: ShiftSubmissionPattern = {
+      kind: "shiftType",
+      options: [
+        { id: "late", name: "遅番", startTime: "17:00", endTime: "21:00", sortOrder: 1 },
+        { id: "morning", name: "早番", startTime: "09:00", endTime: "13:00", sortOrder: 0 },
+      ],
+    };
+
+    expect(getSubmissionPatternTimeRange(pattern)).toEqual({ startTime: "09:00", endTime: "21:00" });
+  });
+
+  it("日付のみはデフォルトの時間範囲を返す", () => {
+    expect(getSubmissionPatternTimeRange({ kind: "dateOnly" })).toEqual({
+      startTime: "09:00",
+      endTime: "22:00",
+    });
+  });
+
+  it("勤務区分が空の場合はデフォルトの時間範囲を返す", () => {
+    expect(getSubmissionPatternTimeRange({ kind: "shiftType", options: [] })).toEqual({
+      startTime: "09:00",
+      endTime: "22:00",
+    });
+  });
+});

--- a/convex/_lib/submissionPattern.ts
+++ b/convex/_lib/submissionPattern.ts
@@ -31,6 +31,18 @@ export const DEFAULT_SUBMISSION_PATTERN: ShiftSubmissionPattern = {
   endTime: "22:00",
 };
 
+export function getSubmissionPatternTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
+  if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
+  if (pattern.kind === "shiftType" && pattern.options.length > 0) {
+    const starts = pattern.options
+      .map((option) => option.startTime)
+      .sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
+    const ends = pattern.options.map((option) => option.endTime).sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
+    return { startTime: starts[0], endTime: ends[ends.length - 1] };
+  }
+  return { startTime: "09:00", endTime: "22:00" };
+}
+
 export const shiftTypeOptionValidator = v.object({
   id: v.string(),
   name: v.string(),

--- a/convex/_scenario/confirmedStaffAddition.test.ts
+++ b/convex/_scenario/confirmedStaffAddition.test.ts
@@ -20,7 +20,7 @@ describe("確定後スタッフ追加シナリオ", () => {
     const staff = scenario.staff();
 
     // Arrange: 既存スタッフだけを割り当てたシフトを確定し、初回通知を完了させる。
-    const { existingStaffId } = await t.run(async (ctx) => {
+    const { existingStaffId, shopId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
         email: "confirmed-addition-manager@example.com",
@@ -31,7 +31,7 @@ describe("確定後スタッフ追加シナリオ", () => {
         name: "既存スタッフ",
         email: "confirmed-existing@example.com",
       });
-      return { existingStaffId };
+      return { existingStaffId, shopId };
     });
     const periodStart = scenarioDate(7);
     const recruitmentId = await asManager.createRecruitment({
@@ -89,6 +89,7 @@ describe("確定後スタッフ追加シナリオ", () => {
       .mutation(api.shiftBoard.mutations.confirmRecruitment, {
         recruitmentId,
         intent: "resend",
+        shopId,
       });
     expect(resendResult).toEqual({ status: "scheduled", notifiedStaffCount: 1 });
 

--- a/convex/_scenario/featureRequest.test.ts
+++ b/convex/_scenario/featureRequest.test.ts
@@ -8,7 +8,7 @@ import { getFeatureRequestsRef } from "../analyticsDashboard/refs";
 
 const submitFeatureRequest = makeFunctionReference<
   "mutation",
-  { comment: string; requestId: string; shopId?: Id<"shops"> },
+  { comment: string; requestId: string; shopId: Id<"shops"> },
   { status: "accepted" }
 >("featureRequest/mutations:submit");
 
@@ -28,8 +28,16 @@ describe("要望受付シナリオ", () => {
     });
     const asManager = t.withIdentity({ subject });
 
-    await asManager.mutation(submitFeatureRequest, { comment: "スタッフ一覧を絞り込みたい", requestId });
-    await asManager.mutation(submitFeatureRequest, { comment: "再送された要望", requestId });
+    await asManager.mutation(submitFeatureRequest, {
+      comment: "スタッフ一覧を絞り込みたい",
+      requestId,
+      shopId: seeded.shopId,
+    });
+    await asManager.mutation(submitFeatureRequest, {
+      comment: "再送された要望",
+      requestId,
+      shopId: seeded.shopId,
+    });
 
     const result = await t.query(getFeatureRequestsRef, { cursor: null, limit: 50 });
     expect(result.rows).toHaveLength(1);

--- a/convex/_scenario/notificationDelivery.test.ts
+++ b/convex/_scenario/notificationDelivery.test.ts
@@ -153,6 +153,7 @@ describe("通知配送outboxシナリオ", () => {
       .withIdentity({ subject: MANAGER_SUBJECT })
       .query(api.notificationOutbox.queries.listOpenFailures, {
         paginationOpts: { numItems: 10, cursor: null },
+        shopId: ids.shopId,
       });
     expect(openPage.page).toHaveLength(1);
     expect(openPage.page[0]).toMatchObject({
@@ -541,7 +542,7 @@ describe("通知配送outboxシナリオ", () => {
         endTime: "18:00",
         positionId,
       });
-      return { recruitmentId, staffId };
+      return { recruitmentId, shopId, staffId };
     });
 
     await t.action(internal.notification.actions.sendShiftConfirmationEmails, {
@@ -567,12 +568,13 @@ describe("通知配送outboxシナリオ", () => {
       .withIdentity({ subject: MANAGER_SUBJECT })
       .query(api.notificationOutbox.queries.listOpenFailures, {
         paginationOpts: { numItems: 10, cursor: null },
+        shopId: ids.shopId,
       });
     expect(openPage.page).toHaveLength(0);
 
     const result = await t
       .withIdentity({ subject: MANAGER_SUBJECT })
-      .mutation(api.notificationOutbox.mutations.resendOpenFailures, {});
+      .mutation(api.notificationOutbox.mutations.resendOpenFailures, { shopId: ids.shopId });
     expect(result).toMatchObject({
       scheduled: false,
       scheduledCount: 0,
@@ -585,6 +587,7 @@ describe("通知配送outboxシナリオ", () => {
       t.run(async (ctx) => await ctx.db.query("notificationFailureInbox").collect()),
       t.withIdentity({ subject: MANAGER_SUBJECT }).query(api.notificationOutbox.queries.listOpenFailures, {
         paginationOpts: { numItems: 10, cursor: null },
+        shopId: ids.shopId,
       }),
     ]);
     expect(jobs.filter((job) => job.status === "pending")).toHaveLength(0);
@@ -646,6 +649,7 @@ describe("通知配送outboxシナリオ", () => {
       .withIdentity({ subject: MANAGER_SUBJECT })
       .query(api.notificationOutbox.queries.listOpenFailures, {
         paginationOpts: { numItems: 10, cursor: null },
+        shopId: ids.shopId,
       });
     expect(firstOpenPage.page).toHaveLength(1);
     expect(firstOpenPage.page[0]).toMatchObject({
@@ -657,9 +661,10 @@ describe("通知配送outboxシナリオ", () => {
       canRetry: true,
     });
 
-    await t
-      .withIdentity({ subject: MANAGER_SUBJECT })
-      .mutation(api.notificationOutbox.mutations.retryFailure, { failureId: firstOpenPage.page[0]._id });
+    await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.notificationOutbox.mutations.retryFailure, {
+      failureId: firstOpenPage.page[0]._id,
+      shopId: ids.shopId,
+    });
     let inbox = await t.run(async (ctx) => await ctx.db.query("notificationFailureInbox").collect());
     expect(inbox[0].status).toBe("retrying");
 
@@ -670,30 +675,36 @@ describe("通知配送outboxシナリオ", () => {
 
     vi.advanceTimersByTime(60_000);
     fetchMock.mockImplementationOnce(async () => ({ ok: true, status: 200, text: async () => "{}" }));
-    await t
-      .withIdentity({ subject: MANAGER_SUBJECT })
-      .mutation(api.notificationOutbox.mutations.retryFailure, { failureId: firstOpenPage.page[0]._id });
+    await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.notificationOutbox.mutations.retryFailure, {
+      failureId: firstOpenPage.page[0]._id,
+      shopId: ids.shopId,
+    });
     await t.action(internal.notificationOutbox.actions.processPending, {});
 
     inbox = await t.run(async (ctx) => await ctx.db.query("notificationFailureInbox").collect());
     expect(inbox[0]).toMatchObject({ status: "resolved", resolutionKind: "sent" });
     await expect(
-      t.withIdentity({ subject: MANAGER_SUBJECT }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+      t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .query(api.notificationOutbox.queries.hasOpenFailures, { shopId: ids.shopId }),
     ).resolves.toBe(false);
   });
 
   it("スタッフ参加申請の日次digestはpending時だけowner向けoutboxを作る", async () => {
     const t = convexTest(schema, modules);
 
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, {
+    const shopId = await t.run(async (ctx) => {
+      const seeded = await seedManagerShop(ctx, {
         subject: MANAGER_SUBJECT,
         email: "owner-digest@example.com",
         shopName: "参加申請通知店舗",
       });
+      return seeded.shopId;
     });
     const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
-    const registrationLink = await asManager.mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+    const registrationLink = await asManager.mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {
+      shopId,
+    });
     const request = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: registrationLink.token,
       name: "申請スタッフ",
@@ -719,6 +730,7 @@ describe("通知配送outboxシナリオ", () => {
 
     await asManager.mutation(api.staffRegistration.mutations.approveRequest, {
       requestId: request.requestId,
+      shopId,
     });
     await t.action(internal.staffRegistration.actions.sendOwnerDailyDigest, {});
 

--- a/convex/_scenario/staffRegistration.test.ts
+++ b/convex/_scenario/staffRegistration.test.ts
@@ -39,7 +39,7 @@ describe("スタッフ参加QRシナリオ", () => {
 
     const link = await t
       .withIdentity({ subject: MANAGER_SUBJECT })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
     await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "QR申請スタッフ",
@@ -59,12 +59,12 @@ describe("スタッフ参加QRシナリオ", () => {
 
     const pending = await t
       .withIdentity({ subject: MANAGER_SUBJECT })
-      .query(api.staffRegistration.queries.getPendingRequests, {});
+      .query(api.staffRegistration.queries.getPendingRequests, { shopId });
     expect(pending).toMatchObject([{ name: "QR申請スタッフ", email: "qr-staff@example.com" }]);
 
     const { staffId } = await t
       .withIdentity({ subject: MANAGER_SUBJECT })
-      .mutation(api.staffRegistration.mutations.approveRequest, { requestId: pending[0]._id });
+      .mutation(api.staffRegistration.mutations.approveRequest, { requestId: pending[0]._id, shopId });
 
     const staffPage = await asManager.getDashboardStaffs();
     expect(staffPage.page.find((staff) => staff._id === staffId)).toMatchObject({

--- a/convex/_test/scenarioFixtures.ts
+++ b/convex/_test/scenarioFixtures.ts
@@ -68,79 +68,125 @@ export function createScenario(t: ScenarioTest) {
   return {
     manager(identity: ManagerIdentity) {
       const asManager = t.withIdentity(typeof identity === "string" ? { subject: identity } : identity);
+      let selectedShopId: Id<"shops"> | null = null;
+
+      // Scenario fixture では単一店舗を選択中店舗として解決し、public API には必ず shopId を明示する。
+      const getSelectedShopId = async () => {
+        if (selectedShopId) return selectedShopId;
+        const [selectedShop] = await asManager.query(api.dashboard.queries.getMyShops, {});
+        const shopId = selectedShop?.shopId ?? null;
+        if (!shopId) throw new Error("Scenario manager shop is not selected");
+        selectedShopId = shopId;
+        return shopId;
+      };
 
       return {
-        setupShopAndManager(
+        async setupShopAndManager(
           args: ShopSettingsInput & { managerName: string; managerEmail: string; acceptedLegal: true },
         ) {
-          return asManager.mutation(api.setup.mutations.setupShopAndManager, {
+          const shopId = await asManager.mutation(api.setup.mutations.setupShopAndManager, {
             shopName: args.shopName,
             submissionPattern: resolveSubmissionPattern(args),
             managerName: args.managerName,
             managerEmail: args.managerEmail,
             acceptedLegal: args.acceptedLegal,
           });
+          selectedShopId = shopId;
+          return shopId;
         },
-        createRecruitment(args: RecruitmentInput) {
+        async createRecruitment(args: RecruitmentInput) {
           return asManager.mutation(api.recruitment.mutations.createRecruitment, {
             ...args,
             shopClosedDates: args.shopClosedDates ?? [],
+            shopId: await getSelectedShopId(),
           });
         },
-        deleteRecruitment(recruitmentId: Id<"recruitments">) {
-          return asManager.mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId });
+        async deleteRecruitment(recruitmentId: Id<"recruitments">) {
+          return asManager.mutation(api.recruitment.mutations.deleteRecruitment, {
+            recruitmentId,
+            shopId: await getSelectedShopId(),
+          });
         },
-        updateShopSettings(args: UpdateShopSettingsInput) {
+        async updateShopSettings(args: UpdateShopSettingsInput) {
           return asManager.mutation(api.shop.mutations.updateShopSettings, {
             shopName: args.shopName,
             regularClosedDays: args.regularClosedDays,
             submissionPattern: resolveSubmissionPattern(args),
+            shopId: await getSelectedShopId(),
           });
         },
-        addStaffs(entries: StaffEntry[]) {
-          return asManager.mutation(api.staff.mutations.addStaffs, { entries });
+        async addStaffs(entries: StaffEntry[]) {
+          return asManager.mutation(api.staff.mutations.addStaffs, { entries, shopId: await getSelectedShopId() });
         },
-        editStaff(args: { staffId: Id<"staffs">; name: string; email: string }) {
-          return asManager.mutation(api.staff.mutations.editStaff, args);
+        async editStaff(args: { staffId: Id<"staffs">; name: string; email: string }) {
+          return asManager.mutation(api.staff.mutations.editStaff, { ...args, shopId: await getSelectedShopId() });
         },
-        sendOpenRecruitmentNotifications(staffId: Id<"staffs">) {
-          return asManager.mutation(api.staff.mutations.sendOpenRecruitmentNotifications, { staffId });
+        async sendOpenRecruitmentNotifications(staffId: Id<"staffs">) {
+          return asManager.mutation(api.staff.mutations.sendOpenRecruitmentNotifications, {
+            staffId,
+            shopId: await getSelectedShopId(),
+          });
         },
-        sendCurrentShiftNotification(staffId: Id<"staffs">) {
-          return asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
+        async sendCurrentShiftNotification(staffId: Id<"staffs">) {
+          return asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, {
+            staffId,
+            shopId: await getSelectedShopId(),
+          });
         },
-        deleteStaff(staffId: Id<"staffs">) {
-          return asManager.mutation(api.staff.mutations.deleteStaff, { staffId });
+        async deleteStaff(staffId: Id<"staffs">) {
+          return asManager.mutation(api.staff.mutations.deleteStaff, { staffId, shopId: await getSelectedShopId() });
         },
-        setShiftExclusion(staffId: Id<"staffs">, excluded: boolean) {
-          return asManager.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded });
+        async setShiftExclusion(staffId: Id<"staffs">, excluded: boolean) {
+          return asManager.mutation(api.staff.mutations.setShiftExclusion, {
+            staffId,
+            excluded,
+            shopId: await getSelectedShopId(),
+          });
         },
-        saveShiftAssignments(args: { recruitmentId: Id<"recruitments">; assignments: ShiftAssignment[] }) {
-          return asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, args);
+        async saveShiftAssignments(args: { recruitmentId: Id<"recruitments">; assignments: ShiftAssignment[] }) {
+          return asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+            ...args,
+            shopId: await getSelectedShopId(),
+          });
         },
-        confirmRecruitment(recruitmentId: Id<"recruitments">) {
-          return asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+        async confirmRecruitment(recruitmentId: Id<"recruitments">) {
+          return asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+            recruitmentId,
+            shopId: await getSelectedShopId(),
+          });
         },
-        generateLineLinkToken(staffId: Id<"staffs">) {
-          return asManager.mutation(api.line.mutations.generateLinkToken, { staffId });
+        async generateLineLinkToken(staffId: Id<"staffs">) {
+          return asManager.mutation(api.line.mutations.generateLinkToken, {
+            staffId,
+            shopId: await getSelectedShopId(),
+          });
         },
         getCurrentUser() {
           return asManager.query(api.dashboard.queries.getCurrentUser, {});
         },
-        getDashboardShop() {
-          return asManager.query(api.dashboard.queries.getDashboardShop, {});
+        async getDashboardShop() {
+          return asManager.query(api.dashboard.queries.getDashboardShop, { shopId: await getSelectedShopId() });
         },
-        getDashboardStaffs(paginationOpts = { numItems: 20, cursor: null as string | null }) {
-          return asManager.query(api.dashboard.queries.getDashboardStaffs, { paginationOpts });
+        async getDashboardStaffs(paginationOpts = { numItems: 20, cursor: null as string | null }) {
+          return asManager.query(api.dashboard.queries.getDashboardStaffs, {
+            paginationOpts,
+            shopId: await getSelectedShopId(),
+          });
         },
-        getDashboardRecruitments(paginationOpts = { numItems: 20, cursor: null as string | null }) {
-          return asManager.query(api.dashboard.queries.getDashboardRecruitments, { paginationOpts });
+        async getDashboardRecruitments(paginationOpts = { numItems: 20, cursor: null as string | null }) {
+          return asManager.query(api.dashboard.queries.getDashboardRecruitments, {
+            paginationOpts,
+            shopId: await getSelectedShopId(),
+          });
         },
         getManagerConsentStatus() {
           return asManager.query(api.legal.queries.getManagerConsentStatus, {});
         },
-        getShiftBoardData(recruitmentId: Id<"recruitments">) {
-          return asManager.query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+        async getShiftBoardData(recruitmentId: Id<"recruitments">) {
+          return asManager.query(api.shiftBoard.queries.getShiftBoardData, {
+            recruitmentId,
+            shopId: await getSelectedShopId(),
+          });
         },
       };
     },

--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -1,32 +1,40 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
 import { seedManagerShop, seedShop, seedShopMembership, seedUser, testAuthTokenIdentifier } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
 
 const PAGINATION_FIRST_PAGE = { paginationOpts: { numItems: 10, cursor: null } };
+const firstPageArgs = (shopId: Id<"shops">) => ({ ...PAGINATION_FIRST_PAGE, shopId });
 
 describe("dashboard/queries", () => {
   describe("getDashboardShop", () => {
     it("未認証の場合 null を返す", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.query(api.dashboard.queries.getDashboardShop, {});
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "対象店舗"));
+      const result = await t.query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(result).toBeNull();
     });
 
     it("認証済みだが店舗未登録の場合 null を返す", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardShop, {});
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "未所属店舗"));
+      const result = await t
+        .withIdentity({ subject: "user_123" })
+        .query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(result).toBeNull();
     });
 
     it("店舗登録済みの場合、店舗情報を返す", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_123", shopName: "テスト店舗" });
-      });
+      const { shopId } = await t.run(
+        async (ctx) => await seedManagerShop(ctx, { subject: "user_123", shopName: "テスト店舗" }),
+      );
 
-      const result = await t.withIdentity({ subject: "user_123" }).query(api.dashboard.queries.getDashboardShop, {});
+      const result = await t
+        .withIdentity({ subject: "user_123" })
+        .query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(result).toEqual({
         name: "テスト店舗",
         regularClosedDays: [],
@@ -34,21 +42,63 @@ describe("dashboard/queries", () => {
       });
     });
 
-    it("論理削除された店舗は null を返す", async () => {
+    it("同一managerの複数店舗は明示shopIdに応じて返し分ける", async () => {
+      const t = convexTest(schema, modules);
+      const { firstShopId, secondShopId } = await t.run(async (ctx) => {
+        const userId = await seedUser(ctx, "multi_shop_dashboard_user");
+        const firstShopId = await seedShop(ctx, "有効店舗A");
+        const secondShopId = await seedShop(ctx, "有効店舗B");
+        await seedShopMembership(ctx, { userId, shopId: firstShopId });
+        await seedShopMembership(ctx, { userId, shopId: secondShopId });
+        return { firstShopId, secondShopId };
+      });
+      const asManager = t.withIdentity({ subject: "multi_shop_dashboard_user" });
+
+      const firstShop = await asManager.query(api.dashboard.queries.getDashboardShop, { shopId: firstShopId });
+      const secondShop = await asManager.query(api.dashboard.queries.getDashboardShop, { shopId: secondShopId });
+
+      expect(firstShop?.name).toBe("有効店舗A");
+      expect(secondShop?.name).toBe("有効店舗B");
+    });
+
+    it("shopId省略時は旧クライアント互換で先頭の有効所属店舗を返す", async () => {
       const t = convexTest(schema, modules);
       await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_deleted", shopName: "削除済み店舗", shopDeleted: true });
+        const userId = await seedUser(ctx, "legacy_multi_shop_dashboard_user");
+
+        const deletedShopId = await seedShop(ctx, "削除済み店舗");
+        await ctx.db.patch(deletedShopId, { isDeleted: true });
+        await seedShopMembership(ctx, { userId, shopId: deletedShopId });
+
+        const firstActiveShopId = await seedShop(ctx, "先頭の有効店舗");
+        const secondActiveShopId = await seedShop(ctx, "2件目の有効店舗");
+        await seedShopMembership(ctx, { userId, shopId: firstActiveShopId });
+        await seedShopMembership(ctx, { userId, shopId: secondActiveShopId });
       });
 
       const result = await t
-        .withIdentity({ subject: "user_deleted" })
+        .withIdentity({ subject: "legacy_multi_shop_dashboard_user" })
         .query(api.dashboard.queries.getDashboardShop, {});
+
+      expect(result?.name).toBe("先頭の有効店舗");
+    });
+
+    it("論理削除された店舗は null を返す", async () => {
+      const t = convexTest(schema, modules);
+      const { shopId } = await t.run(
+        async (ctx) =>
+          await seedManagerShop(ctx, { subject: "user_deleted", shopName: "削除済み店舗", shopDeleted: true }),
+      );
+
+      const result = await t
+        .withIdentity({ subject: "user_deleted" })
+        .query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(result).toBeNull();
     });
 
-    it("先頭の所属店舗が削除済みの場合、次の有効店舗を返す", async () => {
+    it("指定した店舗が削除済みの場合、別の有効店舗へフォールバックしない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const deletedShopId = await t.run(async (ctx) => {
         const userId = await seedUser(ctx, "user_deleted_first");
         const deletedShopId = await seedShop(ctx, "削除済み店舗");
         await ctx.db.patch(deletedShopId, { isDeleted: true });
@@ -56,53 +106,58 @@ describe("dashboard/queries", () => {
 
         const activeShopId = await seedShop(ctx, "残っている店舗");
         await seedShopMembership(ctx, { userId, shopId: activeShopId });
+        return deletedShopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_deleted_first" })
-        .query(api.dashboard.queries.getDashboardShop, {});
+        .query(api.dashboard.queries.getDashboardShop, { shopId: deletedShopId });
 
-      expect(result?.name).toBe("残っている店舗");
+      expect(result).toBeNull();
     });
 
     it("削除済みmembershipでは店舗情報を返さない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
-          subject: "user_deleted_membership",
-          shopName: "削除済みmembership店舗",
-          membershipDeleted: true,
-        });
-      });
+      const { shopId } = await t.run(
+        async (ctx) =>
+          await seedManagerShop(ctx, {
+            subject: "user_deleted_membership",
+            shopName: "削除済みmembership店舗",
+            membershipDeleted: true,
+          }),
+      );
 
       const result = await t
         .withIdentity({ subject: "user_deleted_membership" })
-        .query(api.dashboard.queries.getDashboardShop, {});
+        .query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(result).toBeNull();
     });
 
     it("論理削除済みユーザーには所属店舗情報を返さない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        const { userId } = await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const { userId, shopId } = await seedManagerShop(ctx, {
           subject: "deleted_dashboard_user",
           shopName: "削除ユーザー所属店舗",
         });
         await ctx.db.patch(userId, { isDeleted: true });
+        return shopId;
       });
 
       await expect(
-        t.withIdentity({ subject: "deleted_dashboard_user" }).query(api.dashboard.queries.getDashboardShop, {}),
+        t.withIdentity({ subject: "deleted_dashboard_user" }).query(api.dashboard.queries.getDashboardShop, { shopId }),
       ).resolves.toBeNull();
     });
 
     it("返り値に不要なフィールドが含まれない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_fields", shopName: "店舗" });
-      });
+      const { shopId } = await t.run(
+        async (ctx) => await seedManagerShop(ctx, { subject: "user_fields", shopName: "店舗" }),
+      );
 
-      const result = await t.withIdentity({ subject: "user_fields" }).query(api.dashboard.queries.getDashboardShop, {});
+      const result = await t
+        .withIdentity({ subject: "user_fields" })
+        .query(api.dashboard.queries.getDashboardShop, { shopId });
       expect(Object.keys(result ?? {}).sort()).toEqual(["name", "regularClosedDays", "submissionPattern"]);
     });
   });
@@ -288,16 +343,18 @@ describe("dashboard/queries", () => {
 
     it("未認証の場合、空ページを返す（ログアウト時の再実行でエラーにしない）", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "対象店舗"));
+      const result = await t.query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
       expect(result.page).toEqual([]);
       expect(result.isDone).toBe(true);
     });
 
     it("認証済みだが店舗未登録の場合、空ページを返す", async () => {
       const t = convexTest(schema, modules);
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "未所属店舗"));
       const result = await t
         .withIdentity({ subject: "user_no_shop" })
-        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
       expect(result.page).toEqual([]);
       expect(result.isDone).toBe(true);
     });
@@ -330,7 +387,7 @@ describe("dashboard/queries", () => {
 
       const result = await t
         .withIdentity({ subject: "user_rec" })
-        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
 
       expect(result.page).toHaveLength(1);
       expect(result.page[0].status).toBe("open");
@@ -340,7 +397,7 @@ describe("dashboard/queries", () => {
 
     it("論理削除された募集は除外する", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_rec_deleted",
           email: "deleted-rec@example.com",
@@ -367,11 +424,12 @@ describe("dashboard/queries", () => {
           isDeleted: true,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
+        return shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_rec_deleted" })
-        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
 
       expect(result.page).toHaveLength(1);
       expect(result.page[0].periodStart).toBe("2026-04-01");
@@ -394,7 +452,7 @@ describe("dashboard/queries", () => {
       vi.setSystemTime(new Date("2026-06-16T00:00:00+09:00"));
       try {
         const t = convexTest(schema, modules);
-        await t.run(async (ctx) => {
+        const shopId = await t.run(async (ctx) => {
           const { shopId } = await seedManagerShop(ctx, {
             subject: "user_rec_dashboard_order",
             email: "dashboard-order@example.com",
@@ -444,11 +502,12 @@ describe("dashboard/queries", () => {
             status: "confirmed",
             confirmedAt: Date.now(),
           });
+          return shopId;
         });
 
         const result = await t
           .withIdentity({ subject: "user_rec_dashboard_order" })
-          .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+          .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
 
         expect(result.page.map((recruitment) => recruitment.periodStart)).toEqual([
           "2026-06-01",
@@ -466,13 +525,13 @@ describe("dashboard/queries", () => {
     it("未確定シフトは終了日当日まで返し、翌日から初期取得ではなく過去取得で返す", async () => {
       vi.setSystemTime(new Date("2026-07-07T00:00:00+09:00"));
       const t = convexTest(schema, modules);
-      const recruitmentId = await t.run(async (ctx) => {
+      const { recruitmentId, shopId } = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_open_ended",
           email: "open-ended@example.com",
           shopName: "店舗",
         });
-        return await ctx.db.insert("recruitments", {
+        const recruitmentId = await ctx.db.insert("recruitments", {
           shopId,
           periodStart: "2026-07-01",
           periodEnd: "2026-07-07",
@@ -482,15 +541,16 @@ describe("dashboard/queries", () => {
           isDeleted: false,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
+        return { recruitmentId, shopId };
       });
       const asManager = t.withIdentity({ subject: "user_open_ended" });
 
-      const onPeriodEnd = await asManager.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+      const onPeriodEnd = await asManager.query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
       expect(onPeriodEnd.page.map((recruitment) => recruitment._id)).toEqual([recruitmentId]);
 
       vi.setSystemTime(new Date("2026-07-08T00:00:00+09:00"));
-      const nextDay = await asManager.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
-      const past = await asManager.query(api.dashboard.queries.getDashboardPastRecruitments, PAGINATION_FIRST_PAGE);
+      const nextDay = await asManager.query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
+      const past = await asManager.query(api.dashboard.queries.getDashboardPastRecruitments, firstPageArgs(shopId));
 
       expect(nextDay.page).toEqual([]);
       expect(past.page.map((recruitment) => recruitment._id)).toEqual([recruitmentId]);
@@ -499,13 +559,13 @@ describe("dashboard/queries", () => {
     it("終了済みの未確定シフトは締切日が未来でも初期取得で返さない", async () => {
       vi.setSystemTime(new Date("2026-07-07T00:00:00+09:00"));
       const t = convexTest(schema, modules);
-      const recruitmentId = await t.run(async (ctx) => {
+      const { recruitmentId, shopId } = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_ended_before_deadline",
           email: "ended-before-deadline@example.com",
           shopName: "店舗",
         });
-        return await ctx.db.insert("recruitments", {
+        const recruitmentId = await ctx.db.insert("recruitments", {
           shopId,
           periodStart: "2026-07-01",
           periodEnd: "2026-07-06",
@@ -515,11 +575,12 @@ describe("dashboard/queries", () => {
           isDeleted: false,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
+        return { recruitmentId, shopId };
       });
       const asManager = t.withIdentity({ subject: "user_ended_before_deadline" });
 
-      const active = await asManager.query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
-      const past = await asManager.query(api.dashboard.queries.getDashboardPastRecruitments, PAGINATION_FIRST_PAGE);
+      const active = await asManager.query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
+      const past = await asManager.query(api.dashboard.queries.getDashboardPastRecruitments, firstPageArgs(shopId));
 
       expect(active.page).toEqual([]);
       expect(past.page.map((recruitment) => recruitment._id)).toEqual([recruitmentId]);
@@ -530,7 +591,7 @@ describe("dashboard/queries", () => {
       vi.setSystemTime(new Date("2026-06-16T00:00:00+09:00"));
       try {
         const t = convexTest(schema, modules);
-        await t.run(async (ctx) => {
+        const shopId = await t.run(async (ctx) => {
           const { shopId } = await seedManagerShop(ctx, {
             subject: "user_current_rec",
             email: "current-rec@example.com",
@@ -575,11 +636,12 @@ describe("dashboard/queries", () => {
             isDeleted: false,
             submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
           });
+          return shopId;
         });
 
         const result = await t
           .withIdentity({ subject: "user_current_rec" })
-          .query(api.dashboard.queries.getDashboardCurrentRecruitments, {});
+          .query(api.dashboard.queries.getDashboardCurrentRecruitments, { shopId });
 
         expect(result.map((recruitment) => recruitment.periodEnd)).toEqual(["2026-06-20", "2026-06-30"]);
         expect(result.every((recruitment) => recruitment.status === "confirmed")).toBe(true);
@@ -590,7 +652,7 @@ describe("dashboard/queries", () => {
 
     it("recruitmentStats がない古い募集では responseCount は shiftSubmissions の件数を返す", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_rc",
           email: "rc@example.com",
@@ -658,18 +720,19 @@ describe("dashboard/queries", () => {
           startTime: "10:00",
           endTime: "18:00",
         });
+        return shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_rc" })
-        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
       expect(result.page[0].responseCount).toBe(2);
       expect(result.page[0].totalStaffCount).toBe(2);
     });
 
     it("recruitmentStats がある場合も totalStaffCount は現在の有効スタッフ数を返す", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_stats",
           email: "stats@example.com",
@@ -716,11 +779,12 @@ describe("dashboard/queries", () => {
           activeStaffCountSnapshot: 1,
           updatedAt: Date.now(),
         });
+        return shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_stats" })
-        .query(api.dashboard.queries.getDashboardRecruitments, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardRecruitments, firstPageArgs(shopId));
       expect(result.page[0].responseCount).toBe(2);
       expect(result.page[0].totalStaffCount).toBe(3);
     });
@@ -732,7 +796,7 @@ describe("dashboard/queries", () => {
       vi.setSystemTime(new Date("2026-06-16T00:00:00+09:00"));
       try {
         const t = convexTest(schema, modules);
-        await t.run(async (ctx) => {
+        const shopId = await t.run(async (ctx) => {
           const { shopId } = await seedManagerShop(ctx, {
             subject: "user_has_past",
             email: "has-past@example.com",
@@ -766,11 +830,12 @@ describe("dashboard/queries", () => {
             confirmedAt: Date.now(),
             isDeleted: true,
           });
+          return shopId;
         });
 
         const result = await t
           .withIdentity({ subject: "user_has_past" })
-          .query(api.dashboard.queries.hasDashboardPastRecruitments, {});
+          .query(api.dashboard.queries.hasDashboardPastRecruitments, { shopId });
 
         expect(result).toBe(true);
       } finally {
@@ -783,7 +848,7 @@ describe("dashboard/queries", () => {
       vi.setSystemTime(new Date("2026-06-16T00:00:00+09:00"));
       try {
         const t = convexTest(schema, modules);
-        await t.run(async (ctx) => {
+        const shopId = await t.run(async (ctx) => {
           const { shopId } = await seedManagerShop(ctx, {
             subject: "user_no_past",
             email: "no-past@example.com",
@@ -800,11 +865,12 @@ describe("dashboard/queries", () => {
             isDeleted: false,
             submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
           });
+          return shopId;
         });
 
         const result = await t
           .withIdentity({ subject: "user_no_past" })
-          .query(api.dashboard.queries.hasDashboardPastRecruitments, {});
+          .query(api.dashboard.queries.hasDashboardPastRecruitments, { shopId });
 
         expect(result).toBe(false);
       } finally {
@@ -819,7 +885,7 @@ describe("dashboard/queries", () => {
       vi.setSystemTime(new Date("2026-06-16T00:00:00+09:00"));
       try {
         const t = convexTest(schema, modules);
-        await t.run(async (ctx) => {
+        const shopId = await t.run(async (ctx) => {
           const { shopId } = await seedManagerShop(ctx, {
             subject: "user_past_page",
             email: "past-page@example.com",
@@ -852,14 +918,19 @@ describe("dashboard/queries", () => {
             status: "confirmed",
             confirmedAt: Date.now(),
           });
+          return shopId;
         });
 
         const firstPage = await t
           .withIdentity({ subject: "user_past_page" })
-          .query(api.dashboard.queries.getDashboardPastRecruitments, { paginationOpts: { numItems: 2, cursor: null } });
+          .query(api.dashboard.queries.getDashboardPastRecruitments, {
+            shopId,
+            paginationOpts: { numItems: 2, cursor: null },
+          });
         const secondPage = await t
           .withIdentity({ subject: "user_past_page" })
           .query(api.dashboard.queries.getDashboardPastRecruitments, {
+            shopId,
             paginationOpts: { numItems: 2, cursor: firstPage.continueCursor },
           });
 
@@ -876,23 +947,25 @@ describe("dashboard/queries", () => {
   describe("getDashboardStaffs", () => {
     it("未認証の場合、空ページを返す（ログアウト時の再実行でエラーにしない）", async () => {
       const t = convexTest(schema, modules);
-      const result = await t.query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "対象店舗"));
+      const result = await t.query(api.dashboard.queries.getDashboardStaffs, firstPageArgs(shopId));
       expect(result.page).toEqual([]);
       expect(result.isDone).toBe(true);
     });
 
     it("認証済みだが店舗未登録の場合、空ページを返す", async () => {
       const t = convexTest(schema, modules);
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "未所属店舗"));
       const result = await t
         .withIdentity({ subject: "user_no_shop" })
-        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardStaffs, firstPageArgs(shopId));
       expect(result.page).toEqual([]);
       expect(result.isDone).toBe(true);
     });
 
     it("スタッフをページネーションで返し、削除済みは除外される", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_staff",
           email: "m@example.com",
@@ -910,11 +983,12 @@ describe("dashboard/queries", () => {
           email: "deleted@example.com",
           isDeleted: true,
         });
+        return shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_staff" })
-        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardStaffs, firstPageArgs(shopId));
 
       expect(result.page).toHaveLength(1);
       expect(result.page[0].name).toBe("田中太郎");
@@ -922,7 +996,7 @@ describe("dashboard/queries", () => {
 
     it("返り値に不要なフィールドが含まれない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_sf",
           email: "m@example.com",
@@ -934,11 +1008,12 @@ describe("dashboard/queries", () => {
           email: "staff@example.com",
           isDeleted: false,
         });
+        return shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "user_sf" })
-        .query(api.dashboard.queries.getDashboardStaffs, PAGINATION_FIRST_PAGE);
+        .query(api.dashboard.queries.getDashboardStaffs, firstPageArgs(shopId));
       expect(Object.keys(result.page[0]).sort()).toEqual([
         "_id",
         "email",

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -2,7 +2,7 @@ import type { GenericDatabaseReader } from "convex/server";
 import { paginationOptsValidator } from "convex/server";
 import type { DataModel, Doc } from "../_generated/dataModel";
 import { todayJST } from "../_lib/dateFormat";
-import { authenticatedQuery } from "../_lib/functions";
+import { authenticatedQuery, managerQuery } from "../_lib/functions";
 import {
   DASHBOARD_CURRENT_RECRUITMENT_SCAN_LIMIT,
   DASHBOARD_OPEN_RECRUITMENT_SCAN_LIMIT,
@@ -18,24 +18,6 @@ const EMPTY_PAGE = { page: [], isDone: true, continueCursor: "" } as {
   isDone: boolean;
   continueCursor: string;
 };
-
-async function getManagerShop(ctx: {
-  db: GenericDatabaseReader<DataModel>;
-  identity: { subject: string } | null;
-  user: Doc<"users"> | null;
-}) {
-  if (!ctx.identity || !ctx.user || ctx.user.isDeleted) return null;
-  const user = ctx.user;
-  const memberships = ctx.db
-    .query("shopMembers")
-    .withIndex("by_userId_and_isDeleted", (q) => q.eq("userId", user._id).eq("isDeleted", false));
-
-  for await (const membership of memberships) {
-    const shop = await ctx.db.get(membership.shopId);
-    if (shop && !shop.isDeleted) return shop;
-  }
-  return null;
-}
 
 async function getTotalStaffCount(ctx: { db: GenericDatabaseReader<DataModel> }, shopId: Doc<"shops">["_id"]) {
   const activeStaffs = await ctx.db
@@ -148,10 +130,10 @@ async function getDashboardRecruitmentCandidateDocs(
   return Array.from(uniqueRecruitments.values());
 }
 
-export const getDashboardShop = authenticatedQuery({
+export const getDashboardShop = managerQuery({
   args: {},
   handler: async (ctx) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return null;
 
     return {
@@ -205,10 +187,10 @@ export const getActiveDashboardAnnouncement = authenticatedQuery({
   },
 });
 
-export const getDashboardRecruitments = authenticatedQuery({
+export const getDashboardRecruitments = managerQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return EMPTY_PAGE;
 
     const groupLimit = Math.max(args.paginationOpts.numItems, DASHBOARD_RECRUITMENT_CANDIDATE_GROUP_LIMIT);
@@ -227,10 +209,10 @@ export const getDashboardRecruitments = authenticatedQuery({
   },
 });
 
-export const hasDashboardPastRecruitments = authenticatedQuery({
+export const hasDashboardPastRecruitments = managerQuery({
   args: {},
   handler: async (ctx) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return false;
 
     const today = todayJST();
@@ -245,10 +227,10 @@ export const hasDashboardPastRecruitments = authenticatedQuery({
   },
 });
 
-export const getDashboardPastRecruitments = authenticatedQuery({
+export const getDashboardPastRecruitments = managerQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return EMPTY_PAGE;
 
     const today = todayJST();
@@ -272,10 +254,10 @@ export const getDashboardPastRecruitments = authenticatedQuery({
   },
 });
 
-export const getDashboardCurrentRecruitments = authenticatedQuery({
+export const getDashboardCurrentRecruitments = managerQuery({
   args: {},
   handler: async (ctx) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return [];
 
     const currentRecruitments = await getCurrentRecruitmentDocs(ctx, shop._id);
@@ -287,10 +269,10 @@ export const getDashboardCurrentRecruitments = authenticatedQuery({
   },
 });
 
-export const getDashboardStaffs = authenticatedQuery({
+export const getDashboardStaffs = managerQuery({
   args: { paginationOpts: paginationOptsValidator },
   handler: async (ctx, args) => {
-    const shop = await getManagerShop(ctx);
+    const shop = ctx.shop;
     if (!shop) return EMPTY_PAGE;
 
     const paginatedResult = await ctx.db

--- a/convex/featureRequest/mutations.test.ts
+++ b/convex/featureRequest/mutations.test.ts
@@ -9,7 +9,7 @@ import { FEATURE_REQUEST_COMMENT_MAX_LENGTH } from "../constants";
 const REQUEST_ID = "f4c8f39b-4dc1-4b97-b322-c1cc0f2dfe6f";
 const submitFeatureRequest = makeFunctionReference<
   "mutation",
-  { comment: string; requestId: string; shopId?: Id<"shops"> },
+  { comment: string; requestId: string; shopId: Id<"shops"> },
   { status: "accepted" }
 >("featureRequest/mutations:submit");
 
@@ -22,9 +22,10 @@ const submitFeatureRequestFromStaff = makeFunctionReference<
 describe("featureRequest/mutations", () => {
   it("未認証では要望を登録できない", async () => {
     const t = convexTest(schema, modules);
+    const shopId = await t.run((ctx) => seedShop(ctx, "未認証テスト店舗"));
 
     await expect(
-      t.mutation(submitFeatureRequest, { comment: "一覧をCSVで出したい", requestId: REQUEST_ID }),
+      t.mutation(submitFeatureRequest, { comment: "一覧をCSVで出したい", requestId: REQUEST_ID, shopId }),
     ).rejects.toThrow();
   });
 
@@ -37,6 +38,7 @@ describe("featureRequest/mutations", () => {
     const result = await t.withIdentity({ subject: "feature_request_manager" }).mutation(submitFeatureRequest, {
       comment: "  一覧をCSVで出したい  ",
       requestId: REQUEST_ID,
+      shopId: seeded.shopId,
     });
 
     expect(result).toEqual({ status: "accepted" });
@@ -52,14 +54,14 @@ describe("featureRequest/mutations", () => {
 
   it("同じrequestIdの再送は登録を増やさない", async () => {
     const t = convexTest(schema, modules);
-    await t.run((ctx) =>
+    const { shopId } = await t.run((ctx) =>
       seedManagerShop(ctx, { subject: "feature_request_retry", email: "retry@example.com", shopName: "再送店舗" }),
     );
     const asManager = t.withIdentity({ subject: "feature_request_retry" });
 
-    await asManager.mutation(submitFeatureRequest, { comment: "最初の要望", requestId: REQUEST_ID });
+    await asManager.mutation(submitFeatureRequest, { comment: "最初の要望", requestId: REQUEST_ID, shopId });
     await expect(
-      asManager.mutation(submitFeatureRequest, { comment: "再送された要望", requestId: REQUEST_ID }),
+      asManager.mutation(submitFeatureRequest, { comment: "再送された要望", requestId: REQUEST_ID, shopId }),
     ).resolves.toEqual({ status: "accepted" });
 
     expect(await t.run((ctx) => ctx.db.query("featureRequests").collect())).toHaveLength(1);
@@ -93,34 +95,36 @@ describe("featureRequest/mutations", () => {
 
   it("空白だけと201文字の要望を拒否する", async () => {
     const t = convexTest(schema, modules);
-    await t.run((ctx) =>
+    const { shopId } = await t.run((ctx) =>
       seedManagerShop(ctx, { subject: "feature_request_validation", email: "valid@example.com", shopName: "検証店舗" }),
     );
     const asManager = t.withIdentity({ subject: "feature_request_validation" });
 
-    await expect(asManager.mutation(submitFeatureRequest, { comment: "   ", requestId: REQUEST_ID })).rejects.toThrow(
-      "要望を入力してください",
-    );
+    await expect(
+      asManager.mutation(submitFeatureRequest, { comment: "   ", requestId: REQUEST_ID, shopId }),
+    ).rejects.toThrow("要望を入力してください");
     await expect(
       asManager.mutation(submitFeatureRequest, {
         comment: "あ".repeat(FEATURE_REQUEST_COMMENT_MAX_LENGTH + 1),
         requestId: "842ff731-6646-49f7-ac47-cea4cf432a30",
+        shopId,
       }),
     ).rejects.toThrow("要望は200文字以内で入力してください");
   });
 
   it("異なる要望の短時間連続送信を拒否する", async () => {
     const t = convexTest(schema, modules);
-    await t.run((ctx) =>
+    const { shopId } = await t.run((ctx) =>
       seedManagerShop(ctx, { subject: "feature_request_limit", email: "limit@example.com", shopName: "制限店舗" }),
     );
     const asManager = t.withIdentity({ subject: "feature_request_limit" });
 
-    await asManager.mutation(submitFeatureRequest, { comment: "最初の要望", requestId: REQUEST_ID });
+    await asManager.mutation(submitFeatureRequest, { comment: "最初の要望", requestId: REQUEST_ID, shopId });
     await expect(
       asManager.mutation(submitFeatureRequest, {
         comment: "次の要望",
         requestId: "6cf637aa-9b42-4027-a0c8-46872f7e4a22",
+        shopId,
       }),
     ).rejects.toThrow("少し時間をおいて");
   });

--- a/convex/legal/mutations.test.ts
+++ b/convex/legal/mutations.test.ts
@@ -159,7 +159,7 @@ describe("legal/mutations", () => {
 
     const result = await t
       .withIdentity({ subject: "manager_1" })
-      .mutation(api.legal.mutations.acceptManagerLegalConsent, { acceptedLegal: true });
+      .mutation(api.legal.mutations.acceptManagerLegalConsent, { acceptedLegal: true, shopId });
 
     expect(result.status).toBe("ok");
     const [state, events] = await t.run(async (ctx) => {

--- a/convex/legal/queries.ts
+++ b/convex/legal/queries.ts
@@ -1,15 +1,15 @@
 import { v } from "convex/values";
 import { internalQuery, query } from "../_generated/server";
-import { managerQuery } from "../_lib/functions";
+import { authenticatedQuery } from "../_lib/functions";
 import { getStaffLineAccount } from "../line/service";
 import { getLegalDocumentsForAudience } from "./documents";
 import { hasCurrentStaffLegalConsent, hasCurrentUserLegalConsent } from "./service";
 
-export const getManagerConsentStatus = managerQuery({
+export const getManagerConsentStatus = authenticatedQuery({
   args: {},
   handler: async (ctx) => {
     const documents = getLegalDocumentsForAudience("manager");
-    if (!ctx.user || !ctx.shop) {
+    if (!ctx.identity || !ctx.user || ctx.user.isDeleted) {
       return {
         required: false,
         documents,

--- a/convex/line/mutations.test.ts
+++ b/convex/line/mutations.test.ts
@@ -51,17 +51,17 @@ describe("line/mutations", () => {
   describe("generateLinkToken", () => {
     it("未認証なら拒否", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupShop(t);
-      await expect(t.mutation(api.line.mutations.generateLinkToken, { staffId })).rejects.toThrow();
+      const { shopId, staffId } = await setupShop(t);
+      await expect(t.mutation(api.line.mutations.generateLinkToken, { shopId, staffId })).rejects.toThrow();
     });
 
     it("認証済みシフト担当者は自店舗スタッフにトークンを発行できる", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupShop(t);
+      const { shopId, staffId } = await setupShop(t);
 
       const { token } = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.line.mutations.generateLinkToken, { staffId });
+        .mutation(api.line.mutations.generateLinkToken, { shopId, staffId });
       expect(token).toMatch(/^[0-9a-f-]{36}$/);
 
       const link = await t.run(async (ctx) =>
@@ -76,7 +76,7 @@ describe("line/mutations", () => {
 
     it("他店舗スタッフへのトークン発行は拒否（IDOR）", async () => {
       const t = convexTest(schema, modules);
-      await setupShop(t);
+      const { shopId } = await setupShop(t);
       const otherStaffId = await t.run(async (ctx) => {
         const otherShopId = await seedShop(ctx, "他店舗");
         return await ctx.db.insert("staffs", {
@@ -89,6 +89,7 @@ describe("line/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.generateLinkToken, {
+          shopId,
           staffId: otherStaffId,
         }),
       ).rejects.toThrow("Not found");
@@ -96,9 +97,8 @@ describe("line/mutations", () => {
 
     it("複数店舗マネージャーは shopId 指定でその店舗のスタッフにトークンを発行できる", async () => {
       const t = convexTest(schema, modules);
-      // user_mgr は setupShop で店舗A（先頭）に所属。さらに店舗Bにも所属させる
-      const { shopBId, staffBId } = await t.run(async (ctx) => {
-        const { userId } = await seedManagerShop(ctx, {
+      const { shopAId, shopBId, staffBId } = await t.run(async (ctx) => {
+        const { userId, shopId: shopAId } = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
           shopName: "店舗A",
@@ -111,18 +111,19 @@ describe("line/mutations", () => {
           email: "b@example.com",
           isDeleted: false,
         });
-        return { shopBId, staffBId };
+        return { shopAId, shopBId, staffBId };
       });
 
-      // shopId 未指定だと先頭店舗(A)に解決され、店舗Bスタッフは Not found
+      // 店舗Aを明示した場合、店舗Bスタッフは店舗境界の外なので参照できない
       await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.generateLinkToken, { staffId: staffBId }),
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.line.mutations.generateLinkToken, { shopId: shopAId, staffId: staffBId }),
       ).rejects.toThrow("Not found");
 
-      // shopId=店舗B を指定すれば発行できる
       const { token } = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.line.mutations.generateLinkToken, { staffId: staffBId, shopId: shopBId });
+        .mutation(api.line.mutations.generateLinkToken, { shopId: shopBId, staffId: staffBId });
       const link = await t.run(async (ctx) =>
         ctx.db
           .query("lineLinkTokens")
@@ -653,19 +654,19 @@ describe("line/mutations", () => {
 
     it("自店舗スタッフへの送信が成功する", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupShop(t);
+      const { shopId, staffId } = await setupShop(t);
       await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.sendInvite, { staffId }),
+        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.sendInvite, { shopId, staffId }),
       ).resolves.not.toThrow();
     });
 
     it("同じスタッフへの短時間連打では送信予約を増やさない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupShop(t);
+      const { shopId, staffId } = await setupShop(t);
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
-      await asManager.mutation(api.line.mutations.sendInvite, { staffId });
-      await asManager.mutation(api.line.mutations.sendInvite, { staffId });
+      await asManager.mutation(api.line.mutations.sendInvite, { shopId, staffId });
+      await asManager.mutation(api.line.mutations.sendInvite, { shopId, staffId });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(scheduled.filter((job) => job.name === "line/actions:sendInviteEmail")).toHaveLength(1);
@@ -691,7 +692,7 @@ describe("line/mutations", () => {
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       for (const staffId of staffIds) {
-        await expect(asManager.mutation(api.line.mutations.sendInvite, { staffId })).resolves.not.toThrow();
+        await expect(asManager.mutation(api.line.mutations.sendInvite, { shopId, staffId })).resolves.not.toThrow();
       }
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
@@ -700,7 +701,7 @@ describe("line/mutations", () => {
 
     it("他店舗スタッフへの送信は拒否（IDOR）", async () => {
       const t = convexTest(schema, modules);
-      await setupShop(t);
+      const { shopId } = await setupShop(t);
       const otherStaffId = await t.run(async (ctx) => {
         const sid = await seedShop(ctx, "他店舗");
         return await ctx.db.insert("staffs", {
@@ -711,18 +712,20 @@ describe("line/mutations", () => {
         });
       });
       await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.sendInvite, { staffId: otherStaffId }),
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.line.mutations.sendInvite, { shopId, staffId: otherStaffId }),
       ).rejects.toThrow("Not found");
     });
 
     it("メールアドレス未登録なら拒否", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupShop(t);
+      const { shopId, staffId } = await setupShop(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(staffId, { email: "" });
       });
       await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.sendInvite, { staffId }),
+        t.withIdentity({ subject: "user_mgr" }).mutation(api.line.mutations.sendInvite, { shopId, staffId }),
       ).rejects.toThrow("メールアドレスが未登録");
     });
   });

--- a/convex/line/mutations.ts
+++ b/convex/line/mutations.ts
@@ -7,6 +7,7 @@ import { buildLineAuthorizeUrl } from "../_lib/lineClient";
 import { rateLimit } from "../_lib/rateLimits";
 import { generateUUID } from "../_lib/uuid";
 import { LINE_LINK_TOKEN_TTL_MS } from "../constants";
+import { getActiveStaffInShop } from "../staff/service";
 import { findStaffLineAccountsByLineUserId, getStaffLineAccount, upsertStaffLineAccount } from "./service";
 
 /**
@@ -18,8 +19,8 @@ import { findStaffLineAccountsByLineUserId, getStaffLineAccount, upsertStaffLine
 export const generateLinkToken = managerMutation({
   args: { staffId: v.id("staffs") },
   handler: async (ctx, args) => {
-    const staff = await ctx.db.get(args.staffId);
-    if (!staff || staff.isDeleted || staff.shopId !== ctx.shop._id) {
+    const staff = await getActiveStaffInShop(ctx, ctx.shop._id, args.staffId);
+    if (!staff) {
       throw new ConvexError("Not found");
     }
 
@@ -269,8 +270,8 @@ export const upsertQuotaStatus = internalMutation({
 export const sendInvite = managerMutation({
   args: { staffId: v.id("staffs") },
   handler: async (ctx, args) => {
-    const staff = await ctx.db.get(args.staffId);
-    if (!staff || staff.isDeleted || staff.shopId !== ctx.shop._id) {
+    const staff = await getActiveStaffInShop(ctx, ctx.shop._id, args.staffId);
+    if (!staff) {
       throw new ConvexError("Not found");
     }
     if (!staff.email) {

--- a/convex/notificationOutbox/mutations.test.ts
+++ b/convex/notificationOutbox/mutations.test.ts
@@ -1208,6 +1208,7 @@ describe("notificationOutbox", () => {
     const failureId = (await collectFailureInbox(t))[0]._id;
     await t.withIdentity({ subject: "user_mgr" }).mutation(api.notificationOutbox.mutations.resolveFailure, {
       failureId,
+      shopId,
     });
 
     vi.advanceTimersByTime(1000);
@@ -1252,23 +1253,25 @@ describe("notificationOutbox", () => {
     });
     await t.mutation(internal.notificationOutbox.mutations.markFailed, { outboxId, lastError: "failed once" });
     const failureId = (await collectFailureInbox(t))[0]._id;
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, {
+    const otherShopId = await t.run(async (ctx) => {
+      const other = await seedManagerShop(ctx, {
         subject: "manager_other",
         email: "other-manager@example.com",
         shopName: "別店舗",
       });
+      return other.shopId;
     });
 
     await expect(
       t.withIdentity({ subject: "manager_other" }).mutation(api.notificationOutbox.mutations.retryFailure, {
         failureId,
+        shopId: otherShopId,
       }),
     ).rejects.toThrow("Not found");
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.retryFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.retryFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: true });
     const state = await t.run(async (ctx) => ({
@@ -1288,6 +1291,7 @@ describe("notificationOutbox", () => {
     const openPage = await t
       .withIdentity({ subject: "user_mgr" })
       .query(api.notificationOutbox.queries.listOpenFailures, {
+        shopId,
         paginationOpts: { numItems: 10, cursor: null },
       });
     expect(openPage.page).toHaveLength(0);
@@ -1326,17 +1330,19 @@ describe("notificationOutbox", () => {
         updatedAt: now,
       });
     });
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, {
+    const otherShopId = await t.run(async (ctx) => {
+      const other = await seedManagerShop(ctx, {
         subject: "manager_other",
         email: "other-manager@example.com",
         shopName: "別店舗",
       });
+      return other.shopId;
     });
 
     await expect(
       t.withIdentity({ subject: "manager_other" }).mutation(api.notificationOutbox.mutations.resendFailure, {
         failureId,
+        shopId: otherShopId,
       }),
     ).rejects.toThrow("Not found");
 
@@ -1344,6 +1350,7 @@ describe("notificationOutbox", () => {
       .withIdentity({ subject: "user_mgr" })
       .mutation(api.notificationOutbox.mutations.resendFailure, {
         failureId,
+        shopId,
       });
 
     expect(result).toEqual({ scheduled: true });
@@ -1366,6 +1373,7 @@ describe("notificationOutbox", () => {
     const openPage = await t
       .withIdentity({ subject: "user_mgr" })
       .query(api.notificationOutbox.queries.listOpenFailures, {
+        shopId,
         paginationOpts: { numItems: 10, cursor: null },
       });
     expect(openPage.page).toHaveLength(0);
@@ -1396,7 +1404,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: true });
     const state = await t.run(async (ctx) => ({
@@ -1442,7 +1450,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: true });
     const state = await t.run(async (ctx) => ({
@@ -1493,7 +1501,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: true });
     const state = await t.run(async (ctx) => ({
@@ -1538,7 +1546,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: true });
     const state = await t.run(async (ctx) => ({
@@ -1552,6 +1560,7 @@ describe("notificationOutbox", () => {
     const openPage = await t
       .withIdentity({ subject: "user_mgr" })
       .query(api.notificationOutbox.queries.listOpenFailures, {
+        shopId,
         paginationOpts: { numItems: 10, cursor: null },
       });
     expect(openPage.page).toHaveLength(0);
@@ -1583,7 +1592,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId, shopId });
 
     expect(result).toEqual({ scheduled: false, reason: "notRetryable" });
     const state = await t.run(async (ctx) => ({
@@ -1630,7 +1639,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId: ids.failureId });
+      .mutation(api.notificationOutbox.mutations.resendFailure, { failureId: ids.failureId, shopId });
 
     expect(result).toEqual({ scheduled: false, reason: "notRetryable" });
     const state = await t.run(async (ctx) => ({
@@ -1666,7 +1675,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendOpenFailures, {});
+      .mutation(api.notificationOutbox.mutations.resendOpenFailures, { shopId });
 
     expect(result.scheduledCount).toBe(1);
     expect(result.skippedCount).toBe(1);
@@ -1752,7 +1761,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendOpenFailures, {});
+      .mutation(api.notificationOutbox.mutations.resendOpenFailures, { shopId });
 
     expect(result.scheduledFailureIds).toEqual([ids.currentFailureId]);
     const failures = await t.run(async (ctx) => ({
@@ -1844,7 +1853,7 @@ describe("notificationOutbox", () => {
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resendOpenFailures, {});
+      .mutation(api.notificationOutbox.mutations.resendOpenFailures, { shopId });
 
     expect(result).toMatchObject({
       scheduled: true,
@@ -1986,23 +1995,25 @@ describe("notificationOutbox", () => {
     });
     await t.mutation(internal.notificationOutbox.mutations.markFailed, { outboxId, lastError: "failed once" });
     const failureId = (await collectFailureInbox(t))[0]._id;
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, {
+    const otherShopId = await t.run(async (ctx) => {
+      const other = await seedManagerShop(ctx, {
         subject: "manager_other",
         email: "other-manager@example.com",
         shopName: "別店舗",
       });
+      return other.shopId;
     });
 
     await expect(
       t.withIdentity({ subject: "manager_other" }).mutation(api.notificationOutbox.mutations.resolveFailure, {
         failureId,
+        shopId: otherShopId,
       }),
     ).rejects.toThrow("Not found");
 
     const result = await t
       .withIdentity({ subject: "user_mgr" })
-      .mutation(api.notificationOutbox.mutations.resolveFailure, { failureId });
+      .mutation(api.notificationOutbox.mutations.resolveFailure, { failureId, shopId });
 
     expect(result).toEqual({ resolved: true });
     const failure = await t.run(async (ctx) => await ctx.db.get(failureId));
@@ -2078,6 +2089,7 @@ describe("notificationOutbox", () => {
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.notificationOutbox.mutations.resolveFailure, {
           failureId,
+          shopId,
         }),
       ).rejects.toThrow("Not found");
     }

--- a/convex/notificationOutbox/queries.test.ts
+++ b/convex/notificationOutbox/queries.test.ts
@@ -108,12 +108,13 @@ describe("notificationOutbox/queries", () => {
         status: "open",
         dedupeKey: "email:test:other",
       });
-      return { oldFailureId, newFailureId };
+      return { oldFailureId, newFailureId, shopId: primary.shopId };
     });
 
     const page = await t
       .withIdentity({ subject: "manager_primary" })
       .query(api.notificationOutbox.queries.listOpenFailures, {
+        shopId: ids.shopId,
         paginationOpts: { numItems: 10, cursor: null },
       });
 
@@ -136,7 +137,7 @@ describe("notificationOutbox/queries", () => {
 
   it("listOpenFailuresは非表示失敗がページを埋めても対応可能な失敗を初回ページで返す", async () => {
     const t = convexTest(schema, modules);
-    const actionableId = await t.run(async (ctx) => {
+    const { actionableId, shopId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: "manager_pagination",
         email: "pagination@example.com",
@@ -204,12 +205,13 @@ describe("notificationOutbox/queries", () => {
           notificationContext: "test.email",
         });
       }
-      return id;
+      return { actionableId: id, shopId };
     });
 
     const page = await t
       .withIdentity({ subject: "manager_pagination" })
       .query(api.notificationOutbox.queries.listOpenFailures, {
+        shopId,
         paginationOpts: { numItems: 1, cursor: null },
       });
 
@@ -218,13 +220,13 @@ describe("notificationOutbox/queries", () => {
 
   it("hasOpenFailuresは現在店舗のopen失敗の有無だけを返す", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
+    const shopIds = await t.run(async (ctx) => {
       const active = await seedManagerShop(ctx, {
         subject: "manager_active",
         email: "active@example.com",
         shopName: "失敗あり店舗",
       });
-      await seedManagerShop(ctx, {
+      const empty = await seedManagerShop(ctx, {
         subject: "manager_empty",
         email: "empty@example.com",
         shopName: "失敗なし店舗",
@@ -273,19 +275,33 @@ describe("notificationOutbox/queries", () => {
         recruitmentId: closedRecruitmentId,
         notificationContext: "notification.sendRecruitmentNotificationEmails",
       });
+      return {
+        active: active.shopId,
+        empty: empty.shopId,
+        otherKind: otherKindOnly.shopId,
+        closedOnly: closedOnly.shopId,
+      };
     });
 
     await expect(
-      t.withIdentity({ subject: "manager_active" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+      t
+        .withIdentity({ subject: "manager_active" })
+        .query(api.notificationOutbox.queries.hasOpenFailures, { shopId: shopIds.active }),
     ).resolves.toBe(true);
     await expect(
-      t.withIdentity({ subject: "manager_empty" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+      t
+        .withIdentity({ subject: "manager_empty" })
+        .query(api.notificationOutbox.queries.hasOpenFailures, { shopId: shopIds.empty }),
     ).resolves.toBe(false);
     await expect(
-      t.withIdentity({ subject: "manager_other_kind" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+      t
+        .withIdentity({ subject: "manager_other_kind" })
+        .query(api.notificationOutbox.queries.hasOpenFailures, { shopId: shopIds.otherKind }),
     ).resolves.toBe(false);
     await expect(
-      t.withIdentity({ subject: "manager_closed_only" }).query(api.notificationOutbox.queries.hasOpenFailures, {}),
+      t
+        .withIdentity({ subject: "manager_closed_only" })
+        .query(api.notificationOutbox.queries.hasOpenFailures, { shopId: shopIds.closedOnly }),
     ).resolves.toBe(false);
   });
 });

--- a/convex/recruitment/mutations.test.ts
+++ b/convex/recruitment/mutations.test.ts
@@ -23,24 +23,34 @@ describe("recruitment/mutations", () => {
     });
 
     it("未認証の場合エラーをthrow", async () => {
-      const t = convexTest(schema, modules);
-      await expect(t.mutation(api.recruitment.mutations.createRecruitment, validArgs())).rejects.toThrow();
+      const { t, shopId } = await setupShop();
+      await expect(
+        t.mutation(api.recruitment.mutations.createRecruitment, { ...validArgs(), shopId }),
+      ).rejects.toThrow();
     });
 
     it("店舗未登録の場合エラーをthrow", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "user_other_shop",
+          email: "other-shop@example.com",
+          shopName: "別店舗",
+        });
         await seedUser(ctx, "user_no_shop", "no@example.com");
+        return seeded.shopId;
       });
 
       await expect(
-        t.withIdentity({ subject: "user_no_shop" }).mutation(api.recruitment.mutations.createRecruitment, validArgs()),
+        t
+          .withIdentity({ subject: "user_no_shop" })
+          .mutation(api.recruitment.mutations.createRecruitment, { ...validArgs(), shopId }),
       ).rejects.toThrow();
     });
 
-    function setupShop() {
+    async function setupShop() {
       const t = convexTest(schema, modules);
-      const shopId = t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const seeded = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
@@ -57,13 +67,12 @@ describe("recruitment/mutations", () => {
     afterEach(() => vi.useRealTimers());
 
     it("募集を作成できる", async () => {
-      const { t, shopId: shopIdPromise } = setupShop();
-      const shopId = await shopIdPromise;
+      const { t, shopId } = await setupShop();
       const args = validArgs();
 
       const recruitmentId = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.recruitment.mutations.createRecruitment, args);
+        .mutation(api.recruitment.mutations.createRecruitment, { ...args, shopId });
 
       expect(recruitmentId).toBeDefined();
 
@@ -77,15 +86,15 @@ describe("recruitment/mutations", () => {
     });
 
     it("同一内容の募集作成はエラーにし、統計と通知予約を増やさない", async () => {
-      const { t, shopId: shopIdPromise } = setupShop();
-      const shopId = await shopIdPromise;
+      const { t, shopId } = await setupShop();
       const args = { ...validArgs(), shopClosedDates: [futureDate(8), futureDate(10)] };
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
-      await asManager.mutation(api.recruitment.mutations.createRecruitment, args);
+      await asManager.mutation(api.recruitment.mutations.createRecruitment, { ...args, shopId });
       await expect(
         asManager.mutation(api.recruitment.mutations.createRecruitment, {
           ...args,
+          shopId,
           shopClosedDates: [...args.shopClosedDates].reverse(),
         }),
       ).rejects.toThrow("RECRUITMENT_DUPLICATE");
@@ -115,10 +124,11 @@ describe("recruitment/mutations", () => {
 
     it("提出締切日前日17:00が未来なら自動催促を予約する", async () => {
       vi.setSystemTime(new Date("2026-01-01T00:00:00+09:00"));
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const recruitmentId = await t
         .withIdentity({ subject: "user_mgr" })
         .mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: "2026-01-10",
           periodEnd: "2026-01-16",
           deadline: "2026-01-05",
@@ -139,10 +149,11 @@ describe("recruitment/mutations", () => {
 
     it("提出締切日前日17:00を過ぎている募集では自動催促を予約しない", async () => {
       vi.setSystemTime(new Date("2026-01-05T00:00:00+09:00"));
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const recruitmentId = await t
         .withIdentity({ subject: "user_mgr" })
         .mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: "2026-01-10",
           periodEnd: "2026-01-16",
           deadline: "2026-01-05",
@@ -162,15 +173,17 @@ describe("recruitment/mutations", () => {
     });
 
     it("同じ期間でも定休日が違う募集は別に作成できる", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       const firstId = await asManager.mutation(api.recruitment.mutations.createRecruitment, {
         ...validArgs(),
+        shopId,
         shopClosedDates: [futureDate(8)],
       });
       const secondId = await asManager.mutation(api.recruitment.mutations.createRecruitment, {
         ...validArgs(),
+        shopId,
         shopClosedDates: [futureDate(9)],
       });
 
@@ -178,20 +191,19 @@ describe("recruitment/mutations", () => {
     });
 
     it("削除済みの同一募集がある場合は新しく作成できる", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const asManager = t.withIdentity({ subject: "user_mgr" });
       const args = validArgs();
-      const firstId = await asManager.mutation(api.recruitment.mutations.createRecruitment, args);
-      await asManager.mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId: firstId });
+      const firstId = await asManager.mutation(api.recruitment.mutations.createRecruitment, { ...args, shopId });
+      await asManager.mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId: firstId, shopId });
 
-      const secondId = await asManager.mutation(api.recruitment.mutations.createRecruitment, args);
+      const secondId = await asManager.mutation(api.recruitment.mutations.createRecruitment, { ...args, shopId });
 
       expect(secondId).not.toBe(firstId);
     });
 
     it("店舗の提出方法を募集作成時点でスナップショットする", async () => {
-      const { t, shopId: shopIdPromise } = setupShop();
-      const shopId = await shopIdPromise;
+      const { t, shopId } = await setupShop();
       await t.run(async (ctx) => {
         await ctx.db.patch(shopId, {
           submissionPattern: {
@@ -206,7 +218,7 @@ describe("recruitment/mutations", () => {
 
       const recruitmentId = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.recruitment.mutations.createRecruitment, validArgs());
+        .mutation(api.recruitment.mutations.createRecruitment, { ...validArgs(), shopId });
       await t.run(async (ctx) => {
         await ctx.db.patch(shopId, { submissionPattern: { kind: "dateOnly" } });
       });
@@ -222,7 +234,7 @@ describe("recruitment/mutations", () => {
     });
 
     it("定休日を昇順ユニークにして保存できる", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const args = {
         ...validArgs(),
         shopClosedDates: [futureDate(10), futureDate(8), futureDate(10)],
@@ -230,28 +242,30 @@ describe("recruitment/mutations", () => {
 
       const recruitmentId = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.recruitment.mutations.createRecruitment, args);
+        .mutation(api.recruitment.mutations.createRecruitment, { ...args, shopId });
 
       const recruitment = await t.run(async (ctx) => ctx.db.get(recruitmentId));
       expect(recruitment?.shopClosedDates).toEqual([futureDate(8), futureDate(10)]);
     });
 
     it("期間外の定休日はエラー", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           shopClosedDates: [futureDate(15)],
         }),
       ).rejects.toThrow("定休日は募集期間内の日付を選んでください");
     });
 
     it("募集期間のすべてを定休日にするとエラー", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: futureDate(7),
           periodEnd: futureDate(8),
           deadline: futureDate(3),
@@ -261,44 +275,49 @@ describe("recruitment/mutations", () => {
     });
 
     it("日付形式が不正な定休日はエラー", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           shopClosedDates: ["2026/04/01"],
         }),
       ).rejects.toThrow("定休日の日付形式が正しくありません");
     });
 
     it("募集日付の形式不正・実在しない日付はエラー", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       await expect(
         asManager.mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           periodStart: "2026/04/01",
         }),
       ).rejects.toThrow("日付の形式が正しくありません");
       await expect(
         asManager.mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           periodEnd: "2026-02-31",
         }),
       ).rejects.toThrow("日付の形式が正しくありません");
       await expect(
         asManager.mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           deadline: "2026-13-01",
         }),
       ).rejects.toThrow("日付の形式が正しくありません");
     });
 
     it("募集期間が62日を超える場合はエラー", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: futureDate(7),
           periodEnd: futureDate(7 + RECRUITMENT_PERIOD_DAYS_MAX),
           deadline: futureDate(3),
@@ -308,10 +327,11 @@ describe("recruitment/mutations", () => {
     });
 
     it("募集期間が上限ちょうど62日なら作成できる", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: futureDate(7),
           periodEnd: futureDate(7 + RECRUITMENT_PERIOD_DAYS_MAX - 1),
           deadline: futureDate(3),
@@ -321,21 +341,23 @@ describe("recruitment/mutations", () => {
     });
 
     it("締切日が過去の場合エラーをthrow", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
           ...validArgs(),
+          shopId,
           deadline: futureDate(-1),
         }),
       ).rejects.toThrow("締切日は今日以降にしてください");
     });
 
     it("開始日が今日以前で締切日も開始日以降の場合は日付関係エラーをthrow", async () => {
-      const { t } = setupShop();
+      const { t, shopId } = await setupShop();
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.recruitment.mutations.createRecruitment, {
+          shopId,
           periodStart: todayJST(),
           periodEnd: futureDate(14),
           deadline: futureDate(3),
@@ -351,13 +373,13 @@ describe("recruitment/mutations", () => {
     ) {
       const t = convexTest(schema, modules);
       const subject = options.subject ?? "user_delete_mgr";
-      const recruitmentId = await t.run(async (ctx) => {
+      const seeded = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject,
           email: `${subject}@example.com`,
           shopName: "削除テスト店舗",
         });
-        return await ctx.db.insert("recruitments", {
+        const recruitmentId = await ctx.db.insert("recruitments", {
           shopId,
           periodStart: "2026-04-01",
           periodEnd: "2026-04-07",
@@ -368,18 +390,21 @@ describe("recruitment/mutations", () => {
           isDeleted: options.isDeleted ?? false,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
+        return { recruitmentId, shopId };
       });
-      return { t, recruitmentId, subject };
+      return { t, ...seeded, subject };
     }
 
     it("未認証の場合エラーをthrow", async () => {
-      const { t, recruitmentId } = await setupRecruitment();
+      const { t, recruitmentId, shopId } = await setupRecruitment();
 
-      await expect(t.mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId })).rejects.toThrow();
+      await expect(
+        t.mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId }),
+      ).rejects.toThrow();
     });
 
     it("店舗未登録の場合エラーをthrow", async () => {
-      const { t, recruitmentId } = await setupRecruitment();
+      const { t, recruitmentId, shopId } = await setupRecruitment();
       await t.run(async (ctx) => {
         await seedUser(ctx, "user_no_shop_delete", "no-shop-delete@example.com");
       });
@@ -387,23 +412,27 @@ describe("recruitment/mutations", () => {
       await expect(
         t
           .withIdentity({ subject: "user_no_shop_delete" })
-          .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId }),
+          .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId }),
       ).rejects.toThrow();
     });
 
     it("募集中の募集を論理削除できる", async () => {
-      const { t, recruitmentId, subject } = await setupRecruitment({ status: "open" });
+      const { t, recruitmentId, shopId, subject } = await setupRecruitment({ status: "open" });
 
-      await t.withIdentity({ subject }).mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId });
+      await t
+        .withIdentity({ subject })
+        .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId });
 
       const recruitment = await t.run(async (ctx) => ctx.db.get(recruitmentId));
       expect(recruitment?.isDeleted).toBe(true);
     });
 
     it("確定済みの募集を論理削除できる", async () => {
-      const { t, recruitmentId, subject } = await setupRecruitment({ status: "confirmed" });
+      const { t, recruitmentId, shopId, subject } = await setupRecruitment({ status: "confirmed" });
 
-      await t.withIdentity({ subject }).mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId });
+      await t
+        .withIdentity({ subject })
+        .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId });
 
       const recruitment = await t.run(async (ctx) => ctx.db.get(recruitmentId));
       expect(recruitment).toMatchObject({ status: "confirmed", isDeleted: true });
@@ -411,35 +440,37 @@ describe("recruitment/mutations", () => {
 
     it("他店舗の募集は削除できない", async () => {
       const { t, recruitmentId } = await setupRecruitment({ subject: "user_delete_manager" });
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const otherShopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: "user_delete_other",
           email: "delete-other@example.com",
           shopName: "別店舗",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t
           .withIdentity({ subject: "user_delete_other" })
-          .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId }),
+          .mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId: otherShopId }),
       ).rejects.toThrow("Not found");
     });
 
     it("削除済みの募集は削除できない", async () => {
-      const { t, recruitmentId, subject } = await setupRecruitment({ isDeleted: true });
+      const { t, recruitmentId, shopId, subject } = await setupRecruitment({ isDeleted: true });
 
       await expect(
-        t.withIdentity({ subject }).mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId }),
+        t.withIdentity({ subject }).mutation(api.recruitment.mutations.deleteRecruitment, { recruitmentId, shopId }),
       ).rejects.toThrow("Not found");
     });
 
     it("存在しない募集IDは削除できない", async () => {
-      const { t, subject } = await setupRecruitment();
+      const { t, shopId, subject } = await setupRecruitment();
 
       await expect(
         t.withIdentity({ subject }).mutation(api.recruitment.mutations.deleteRecruitment, {
           recruitmentId: "missing" as Id<"recruitments">,
+          shopId,
         }),
       ).rejects.toThrow();
     });

--- a/convex/recruitment/mutations.ts
+++ b/convex/recruitment/mutations.ts
@@ -10,6 +10,7 @@ import { managerMutation } from "../_lib/functions";
 import { isValidIsoDateString } from "../_lib/validation";
 import { RECRUITMENT_DUPLICATE_SCAN_LIMIT } from "../constants";
 import { createRecruitmentSchema } from "./schemas";
+import { getActiveRecruitmentInShop } from "./service";
 
 const RECRUITMENT_DUPLICATE_ERROR_CODE = "RECRUITMENT_DUPLICATE";
 
@@ -135,8 +136,8 @@ export const deleteRecruitment = managerMutation({
     recruitmentId: v.id("recruitments"),
   },
   handler: async (ctx, args) => {
-    const recruitment = await ctx.db.get(args.recruitmentId);
-    if (!recruitment || recruitment.shopId !== ctx.shop._id || recruitment.isDeleted) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, ctx.shop._id, args.recruitmentId);
+    if (!recruitment) {
       throw new ConvexError("Not found");
     }
 

--- a/convex/recruitment/service.ts
+++ b/convex/recruitment/service.ts
@@ -1,0 +1,9 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
+
+export async function getActiveRecruitmentInShop(ctx: DbCtx, shopId: Id<"shops">, recruitmentId: Id<"recruitments">) {
+  const recruitment = await ctx.db.get(recruitmentId);
+  return recruitment && recruitment.shopId === shopId && !recruitment.isDeleted ? recruitment : null;
+}

--- a/convex/shiftBoard/mutations.test.ts
+++ b/convex/shiftBoard/mutations.test.ts
@@ -109,9 +109,11 @@ describe("shiftBoard/mutations", () => {
 
     it("未認証の場合エラーをthrow", async () => {
       const t = convexTest(schema, modules);
+      const { recruitmentId, shopId } = await setupTestData(t);
       await expect(
         t.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
-          recruitmentId: "invalid" as Id<"recruitments">,
+          recruitmentId,
+          shopId,
           assignments: [],
         }),
       ).rejects.toThrow();
@@ -122,7 +124,7 @@ describe("shiftBoard/mutations", () => {
       const { recruitmentId } = await setupTestData(t);
 
       // 別のshop+userを作成
-      await t.run(async (ctx) => {
+      const otherShopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_other",
           email: "other@example.com",
@@ -134,6 +136,7 @@ describe("shiftBoard/mutations", () => {
       await expect(
         t.withIdentity({ subject: "user_other" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
           recruitmentId,
+          shopId: otherShopId,
           assignments: [],
         }),
       ).rejects.toThrow(ConvexError);
@@ -141,10 +144,11 @@ describe("shiftBoard/mutations", () => {
 
     it("正常にシフト割当を保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "18:00" }],
       });
@@ -162,7 +166,7 @@ describe("shiftBoard/mutations", () => {
 
     it("勤務区分IDつきのシフト割当を保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -176,6 +180,7 @@ describe("shiftBoard/mutations", () => {
       });
 
       await t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           {
@@ -200,11 +205,12 @@ describe("shiftBoard/mutations", () => {
 
     it("不正な日付・時刻形式のシフト割当は構造化エラーで拒否する", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await expectValidationIssues(
         asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-02-31", startTime: "10:00", endTime: "18:00" }],
         }),
@@ -212,6 +218,7 @@ describe("shiftBoard/mutations", () => {
       );
       await expectValidationIssues(
         asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId2, date: "2026-01-20", startTime: "bad", endTime: "18:00" }],
         }),
@@ -221,7 +228,7 @@ describe("shiftBoard/mutations", () => {
 
     it("勤務区分募集では勤務区分IDなしの割当を保存できない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -233,6 +240,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [
             {
@@ -249,7 +257,7 @@ describe("shiftBoard/mutations", () => {
 
     it("存在しない勤務区分IDは保存できない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -261,6 +269,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [
             {
@@ -278,7 +287,7 @@ describe("shiftBoard/mutations", () => {
 
     it("勤務区分IDと時間が一致しない割当は保存できない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -290,6 +299,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [
             {
@@ -307,7 +317,7 @@ describe("shiftBoard/mutations", () => {
 
     it("分つきシフト時間の境界内なら保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: { kind: "time", startTime: "05:30", endTime: "22:30" },
@@ -316,6 +326,7 @@ describe("shiftBoard/mutations", () => {
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "05:30", endTime: "06:30" },
@@ -334,10 +345,11 @@ describe("shiftBoard/mutations", () => {
 
     it("空のassignmentsで保存できる（全員休み）", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [],
       });
@@ -355,10 +367,11 @@ describe("shiftBoard/mutations", () => {
 
     it("保存時にdraftSavedAtを更新する", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "18:00" }],
       });
@@ -369,7 +382,7 @@ describe("shiftBoard/mutations", () => {
 
     it("過去シフトの下書き保存は拒否し、既存割当を置き換えない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await t.run(async (ctx) => {
@@ -400,6 +413,7 @@ describe("shiftBoard/mutations", () => {
 
       await expect(
         asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-10", startTime: "11:00", endTime: "19:00" }],
         }),
@@ -420,7 +434,7 @@ describe("shiftBoard/mutations", () => {
 
     it("既存の割当がある場合は全削除して置き換える", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await t.run(async (ctx) => {
@@ -453,6 +467,7 @@ describe("shiftBoard/mutations", () => {
       });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "09:00", endTime: "17:00" }],
       });
@@ -469,9 +484,10 @@ describe("shiftBoard/mutations", () => {
 
     it("同一スタッフ×同一日の時間が重ならない複数割当を保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "14:00" },
@@ -490,7 +506,7 @@ describe("shiftBoard/mutations", () => {
 
     it("勤務区分募集では同一スタッフ×同一日の隣接する勤務区分を保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -504,6 +520,7 @@ describe("shiftBoard/mutations", () => {
       });
 
       await t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "09:00", endTime: "12:00", optionId: "early" },
@@ -523,7 +540,7 @@ describe("shiftBoard/mutations", () => {
 
     it("勤務区分募集では同一スタッフ×同一日の重なる別勤務区分を保存できる", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: {
@@ -537,6 +554,7 @@ describe("shiftBoard/mutations", () => {
       });
 
       await t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "15:00", optionId: "early" },
@@ -556,10 +574,11 @@ describe("shiftBoard/mutations", () => {
 
     it("同一スタッフ×同一日の時間が重なる割当でエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [
             { staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "15:00" },
@@ -572,10 +591,11 @@ describe("shiftBoard/mutations", () => {
 
     it("募集期間外の日付でエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-27", startTime: "10:00", endTime: "18:00" }],
         }),
@@ -585,10 +605,11 @@ describe("shiftBoard/mutations", () => {
 
     it("定休日の日付ではシフト割当を保存できない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t, { shopClosedDates: ["2026-01-21"] });
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t, { shopClosedDates: ["2026-01-21"] });
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-21", startTime: "10:00", endTime: "18:00" }],
         }),
@@ -598,10 +619,11 @@ describe("shiftBoard/mutations", () => {
 
     it("開始時間が終了時間以降でエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "18:00", endTime: "10:00" }],
         }),
@@ -611,10 +633,11 @@ describe("shiftBoard/mutations", () => {
 
     it("開始時間と終了時間が同じでエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "10:00" }],
         }),
@@ -624,10 +647,11 @@ describe("shiftBoard/mutations", () => {
 
     it("店舗のシフト時間外でエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "07:00", endTime: "15:00" }],
         }),
@@ -637,7 +661,7 @@ describe("shiftBoard/mutations", () => {
 
     it("分つきシフト開始時刻より前ならエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: { kind: "time", startTime: "05:30", endTime: "22:30" },
@@ -646,6 +670,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "05:00", endTime: "06:30" }],
         }),
@@ -655,7 +680,7 @@ describe("shiftBoard/mutations", () => {
 
     it("分つきシフト終了時刻より後ならエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t);
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
           submissionPattern: { kind: "time", startTime: "05:30", endTime: "22:30" },
@@ -664,6 +689,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "21:30", endTime: "23:00" }],
         }),
@@ -673,10 +699,13 @@ describe("shiftBoard/mutations", () => {
 
     it("複数の違反がある場合は全issuesをまとめて返す", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t, { shopClosedDates: ["2026-01-21"] });
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t, {
+        shopClosedDates: ["2026-01-21"],
+      });
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [
             { staffId: staffId1, date: "2026-01-27", startTime: "10:00", endTime: "18:00" },
@@ -694,7 +723,7 @@ describe("shiftBoard/mutations", () => {
 
     it("削除済みスタッフでエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
 
       const deletedStaffId = await t.run(async (ctx) => {
         const user = await ctx.db
@@ -719,6 +748,7 @@ describe("shiftBoard/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+          shopId,
           recruitmentId,
           assignments: [{ staffId: deletedStaffId, date: "2026-01-20", startTime: "10:00", endTime: "18:00" }],
         }),
@@ -737,20 +767,22 @@ describe("shiftBoard/mutations", () => {
 
     it("未認証の場合エラーをthrow", async () => {
       const t = convexTest(schema, modules);
+      const { shopId, recruitmentId } = await setupTestData(t);
       await expect(
         t.mutation(api.shiftBoard.mutations.confirmRecruitment, {
-          recruitmentId: "invalid" as Id<"recruitments">,
+          shopId,
+          recruitmentId,
         }),
       ).rejects.toThrow();
     });
 
     it("正常にステータスとconfirmedAtを更新する", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
 
       await t
         .withIdentity({ subject: "user_manager" })
-        .mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+        .mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
 
       const recruitment = await t.run(async (ctx) => ctx.db.get(recruitmentId));
       expect(recruitment?.status).toBe("confirmed");
@@ -764,7 +796,7 @@ describe("shiftBoard/mutations", () => {
 
     it("過去シフトの確定通知は拒否し、通知予約しない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
 
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
@@ -776,6 +808,7 @@ describe("shiftBoard/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.confirmRecruitment, {
+          shopId,
           recruitmentId,
         }),
       ).rejects.toThrow(PAST_SHIFT_NOTIFY_ERROR);
@@ -789,11 +822,15 @@ describe("shiftBoard/mutations", () => {
 
     it("確定済み募集へのconfirm intentは通知を増やさない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, intent: "confirm" });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+        recruitmentId,
+        shopId,
+        intent: "confirm",
+      });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(scheduled.filter((job) => job.name === "notification/actions:sendShiftConfirmationEmails")).toHaveLength(
@@ -803,11 +840,15 @@ describe("shiftBoard/mutations", () => {
 
     it("確定済み募集へのresend intentは再通知として予約する", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, intent: "resend" });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+        recruitmentId,
+        shopId,
+        intent: "resend",
+      });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       const confirmationJobs = scheduled.filter(
@@ -819,20 +860,22 @@ describe("shiftBoard/mutations", () => {
 
     it("再通知は前回通知時点から変更されたスタッフだけを対象にする", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "18:00" },
           { staffId: staffId2, date: "2026-01-20", startTime: "12:00", endTime: "20:00" },
         ],
       });
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
       await seedCurrentConfirmationSnapshots(t, recruitmentId, [staffId1, staffId2]);
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [
           { staffId: staffId1, date: "2026-01-20", startTime: "11:00", endTime: "18:00" },
@@ -840,6 +883,7 @@ describe("shiftBoard/mutations", () => {
         ],
       });
       const result = await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+        shopId,
         recruitmentId,
         intent: "resend",
       });
@@ -855,17 +899,19 @@ describe("shiftBoard/mutations", () => {
 
     it("再通知で変更対象がいない場合は通知を予約しない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "18:00" }],
       });
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
       await seedCurrentConfirmationSnapshots(t, recruitmentId, [staffId1, staffId2]);
 
       const result = await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+        shopId,
         recruitmentId,
         intent: "resend",
       });
@@ -880,15 +926,17 @@ describe("shiftBoard/mutations", () => {
 
     it("snapshotがない既存の確定済み募集では初回再通知だけ全員を対象にする", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1, staffId2 } = await setupTestData(t);
+      const { shopId, recruitmentId, staffId1, staffId2 } = await setupTestData(t);
       const asManager = t.withIdentity({ subject: "user_manager" });
 
       await asManager.mutation(api.shiftBoard.mutations.saveShiftAssignments, {
+        shopId,
         recruitmentId,
         assignments: [{ staffId: staffId1, date: "2026-01-20", startTime: "10:00", endTime: "18:00" }],
       });
-      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId });
+      await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId });
       const result = await asManager.mutation(api.shiftBoard.mutations.confirmRecruitment, {
+        shopId,
         recruitmentId,
         intent: "resend",
       });
@@ -903,7 +951,7 @@ describe("shiftBoard/mutations", () => {
 
     it("再通知の対象スタッフ読み取りはシフトボード上限までにする", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffIds } = await t.run(async (ctx) => {
+      const { shopId, recruitmentId, staffIds } = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_manager",
           email: "manager@example.com",
@@ -931,12 +979,13 @@ describe("shiftBoard/mutations", () => {
             }),
           );
         }
-        return { recruitmentId, staffIds };
+        return { shopId, recruitmentId, staffIds };
       });
 
       const result = await t
         .withIdentity({ subject: "user_manager" })
         .mutation(api.shiftBoard.mutations.confirmRecruitment, {
+          shopId,
           recruitmentId,
           intent: "resend",
         });
@@ -952,7 +1001,7 @@ describe("shiftBoard/mutations", () => {
 
     it("過去シフトの再通知は拒否し、通知予約しない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
 
       await t.run(async (ctx) => {
         await ctx.db.patch(recruitmentId, {
@@ -966,6 +1015,7 @@ describe("shiftBoard/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.confirmRecruitment, {
+          shopId,
           recruitmentId,
           intent: "resend",
         }),
@@ -980,10 +1030,11 @@ describe("shiftBoard/mutations", () => {
 
     it("未確定募集へのresend intentはエラー", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId } = await setupTestData(t);
+      const { shopId, recruitmentId } = await setupTestData(t);
 
       await expect(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.confirmRecruitment, {
+          shopId,
           recruitmentId,
           intent: "resend",
         }),
@@ -992,7 +1043,7 @@ describe("shiftBoard/mutations", () => {
 
     it("定休日に既存シフトが残っている場合は確定できない", async () => {
       const t = convexTest(schema, modules);
-      const { recruitmentId, staffId1 } = await setupTestData(t, { shopClosedDates: ["2026-01-21"] });
+      const { shopId, recruitmentId, staffId1 } = await setupTestData(t, { shopClosedDates: ["2026-01-21"] });
       await t.run(async (ctx) => {
         const recruitment = await ctx.db.get(recruitmentId);
         if (!recruitment) throw new Error("missing recruitment");
@@ -1016,6 +1067,7 @@ describe("shiftBoard/mutations", () => {
 
       await expectValidationIssues(
         t.withIdentity({ subject: "user_manager" }).mutation(api.shiftBoard.mutations.confirmRecruitment, {
+          shopId,
           recruitmentId,
         }),
         [{ code: "CLOSED_DAY", date: "2026-01-21", staffId: staffId1 }],
@@ -1026,18 +1078,19 @@ describe("shiftBoard/mutations", () => {
       const t = convexTest(schema, modules);
       const { recruitmentId } = await setupTestData(t);
 
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const otherShopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: "user_other2",
           email: "other2@example.com",
           shopName: "他店舗",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t
           .withIdentity({ subject: "user_other2" })
-          .mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId }),
+          .mutation(api.shiftBoard.mutations.confirmRecruitment, { recruitmentId, shopId: otherShopId }),
       ).rejects.toThrow(ConvexError);
     });
   });

--- a/convex/shiftBoard/mutations.ts
+++ b/convex/shiftBoard/mutations.ts
@@ -5,6 +5,8 @@ import { managerMutation } from "../_lib/functions";
 import { SHIFT_ASSIGNMENT_LIMIT, SHIFT_BOARD_STAFF_LIMIT } from "../constants";
 import { buildConfirmationSnapshotsForStaffs } from "../notification/confirmationSnapshots";
 import { ensureDefaultPosition } from "../position/service";
+import { getActiveRecruitmentInShop } from "../recruitment/service";
+import { getActiveStaffInShop } from "../staff/service";
 import { buildAssignmentIssue, SHIFT_ASSIGNMENT_VALIDATION, validateShiftAssignments } from "./validation";
 
 const PAST_SHIFT_SAVE_ERROR = "過去のシフトは保存できません";
@@ -25,8 +27,8 @@ export const saveShiftAssignments = managerMutation({
     ),
   },
   handler: async (ctx, args) => {
-    const recruitment = await ctx.db.get(args.recruitmentId);
-    if (!recruitment || recruitment.isDeleted || recruitment.shopId !== ctx.shop._id) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, ctx.shop._id, args.recruitmentId);
+    if (!recruitment) {
       throw new ConvexError("Not found");
     }
     if (isPastShiftPeriod(recruitment.periodEnd)) {
@@ -51,8 +53,8 @@ export const saveShiftAssignments = managerMutation({
     await Promise.all(
       [
         uniqueStaffIds.map(async (staffId) => {
-          const staff = await ctx.db.get(staffId);
-          if (!staff || staff.isDeleted || staff.shopId !== ctx.shop._id) {
+          const staff = await getActiveStaffInShop(ctx, ctx.shop._id, staffId);
+          if (!staff) {
             throw new ConvexError("Not found");
           }
         }),
@@ -101,8 +103,8 @@ export const confirmRecruitment = managerMutation({
     intent: v.optional(v.union(v.literal("confirm"), v.literal("resend"))),
   },
   handler: async (ctx, args) => {
-    const recruitment = await ctx.db.get(args.recruitmentId);
-    if (!recruitment || recruitment.isDeleted || recruitment.shopId !== ctx.shop._id) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, ctx.shop._id, args.recruitmentId);
+    if (!recruitment) {
       throw new ConvexError("Not found");
     }
     if (isPastShiftPeriod(recruitment.periodEnd)) {

--- a/convex/shiftBoard/queries.test.ts
+++ b/convex/shiftBoard/queries.test.ts
@@ -7,9 +7,9 @@ import { modules, schema } from "../_test/setup.test-helper";
 describe("shiftBoard/queries", () => {
   it("削除済み募集は null を返す", async () => {
     const t = convexTest(schema, modules);
-    const recruitmentId = await t.run(async (ctx) => {
+    const { shopId, recruitmentId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_deleted_recruitment", shopName: "テスト店舗" });
-      return await ctx.db.insert("recruitments", {
+      const recruitmentId = await ctx.db.insert("recruitments", {
         shopId,
         periodStart: "2026-04-01",
         periodEnd: "2026-04-07",
@@ -20,18 +20,19 @@ describe("shiftBoard/queries", () => {
         isDeleted: true,
         submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
+      return { shopId, recruitmentId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_deleted_recruitment" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result).toBeNull();
   });
 
   it("シフト対象外スタッフはシフト表に含めない", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, includedStaffId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, includedStaffId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_excluded", shopName: "テスト店舗" });
       const includedStaffId = await ctx.db.insert("staffs", {
         shopId,
@@ -56,19 +57,19 @@ describe("shiftBoard/queries", () => {
         isDeleted: false,
         submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
       });
-      return { recruitmentId, includedStaffId };
+      return { shopId, recruitmentId, includedStaffId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_excluded" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.staffs.map((s) => s._id)).toEqual([includedStaffId]);
   });
 
   it("全休み提出は提出済みとして返す", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, staffId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, staffId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_all_off", shopName: "テスト店舗" });
       const staffId = await ctx.db.insert("staffs", {
         shopId,
@@ -91,12 +92,12 @@ describe("shiftBoard/queries", () => {
         staffId,
         submittedAt: Date.now(),
       });
-      return { recruitmentId, staffId };
+      return { shopId, recruitmentId, staffId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_all_off" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.staffs).toEqual([
       {
@@ -111,7 +112,7 @@ describe("shiftBoard/queries", () => {
 
   it("日ごと提出の希望日をシフト表用データとして返す", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, staffId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, staffId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_date_only_board", shopName: "テスト店舗" });
       const staffId = await ctx.db.insert("staffs", {
         shopId,
@@ -140,12 +141,12 @@ describe("shiftBoard/queries", () => {
         staffId,
         date: "2026-04-03",
       });
-      return { recruitmentId, staffId };
+      return { shopId, recruitmentId, staffId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_date_only_board" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.requestedDates).toEqual([{ staffId, date: "2026-04-03" }]);
     expect(result?.requestedSlots).toEqual([]);
@@ -153,7 +154,7 @@ describe("shiftBoard/queries", () => {
 
   it("勤務区分募集のsnapshotとoptionIdつき希望・割当を返す", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, staffId, positionId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, staffId, positionId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_shift_type_board", shopName: "テスト店舗" });
       const staffId = await ctx.db.insert("staffs", {
         shopId,
@@ -208,12 +209,12 @@ describe("shiftBoard/queries", () => {
         positionId,
         optionId: "late",
       });
-      return { recruitmentId, staffId, positionId };
+      return { shopId, recruitmentId, staffId, positionId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_shift_type_board" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.submissionPattern).toEqual({
       kind: "shiftType",
@@ -232,7 +233,7 @@ describe("shiftBoard/queries", () => {
 
   it("下書き保存時点で提出済みだったスタッフを返す", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, staffBeforeDraftId, staffAfterDraftId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, staffBeforeDraftId, staffAfterDraftId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_draft_status", shopName: "テスト店舗" });
       const staffBeforeDraftId = await ctx.db.insert("staffs", {
         shopId,
@@ -269,12 +270,12 @@ describe("shiftBoard/queries", () => {
         firstSubmittedAt: 3000,
         submittedAt: 3000,
       });
-      return { recruitmentId, staffBeforeDraftId, staffAfterDraftId };
+      return { shopId, recruitmentId, staffBeforeDraftId, staffAfterDraftId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_draft_status" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     const staffById = new Map(result?.staffs.map((s) => [s._id, s]));
     expect(staffById.get(staffBeforeDraftId)?.wasSubmittedAtDraft).toBe(true);
@@ -284,7 +285,7 @@ describe("shiftBoard/queries", () => {
 
   it("draftSavedAtがない既存データは保存済み割当の作成時刻を使う", async () => {
     const t = convexTest(schema, modules);
-    const { recruitmentId, staffId } = await t.run(async (ctx) => {
+    const { shopId, recruitmentId, staffId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_legacy_draft", shopName: "テスト店舗" });
       const staffId = await ctx.db.insert("staffs", {
         shopId,
@@ -323,12 +324,12 @@ describe("shiftBoard/queries", () => {
         endTime: "18:00",
         positionId,
       });
-      return { recruitmentId, staffId };
+      return { shopId, recruitmentId, staffId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_legacy_draft" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.recruitment.draftSavedAt).toBeTypeOf("number");
     expect(result?.staffs.find((s) => s._id === staffId)?.wasSubmittedAtDraft).toBe(true);
@@ -336,9 +337,9 @@ describe("shiftBoard/queries", () => {
 
   it("分つきシフト時間は表示用に丸めつつ編集可能境界を分で返す", async () => {
     const t = convexTest(schema, modules);
-    const recruitmentId = await t.run(async (ctx) => {
+    const { shopId, recruitmentId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_half_hour", shopName: "テスト店舗" });
-      return await ctx.db.insert("recruitments", {
+      const recruitmentId = await ctx.db.insert("recruitments", {
         shopId,
         periodStart: "2026-04-01",
         periodEnd: "2026-04-07",
@@ -348,11 +349,12 @@ describe("shiftBoard/queries", () => {
         isDeleted: false,
         submissionPattern: { kind: "time", startTime: "05:30", endTime: "22:30" },
       });
+      return { shopId, recruitmentId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_half_hour" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.timeRange).toEqual({
       start: 5,
@@ -365,9 +367,9 @@ describe("shiftBoard/queries", () => {
 
   it("募集スナップショットの時間指定を店舗設定より優先する", async () => {
     const t = convexTest(schema, modules);
-    const recruitmentId = await t.run(async (ctx) => {
+    const { shopId, recruitmentId } = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, { subject: "manager_snapshot", shopName: "テスト店舗" });
-      return await ctx.db.insert("recruitments", {
+      const recruitmentId = await ctx.db.insert("recruitments", {
         shopId,
         periodStart: "2026-04-01",
         periodEnd: "2026-04-07",
@@ -377,11 +379,12 @@ describe("shiftBoard/queries", () => {
         isDeleted: false,
         submissionPattern: { kind: "time", startTime: "05:30", endTime: "22:30" },
       });
+      return { shopId, recruitmentId };
     });
 
     const result = await t
       .withIdentity({ subject: "manager_snapshot" })
-      .query(api.shiftBoard.queries.getShiftBoardData, { recruitmentId });
+      .query(api.shiftBoard.queries.getShiftBoardData, { shopId, recruitmentId });
 
     expect(result?.timeRange.editableStartMinutes).toBe(330);
     expect(result?.timeRange.editableEndMinutes).toBe(1350);

--- a/convex/shiftBoard/queries.ts
+++ b/convex/shiftBoard/queries.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { managerQuery } from "../_lib/functions";
-import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import { getSubmissionPatternTimeRange } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import {
   SHIFT_ASSIGNMENT_LIMIT,
@@ -8,19 +8,8 @@ import {
   SHIFT_BOARD_STAFF_LIMIT,
   SHIFT_BOARD_TIME_UNIT_MINUTES,
 } from "../constants";
+import { getActiveRecruitmentInShop } from "../recruitment/service";
 import { isShiftTargetStaff } from "../staff/service";
-
-function getBoardTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
-  if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
-  if (pattern.kind === "shiftType" && pattern.options.length > 0) {
-    const starts = pattern.options
-      .map((option) => option.startTime)
-      .sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    const ends = pattern.options.map((option) => option.endTime).sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    return { startTime: starts[0], endTime: ends[ends.length - 1] };
-  }
-  return { startTime: "09:00", endTime: "22:00" };
-}
 
 export const getShiftBoardData = managerQuery({
   args: {
@@ -30,8 +19,8 @@ export const getShiftBoardData = managerQuery({
     const { shop } = ctx;
     if (!shop) return null;
 
-    const recruitment = await ctx.db.get(args.recruitmentId);
-    if (!recruitment || recruitment.isDeleted || recruitment.shopId !== shop._id) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, shop._id, args.recruitmentId);
+    if (!recruitment) {
       return null;
     }
 
@@ -71,7 +60,7 @@ export const getShiftBoardData = managerQuery({
 
     // TimeRange.start/end は「時」の数値を期待（9, 22 等）
     const submissionPattern = recruitment.submissionPattern;
-    const { startTime: startTimeStr, endTime: endTimeStr } = getBoardTimeRange(submissionPattern);
+    const { startTime: startTimeStr, endTime: endTimeStr } = getSubmissionPatternTimeRange(submissionPattern);
     const editableStartMinutes = timeToMinutes(startTimeStr);
     const editableEndMinutes = timeToMinutes(endTimeStr);
     const startHour = Math.floor(editableStartMinutes / 60);

--- a/convex/shiftBoard/validation.test.ts
+++ b/convex/shiftBoard/validation.test.ts
@@ -3,7 +3,6 @@ import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import {
   type AssignmentIssue,
   buildAssignmentIssue,
-  getBoardTimeRange,
   parseShiftAssignmentValidationError,
   SHIFT_ASSIGNMENT_VALIDATION,
   validateShiftAssignments,
@@ -33,20 +32,6 @@ const assignment = (
   startTime: "10:00",
   endTime: "18:00",
   ...overrides,
-});
-
-describe("getBoardTimeRange", () => {
-  it("time提出はそのままの時間範囲を返す", () => {
-    expect(getBoardTimeRange(TIME_PATTERN)).toEqual({ startTime: "09:00", endTime: "22:00" });
-  });
-
-  it("shiftType提出は全区分の最小開始〜最大終了を返す", () => {
-    expect(getBoardTimeRange(SHIFT_TYPE_PATTERN)).toEqual({ startTime: "09:00", endTime: "21:00" });
-  });
-
-  it("dateOnly提出はデフォルトの時間範囲を返す", () => {
-    expect(getBoardTimeRange({ kind: "dateOnly" })).toEqual({ startTime: "09:00", endTime: "22:00" });
-  });
 });
 
 describe("validateShiftAssignments", () => {

--- a/convex/shiftBoard/validation.ts
+++ b/convex/shiftBoard/validation.ts
@@ -1,4 +1,4 @@
-import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import { getSubmissionPatternTimeRange, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { isSupportedShiftTime, timeToMinutes } from "../_lib/time";
 import { isValidIsoDateString } from "../_lib/validation";
 
@@ -51,18 +51,6 @@ export function buildAssignmentIssue(code: AssignmentIssueCode, date: string, st
   return { code, date, staffId, message: ISSUE_MESSAGES[code] };
 }
 
-export function getBoardTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
-  if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
-  if (pattern.kind === "shiftType" && pattern.options.length > 0) {
-    const starts = pattern.options
-      .map((option) => option.startTime)
-      .sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    const ends = pattern.options.map((option) => option.endTime).sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    return { startTime: starts[0], endTime: ends[ends.length - 1] };
-  }
-  return { startTime: "09:00", endTime: "22:00" };
-}
-
 export type ShiftAssignmentValidationInput = {
   assignments: Array<{ staffId: string; date: string; startTime: string; endTime: string; optionId?: string }>;
   periodStart: string;
@@ -75,7 +63,7 @@ export type ShiftAssignmentValidationInput = {
 // 1つのassignmentに複数の違反がある場合はチェック順で最初の1件のみ報告する
 // （例: 時間順序が不正なら、ボード時間外チェックの誤検知を重ねて出さない）。
 export function validateShiftAssignments(input: ShiftAssignmentValidationInput): AssignmentIssue[] {
-  const { startTime, endTime } = getBoardTimeRange(input.pattern);
+  const { startTime, endTime } = getSubmissionPatternTimeRange(input.pattern);
   const boardStartMinutes = timeToMinutes(startTime);
   const boardEndMinutes = timeToMinutes(endTime);
   const closedDateSet = new Set(input.closedDates);

--- a/convex/shiftSubmission/mutations.ts
+++ b/convex/shiftSubmission/mutations.ts
@@ -6,6 +6,7 @@ import { rateLimit } from "../_lib/rateLimits";
 import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { hasCurrentStaffLegalConsent, recordStaffLegalConsent } from "../legal/service";
+import { getActiveRecruitmentInShop } from "../recruitment/service";
 import { type SubmitShiftSelection, submitShiftRequestsSchema, submitShiftSelectionSchema } from "./schemas";
 
 type NormalizedShiftRequest = { date: string; startTime: string; endTime: string; optionId?: string };
@@ -150,8 +151,8 @@ export const submitShiftRequests = staffSessionMutation({
       throw new ConvexError("Not found");
     }
 
-    const recruitment = await ctx.db.get(args.recruitmentId);
-    if (!recruitment || recruitment.isDeleted || recruitment.shopId !== ctx.shop._id) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, ctx.shop._id, args.recruitmentId);
+    if (!recruitment) {
       throw new ConvexError("Not found");
     }
     if (recruitment.status !== "open") {

--- a/convex/shiftSubmission/queries.ts
+++ b/convex/shiftSubmission/queries.ts
@@ -2,8 +2,7 @@ import { v } from "convex/values";
 import { getDeadlineCutoff, getSubmitLinkCutoff } from "../_lib/dateFormat";
 import { staffSessionQuery } from "../_lib/functions";
 import { getPreviousDateOnlyPattern, getPreviousWeeklyPattern } from "../_lib/previousWeeklyPattern";
-import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
-import { timeToMinutes } from "../_lib/time";
+import { getSubmissionPatternTimeRange, type ShiftSubmissionPattern } from "../_lib/submissionPattern";
 import { getLegalDocumentsForAudience } from "../legal/documents";
 import { hasCurrentStaffLegalConsent } from "../legal/service";
 
@@ -12,18 +11,6 @@ type SubmissionUnavailableReason = "invalid_link" | "recruitment_deleted" | "sub
 
 function unavailable(reason: SubmissionUnavailableReason) {
   return { status: "unavailable" as const, reason };
-}
-
-function getSubmissionTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
-  if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
-  if (pattern.kind === "shiftType" && pattern.options.length > 0) {
-    const starts = pattern.options
-      .map((option) => option.startTime)
-      .sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    const ends = pattern.options.map((option) => option.endTime).sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    return { startTime: starts[0], endTime: ends[ends.length - 1] };
-  }
-  return { startTime: "09:00", endTime: "22:00" };
 }
 
 function buildExistingSelection(pattern: ShiftSubmissionPattern, requests: ExistingRequest[], dates: string[]) {
@@ -107,7 +94,7 @@ export const getSubmissionPageData = staffSessionQuery({
       ...(r.optionId ? { optionId: r.optionId } : {}),
     }));
     const existingDates = dateEntries.map((entry) => entry.date);
-    const timeRange = getSubmissionTimeRange(submissionPattern);
+    const timeRange = getSubmissionPatternTimeRange(submissionPattern);
 
     return {
       status: "ok" as const,

--- a/convex/shiftView/queries.ts
+++ b/convex/shiftView/queries.ts
@@ -1,22 +1,11 @@
 import { v } from "convex/values";
 import { formatPeriodLabel } from "../_lib/dateFormat";
 import { staffSessionQuery } from "../_lib/functions";
-import type { ShiftSubmissionPattern } from "../_lib/submissionPattern";
+import { getSubmissionPatternTimeRange } from "../_lib/submissionPattern";
 import { timeToMinutes } from "../_lib/time";
 import { SHIFT_ASSIGNMENT_LIMIT, SHIFT_BOARD_STAFF_LIMIT, SHIFT_BOARD_TIME_UNIT_MINUTES } from "../constants";
+import { getActiveRecruitmentInShop } from "../recruitment/service";
 import { isShiftTargetStaff } from "../staff/service";
-
-function getViewTimeRange(pattern: ShiftSubmissionPattern): { startTime: string; endTime: string } {
-  if (pattern.kind === "time") return { startTime: pattern.startTime, endTime: pattern.endTime };
-  if (pattern.kind === "shiftType" && pattern.options.length > 0) {
-    const starts = pattern.options
-      .map((option) => option.startTime)
-      .sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    const ends = pattern.options.map((option) => option.endTime).sort((a, b) => timeToMinutes(a) - timeToMinutes(b));
-    return { startTime: starts[0], endTime: ends[ends.length - 1] };
-  }
-  return { startTime: "09:00", endTime: "22:00" };
-}
 
 export const getShiftViewData = staffSessionQuery({
   args: { recruitmentId: v.id("recruitments") },
@@ -26,13 +15,8 @@ export const getShiftViewData = staffSessionQuery({
     const session = ctx.session;
     if (session.recruitmentId !== recruitmentId) return null;
 
-    const recruitment = await ctx.db.get(recruitmentId);
-    if (
-      !recruitment ||
-      recruitment.isDeleted ||
-      recruitment.shopId !== shop._id ||
-      recruitment.status !== "confirmed"
-    ) {
+    const recruitment = await getActiveRecruitmentInShop(ctx, shop._id, recruitmentId);
+    if (recruitment?.status !== "confirmed") {
       return null;
     }
 
@@ -52,7 +36,7 @@ export const getShiftViewData = staffSessionQuery({
     ]);
 
     const submissionPattern = recruitment.submissionPattern;
-    const { startTime: startTimeStr, endTime: endTimeStr } = getViewTimeRange(submissionPattern);
+    const { startTime: startTimeStr, endTime: endTimeStr } = getSubmissionPatternTimeRange(submissionPattern);
     const editableStartMinutes = timeToMinutes(startTimeStr);
     const editableEndMinutes = timeToMinutes(endTimeStr);
 

--- a/convex/shop/mutations.test.ts
+++ b/convex/shop/mutations.test.ts
@@ -16,18 +16,40 @@ const MANAGER_SUBJECT = "user_manager";
 
 describe("shop/mutations", () => {
   describe("updateShopSettings", () => {
+    it("shopIdを省略した旧クライアントは先頭の有効所属店舗を更新できる", async () => {
+      const t = convexTest(schema, modules);
+      const shopId = await t.run(async (ctx) => {
+        const { shopId } = await seedManagerShop(ctx, {
+          subject: MANAGER_SUBJECT,
+          email: "yamada@example.com",
+          shopName: "居酒屋たなか",
+        });
+        return shopId;
+      });
+      const asManager = t.withIdentity({ subject: MANAGER_SUBJECT });
+
+      await asManager.mutation(api.shop.mutations.updateShopSettings, validArgs);
+
+      const shop = await t.run(async (ctx) => ctx.db.get(shopId));
+      expect(shop?.name).toBe("新・居酒屋たなか");
+    });
+
     it("未認証の場合エラーをthrowする", async () => {
       const t = convexTest(schema, modules);
-      await expect(t.mutation(api.shop.mutations.updateShopSettings, validArgs)).rejects.toThrow();
+      const shopId = await t.run(async (ctx) => seedShop(ctx));
+      await expect(t.mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId })).rejects.toThrow();
     });
 
     it("店舗が存在しないマネージャーは Not found でエラー", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         await seedUser(ctx, "user_no_shop", "noshop@example.com");
+        return seedShop(ctx);
       });
       await expect(
-        t.withIdentity({ subject: "user_no_shop" }).mutation(api.shop.mutations.updateShopSettings, validArgs),
+        t
+          .withIdentity({ subject: "user_no_shop" })
+          .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId }),
       ).rejects.toThrow();
     });
 
@@ -44,6 +66,7 @@ describe("shop/mutations", () => {
 
       await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
         ...validArgs,
+        shopId,
         regularClosedDays: ["tue", "mon", "mon"],
       });
 
@@ -66,6 +89,7 @@ describe("shop/mutations", () => {
 
       await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
         ...validArgs,
+        shopId,
         submissionPattern: { kind: "dateOnly" },
       });
 
@@ -86,7 +110,7 @@ describe("shop/mutations", () => {
 
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
-        .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopName: "  スペース入り  " });
+        .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId, shopName: "  スペース入り  " });
 
       const shop = await t.run(async (ctx) => ctx.db.get(shopId));
       expect(shop?.name).toBe("スペース入り");
@@ -94,57 +118,62 @@ describe("shop/mutations", () => {
 
     it("空の店舗名は ConvexError", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t
           .withIdentity({ subject: MANAGER_SUBJECT })
-          .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopName: "   " }),
+          .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId, shopName: "   " }),
       ).rejects.toThrow(ConvexError);
     });
 
     it("過長店舗名と制御文字入り店舗名は更新できない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           shopName: "あ".repeat(SHOP_NAME_MAX_LENGTH + 1),
         }),
       ).rejects.toThrow("店舗名は80文字以内で入力してください");
       await expect(
         t
           .withIdentity({ subject: MANAGER_SUBJECT })
-          .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopName: "店舗\n名" }),
+          .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId, shopName: "店舗\n名" }),
       ).rejects.toThrow("店舗名に使用できない文字が含まれています");
     });
 
     it("時間指定の終了時間 <= 開始時間は ConvexError", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: { kind: "time", startTime: "22:00", endTime: "22:00" },
         }),
       ).rejects.toThrow(ConvexError);
@@ -152,6 +181,7 @@ describe("shop/mutations", () => {
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: { kind: "time", startTime: "22:00", endTime: "20:00" },
         }),
       ).rejects.toThrow(ConvexError);
@@ -159,17 +189,19 @@ describe("shop/mutations", () => {
 
     it("時間指定の対応範囲外の時刻は ConvexError", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: { kind: "time", startTime: "10:00", endTime: "99:00" },
         }),
       ).rejects.toThrow(ConvexError);
@@ -188,6 +220,7 @@ describe("shop/mutations", () => {
 
       await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
         ...validArgs,
+        shopId,
         submissionPattern: { kind: "time", startTime: "00:00", endTime: "36:00" },
       });
 
@@ -217,7 +250,9 @@ describe("shop/mutations", () => {
         return { shopId, recruitmentId };
       });
 
-      await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, validArgs);
+      await t
+        .withIdentity({ subject: MANAGER_SUBJECT })
+        .mutation(api.shop.mutations.updateShopSettings, { ...validArgs, shopId });
 
       const shop = await t.run(async (ctx) => ctx.db.get(shopId));
       const recruitment = await t.run(async (ctx) => ctx.db.get(recruitmentId));
@@ -238,6 +273,7 @@ describe("shop/mutations", () => {
 
       await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
         ...validArgs,
+        shopId,
         submissionPattern: {
           kind: "shiftType",
           options: [
@@ -261,17 +297,19 @@ describe("shop/mutations", () => {
 
     it("勤務区分 option id の重複は更新できない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: [
@@ -285,17 +323,19 @@ describe("shop/mutations", () => {
 
     it("不正な勤務区分時刻は ConvexError", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: [{ id: "morning", name: "早番", startTime: "bad", endTime: "15:00", sortOrder: 0 }],
@@ -306,6 +346,7 @@ describe("shop/mutations", () => {
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: [{ id: "night", name: "深夜", startTime: "10:00", endTime: "99:00", sortOrder: 0 }],
@@ -316,17 +357,19 @@ describe("shop/mutations", () => {
 
     it("過長・制御文字入りの勤務区分名は更新できない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: [
@@ -344,6 +387,7 @@ describe("shop/mutations", () => {
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: [{ id: "control", name: "早\n番", startTime: "09:00", endTime: "18:00", sortOrder: 0 }],
@@ -365,6 +409,7 @@ describe("shop/mutations", () => {
 
       await t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
         ...validArgs,
+        shopId,
         submissionPattern: {
           kind: "shiftType",
           options: [{ id: "night", name: "深夜", startTime: "24:00", endTime: "36:00", sortOrder: 0 }],
@@ -380,17 +425,19 @@ describe("shop/mutations", () => {
 
     it("4件を超える勤務区分は更新できない", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, {
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
           subject: MANAGER_SUBJECT,
           email: "yamada@example.com",
           shopName: "居酒屋たなか",
         });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.updateShopSettings, {
           ...validArgs,
+          shopId,
           submissionPattern: {
             kind: "shiftType",
             options: Array.from({ length: 5 }, (_, index) => ({
@@ -415,7 +462,7 @@ describe("shop/mutations", () => {
     it("未認証の場合エラーをthrowする", async () => {
       const t = convexTest(schema, modules);
       const shopId = await t.run(async (ctx) => seedShop(ctx));
-      await expect(t.mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId })).rejects.toThrow();
+      await expect(t.mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId, shopId })).rejects.toThrow();
     });
 
     it("店舗が存在しないマネージャーは Not found でエラー", async () => {
@@ -425,7 +472,9 @@ describe("shop/mutations", () => {
         return seedShop(ctx);
       });
       await expect(
-        t.withIdentity({ subject: "user_no_shop" }).mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId }),
+        t
+          .withIdentity({ subject: "user_no_shop" })
+          .mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId, shopId }),
       ).rejects.toThrow();
     });
 
@@ -443,6 +492,7 @@ describe("shop/mutations", () => {
       await expect(
         t.withIdentity({ subject: MANAGER_SUBJECT }).mutation(api.shop.mutations.deleteShop, {
           confirmShopId: otherShopId,
+          shopId: ownShopId,
         }),
       ).rejects.toThrow();
 
@@ -526,7 +576,7 @@ describe("shop/mutations", () => {
 
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
-        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId });
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId, shopId: ids.shopId });
       await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {
@@ -568,7 +618,7 @@ describe("shop/mutations", () => {
 
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
-        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ownShopId });
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ownShopId, shopId: ownShopId });
       await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {
@@ -622,7 +672,7 @@ describe("shop/mutations", () => {
 
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
-        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId });
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: ids.shopId, shopId: ids.shopId });
       await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {
@@ -675,7 +725,7 @@ describe("shop/mutations", () => {
 
       await t
         .withIdentity({ subject: MANAGER_SUBJECT })
-        .mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId });
+        .mutation(api.shop.mutations.deleteShop, { confirmShopId: shopId, shopId });
       await t.finishAllScheduledFunctions(vi.runAllTimers);
 
       await t.run(async (ctx) => {

--- a/convex/shop/mutations.ts
+++ b/convex/shop/mutations.ts
@@ -86,10 +86,10 @@ export const updateShopSettings = managerMutation({
  * トークン無効化、配信予約済み通知のキャンセルは、大規模店舗でもトランザクション
  * 上限を超えないよう分割実行する（unbounded な collect を避ける）。
  *
- * managerMutation は shopId 省略時に「先頭の所属店舗」へフォールバックするため、
- * 複数店舗マネージャーがうっかり別テナントを消す事故が起きうる。破壊的操作なので
- * 削除対象を `confirmShopId` で明示させ、解決された店舗（ctx.shop）と一致しない限り
- * 実行しない（不一致は列挙対策のため "Not found" で区別しない）。
+ * managerMutation の必須 `shopId` で操作対象は確定するが、破壊的操作では呼び出し側が
+ * 確認画面で示した削除対象も `confirmShopId` として重ねて送る。両者が一致しない限り
+ * 実行しないことで、店舗選択変更や古い確認画面からの誤削除を防ぐ
+ * （不一致は列挙対策のため "Not found" で区別しない）。
  */
 export const deleteShop = managerMutation({
   args: {

--- a/convex/staff/mutations.test.ts
+++ b/convex/staff/mutations.test.ts
@@ -22,8 +22,10 @@ describe("staff/mutations", () => {
 
     it("未認証の場合エラーをthrow", async () => {
       const t = convexTest(schema, modules);
+      const shopId = await t.run(async (ctx) => await seedShop(ctx, "テスト店舗"));
       await expect(
         t.mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "テスト", email: "test@example.com" }],
         }),
       ).rejects.toThrow();
@@ -42,6 +44,7 @@ describe("staff/mutations", () => {
       });
 
       const ids = await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+        shopId,
         entries: [
           { name: "田中太郎", email: "tanaka@example.com" },
           { name: "佐藤花子", email: "sato@example.com" },
@@ -63,11 +66,17 @@ describe("staff/mutations", () => {
     it("追加スタッフ向けの同意依頼メールとLINE連携メールをスケジュールする", async () => {
       const t = convexTest(schema, modules);
 
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_mgr", email: "mgr@example.com", shopName: "テスト店舗" });
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        return seeded.shopId;
       });
 
       const [staffId] = await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+        shopId,
         entries: [{ name: "田中太郎", email: "tanaka@example.com" }],
       });
 
@@ -83,11 +92,17 @@ describe("staff/mutations", () => {
     it("空の name のエントリはスキップする", async () => {
       const t = convexTest(schema, modules);
 
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_mgr", email: "mgr@example.com", shopName: "テスト店舗" });
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        return seeded.shopId;
       });
 
       const ids = await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+        shopId,
         entries: [
           { name: "田中太郎", email: "tanaka@example.com" },
           { name: "", email: "" },
@@ -100,12 +115,18 @@ describe("staff/mutations", () => {
 
     it("一度に50件を超えるスタッフ追加は拒否する", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_mgr", email: "mgr@example.com", shopName: "テスト店舗" });
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        return seeded.shopId;
       });
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: Array.from({ length: STAFF_ADD_ENTRIES_MAX + 1 }, (_, index) => ({
             name: `スタッフ${index + 1}`,
             email: `staff-${index + 1}@example.com`,
@@ -129,7 +150,10 @@ describe("staff/mutations", () => {
         email: `staff-${index + 1}@example.com`,
       }));
 
-      const ids = await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, { entries });
+      const ids = await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+        shopId,
+        entries,
+      });
 
       expect(ids).toHaveLength(STAFF_ADD_ENTRIES_MAX);
       const staffs = await t.run(async (ctx) =>
@@ -143,23 +167,31 @@ describe("staff/mutations", () => {
 
     it("過長名・制御文字入り名・不正メールはスタッフ追加で拒否する", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
-        await seedManagerShop(ctx, { subject: "user_mgr", email: "mgr@example.com", shopName: "テスト店舗" });
+      const shopId = await t.run(async (ctx) => {
+        const seeded = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        return seeded.shopId;
       });
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       await expect(
         asManager.mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "あ".repeat(PERSON_NAME_MAX_LENGTH + 1), email: "too-long@example.com" }],
         }),
       ).rejects.toThrow("名前は80文字以内で入力してください");
       await expect(
         asManager.mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "田中\n太郎", email: "control@example.com" }],
         }),
       ).rejects.toThrow("名前に使用できない文字が含まれています");
       await expect(
         asManager.mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "不正メール", email: "not-email" }],
         }),
       ).rejects.toThrow("メールアドレスの形式で入力してください");
@@ -185,6 +217,7 @@ describe("staff/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [
             { name: "新規スタッフ", email: "new@example.com" },
             { name: "重複スタッフ", email: "existing@example.com" },
@@ -215,10 +248,12 @@ describe("staff/mutations", () => {
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       const firstIds = await asManager.mutation(api.staff.mutations.addStaffs, {
+        shopId,
         entries: [{ name: "田中太郎", email: "tanaka@example.com" }],
       });
       await expect(
         asManager.mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "田中太郎", email: "Tanaka@Example.com" }],
         }),
       ).rejects.toThrow("このメールアドレスはすでに登録されています");
@@ -245,7 +280,7 @@ describe("staff/mutations", () => {
     it("emailNormalizedがない既存スタッフもメール重複としてエラーにする", async () => {
       const t = convexTest(schema, modules);
 
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
@@ -257,10 +292,12 @@ describe("staff/mutations", () => {
           email: "legacy@example.com",
           isDeleted: false,
         });
+        return shopId;
       });
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "新規スタッフ", email: "legacy@example.com" }],
         }),
       ).rejects.toThrow("このメールアドレスはすでに登録されています");
@@ -269,7 +306,7 @@ describe("staff/mutations", () => {
     it("承認待ち申請と同じメールアドレスはエラーにする", async () => {
       const t = convexTest(schema, modules);
 
-      await t.run(async (ctx) => {
+      const shopId = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
@@ -287,10 +324,12 @@ describe("staff/mutations", () => {
           consentedAt: now,
           createdAt: now,
         });
+        return shopId;
       });
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.addStaffs, {
+          shopId,
           entries: [{ name: "新規スタッフ", email: "Pending@Example.com" }],
         }),
       ).rejects.toThrow("このメールアドレスは承認待ちです");
@@ -364,7 +403,7 @@ describe("staff/mutations", () => {
     it("募集通知の手動再送は対象募集がない場合に予約せず理由を返す", async () => {
       const t = convexTest(schema, modules);
 
-      const staffId = await t.run(async (ctx) => {
+      const { shopId, staffId } = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
@@ -386,12 +425,12 @@ describe("staff/mutations", () => {
           isDeleted: false,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
-        return staffId;
+        return { shopId, staffId };
       });
 
       const result = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.sendOpenRecruitmentNotifications, { staffId });
+        .mutation(api.staff.mutations.sendOpenRecruitmentNotifications, { shopId, staffId });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(result).toEqual({ scheduled: false, reason: "noEligibleRecruitments" });
@@ -403,7 +442,7 @@ describe("staff/mutations", () => {
     it("募集通知の手動再送は対象募集がある場合だけ予約する", async () => {
       const t = convexTest(schema, modules);
 
-      const staffId = await t.run(async (ctx) => {
+      const { shopId, staffId } = await t.run(async (ctx) => {
         const { shopId } = await seedManagerShop(ctx, {
           subject: "user_mgr",
           email: "mgr@example.com",
@@ -425,12 +464,12 @@ describe("staff/mutations", () => {
           isDeleted: false,
           submissionPattern: { kind: "time", startTime: "09:00", endTime: "22:00" },
         });
-        return staffId;
+        return { shopId, staffId };
       });
 
       const result = await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.sendOpenRecruitmentNotifications, { staffId });
+        .mutation(api.staff.mutations.sendOpenRecruitmentNotifications, { shopId, staffId });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(result).toEqual({ scheduled: true });
@@ -465,19 +504,27 @@ describe("staff/mutations", () => {
 
     it("未認証の場合エラーをthrow", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
       await expect(
-        t.mutation(api.staff.mutations.editStaff, { staffId, name: "更新後", email: "updated@example.com" }),
+        t.mutation(api.staff.mutations.editStaff, {
+          shopId,
+          staffId,
+          name: "更新後",
+          email: "updated@example.com",
+        }),
       ).rejects.toThrow();
     });
 
     it("スタッフ情報を更新できる", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.editStaff, { staffId, name: "田中花子", email: "tanaka@example.com" });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+        shopId,
+        staffId,
+        name: "田中花子",
+        email: "tanaka@example.com",
+      });
 
       const staff = await t.run(async (ctx) => ctx.db.get(staffId));
       expect(staff?.name).toBe("田中花子");
@@ -486,11 +533,14 @@ describe("staff/mutations", () => {
 
     it("メールアドレス変更時は募集中シフト通知の追送actionをスケジュールする", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.editStaff, { staffId, name: "田中太郎", email: "updated@example.com" });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+        shopId,
+        staffId,
+        name: "田中太郎",
+        email: "updated@example.com",
+      });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(
@@ -506,11 +556,14 @@ describe("staff/mutations", () => {
 
     it("名前だけの変更では募集中シフト通知の追送actionをスケジュールしない", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.editStaff, { staffId, name: "田中太郎 更新", email: "tanaka@example.com" });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+        shopId,
+        staffId,
+        name: "田中太郎 更新",
+        email: "tanaka@example.com",
+      });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(
@@ -522,11 +575,14 @@ describe("staff/mutations", () => {
 
     it("同一メールの大文字小文字・前後空白差分では募集中シフト通知の追送actionをスケジュールしない", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.editStaff, { staffId, name: "田中太郎", email: "  Tanaka@Example.com  " });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+        shopId,
+        staffId,
+        name: "田中太郎",
+        email: "  Tanaka@Example.com  ",
+      });
 
       const scheduled = await t.run(async (ctx) => await ctx.db.system.query("_scheduled_functions").collect());
       expect(
@@ -538,10 +594,11 @@ describe("staff/mutations", () => {
 
     it("空メールへの変更は拒否する", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "田中太郎",
           email: "",
@@ -551,11 +608,12 @@ describe("staff/mutations", () => {
 
     it("過長名・制御文字入り名・不正メールはスタッフ編集で拒否する", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
       const asManager = t.withIdentity({ subject: "user_mgr" });
 
       await expect(
         asManager.mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "あ".repeat(PERSON_NAME_MAX_LENGTH + 1),
           email: "tanaka@example.com",
@@ -563,6 +621,7 @@ describe("staff/mutations", () => {
       ).rejects.toThrow("名前は80文字以内で入力してください");
       await expect(
         asManager.mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "田中\n太郎",
           email: "tanaka@example.com",
@@ -570,6 +629,7 @@ describe("staff/mutations", () => {
       ).rejects.toThrow("名前に使用できない文字が含まれています");
       await expect(
         asManager.mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "田中太郎",
           email: "not-email",
@@ -578,7 +638,8 @@ describe("staff/mutations", () => {
     });
 
     it("他店舗のスタッフは編集できない（IDOR）", async () => {
-      const { t } = setupShopWithStaff();
+      const { t, data } = setupShopWithStaff();
+      const { shopId } = await data;
 
       const otherStaffId = await t.run(async (ctx) => {
         const otherShopId = await seedShop(ctx, "他店舗");
@@ -592,6 +653,7 @@ describe("staff/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId: otherStaffId,
           name: "不正更新",
           email: "hack@example.com",
@@ -601,7 +663,7 @@ describe("staff/mutations", () => {
 
     it("削除済みスタッフは編集できない", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
       await t.run(async (ctx) => {
         await ctx.db.patch(staffId, { isDeleted: true });
@@ -609,6 +671,7 @@ describe("staff/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "更新後",
           email: "updated@example.com",
@@ -631,6 +694,7 @@ describe("staff/mutations", () => {
 
       await expect(
         t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+          shopId,
           staffId,
           name: "田中太郎",
           email: "sato@example.com",
@@ -640,11 +704,14 @@ describe("staff/mutations", () => {
 
     it("自分自身のメールアドレスはそのまま更新可能", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.editStaff, { staffId, name: "田中太郎（更新）", email: "tanaka@example.com" });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.editStaff, {
+        shopId,
+        staffId,
+        name: "田中太郎（更新）",
+        email: "tanaka@example.com",
+      });
 
       const staff = await t.run(async (ctx) => ctx.db.get(staffId));
       expect(staff?.name).toBe("田中太郎（更新）");
@@ -655,108 +722,23 @@ describe("staff/mutations", () => {
   describe("deleteStaff", () => {
     it("未認証の場合エラーをthrow", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
-      await expect(t.mutation(api.staff.mutations.deleteStaff, { staffId })).rejects.toThrow();
+      const { shopId, staffId } = await data;
+      await expect(t.mutation(api.staff.mutations.deleteStaff, { shopId, staffId })).rejects.toThrow();
     });
 
     it("スタッフを論理削除できる", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
+      const { shopId, staffId } = await data;
 
-      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.deleteStaff, { staffId });
+      await t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.deleteStaff, { shopId, staffId });
 
       const staff = await t.run(async (ctx) => ctx.db.get(staffId));
       expect(staff?.isDeleted).toBe(true);
     });
 
     it("他店舗のスタッフは削除できない（IDOR）", async () => {
-      const { t } = setupShopWithStaff();
-
-      const otherStaffId = await t.run(async (ctx) => {
-        const otherShopId = await seedShop(ctx, "他店舗");
-        return await ctx.db.insert("staffs", {
-          shopId: otherShopId,
-          name: "他店スタッフ",
-          email: "other@example.com",
-          isDeleted: false,
-        });
-      });
-
-      await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.deleteStaff, { staffId: otherStaffId }),
-      ).rejects.toThrow("Not found");
-    });
-
-    it("管理者自身は削除できない", async () => {
-      const t = convexTest(schema, modules);
-
-      const adminStaffId = await t.run(async (ctx) => {
-        const { userId, shopId } = await seedManagerShop(ctx, {
-          subject: "user_mgr",
-          email: "mgr@example.com",
-          shopName: "テスト店舗",
-        });
-        return await ctx.db.insert("staffs", {
-          shopId,
-          name: "管理者",
-          email: "mgr@example.com",
-          userId,
-          isDeleted: false,
-        });
-      });
-
-      await expect(
-        t.withIdentity({ subject: "user_mgr" }).mutation(api.staff.mutations.deleteStaff, { staffId: adminStaffId }),
-      ).rejects.toThrow("自分のアカウントは削除できません");
-    });
-  });
-
-  describe("setShiftExclusion", () => {
-    it("未認証の場合エラーをthrow", async () => {
       const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
-      await expect(t.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true })).rejects.toThrow();
-    });
-
-    it("シフト対象外フラグをトグルできる", async () => {
-      const { t, data } = setupShopWithStaff();
-      const { staffId } = await data;
-      const asManager = t.withIdentity({ subject: "user_mgr" });
-
-      await asManager.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true });
-      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(true);
-
-      await asManager.mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: false });
-      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(false);
-    });
-
-    it("管理者自身もシフト対象外にできる（削除と異なる）", async () => {
-      const t = convexTest(schema, modules);
-
-      const adminStaffId = await t.run(async (ctx) => {
-        const { userId, shopId } = await seedManagerShop(ctx, {
-          subject: "user_mgr",
-          email: "mgr@example.com",
-          shopName: "テスト店舗",
-        });
-        return await ctx.db.insert("staffs", {
-          shopId,
-          name: "店舗共通アドレス",
-          email: "mgr@example.com",
-          userId,
-          isDeleted: false,
-        });
-      });
-
-      await t
-        .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.setShiftExclusion, { staffId: adminStaffId, excluded: true });
-
-      expect(await t.run(async (ctx) => (await ctx.db.get(adminStaffId))?.excludedFromShift)).toBe(true);
-    });
-
-    it("他店舗のスタッフは変更できない（IDOR）", async () => {
-      const { t } = setupShopWithStaff();
+      const { shopId } = await data;
 
       const otherStaffId = await t.run(async (ctx) => {
         const otherShopId = await seedShop(ctx, "他店舗");
@@ -771,7 +753,102 @@ describe("staff/mutations", () => {
       await expect(
         t
           .withIdentity({ subject: "user_mgr" })
-          .mutation(api.staff.mutations.setShiftExclusion, { staffId: otherStaffId, excluded: true }),
+          .mutation(api.staff.mutations.deleteStaff, { shopId, staffId: otherStaffId }),
+      ).rejects.toThrow("Not found");
+    });
+
+    it("管理者自身は削除できない", async () => {
+      const t = convexTest(schema, modules);
+
+      const { adminStaffId, shopId } = await t.run(async (ctx) => {
+        const { userId, shopId } = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        const adminStaffId = await ctx.db.insert("staffs", {
+          shopId,
+          name: "管理者",
+          email: "mgr@example.com",
+          userId,
+          isDeleted: false,
+        });
+        return { adminStaffId, shopId };
+      });
+
+      await expect(
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.staff.mutations.deleteStaff, { shopId, staffId: adminStaffId }),
+      ).rejects.toThrow("自分のアカウントは削除できません");
+    });
+  });
+
+  describe("setShiftExclusion", () => {
+    it("未認証の場合エラーをthrow", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { shopId, staffId } = await data;
+      await expect(
+        t.mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId, excluded: true }),
+      ).rejects.toThrow();
+    });
+
+    it("シフト対象外フラグをトグルできる", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { shopId, staffId } = await data;
+      const asManager = t.withIdentity({ subject: "user_mgr" });
+
+      await asManager.mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId, excluded: true });
+      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(true);
+
+      await asManager.mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId, excluded: false });
+      expect(await t.run(async (ctx) => (await ctx.db.get(staffId))?.excludedFromShift)).toBe(false);
+    });
+
+    it("管理者自身もシフト対象外にできる（削除と異なる）", async () => {
+      const t = convexTest(schema, modules);
+
+      const { adminStaffId, shopId } = await t.run(async (ctx) => {
+        const { userId, shopId } = await seedManagerShop(ctx, {
+          subject: "user_mgr",
+          email: "mgr@example.com",
+          shopName: "テスト店舗",
+        });
+        const adminStaffId = await ctx.db.insert("staffs", {
+          shopId,
+          name: "店舗共通アドレス",
+          email: "mgr@example.com",
+          userId,
+          isDeleted: false,
+        });
+        return { adminStaffId, shopId };
+      });
+
+      await t
+        .withIdentity({ subject: "user_mgr" })
+        .mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId: adminStaffId, excluded: true });
+
+      expect(await t.run(async (ctx) => (await ctx.db.get(adminStaffId))?.excludedFromShift)).toBe(true);
+    });
+
+    it("他店舗のスタッフは変更できない（IDOR）", async () => {
+      const { t, data } = setupShopWithStaff();
+      const { shopId } = await data;
+
+      const otherStaffId = await t.run(async (ctx) => {
+        const otherShopId = await seedShop(ctx, "他店舗");
+        return await ctx.db.insert("staffs", {
+          shopId: otherShopId,
+          name: "他店スタッフ",
+          email: "other@example.com",
+          isDeleted: false,
+        });
+      });
+
+      await expect(
+        t
+          .withIdentity({ subject: "user_mgr" })
+          .mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId: otherStaffId, excluded: true }),
       ).rejects.toThrow("Not found");
     });
 
@@ -811,7 +888,7 @@ describe("staff/mutations", () => {
 
       await t
         .withIdentity({ subject: "user_mgr" })
-        .mutation(api.staff.mutations.setShiftExclusion, { staffId, excluded: true });
+        .mutation(api.staff.mutations.setShiftExclusion, { shopId, staffId, excluded: true });
 
       const { session, magicLink } = await t.run(async (ctx) => ({
         session: await ctx.db.get(sessionId),
@@ -871,7 +948,7 @@ describe("staff/mutations", () => {
           });
         }
 
-        return { staffId, recruitmentIds };
+        return { shopId: managerShopId, staffId, recruitmentIds };
       });
     }
 
@@ -890,15 +967,17 @@ describe("staff/mutations", () => {
 
     it("未認証では通知を予約できない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t);
+      const { shopId, staffId } = await setupCurrentShiftNotification(t);
 
-      await expect(t.mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId })).rejects.toThrowError();
+      await expect(
+        t.mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId }),
+      ).rejects.toThrowError();
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
     });
 
     it("現在の確定シフトだけを対象に通知を1件予約する", async () => {
       const t = convexTest(schema, modules);
-      const { staffId, recruitmentIds } = await setupCurrentShiftNotification(t, {
+      const { shopId, staffId, recruitmentIds } = await setupCurrentShiftNotification(t, {
         windows: ["past", "current", "future"],
       });
 
@@ -907,7 +986,7 @@ describe("staff/mutations", () => {
       });
       const result = await t
         .withIdentity({ subject: "current_shift_manager" })
-        .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
+        .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId });
       const jobs = await getScheduledCurrentShiftNotifications(t);
 
       expect(notificationData?.recruitments.map((recruitment) => recruitment.recruitmentId)).toEqual([
@@ -920,11 +999,11 @@ describe("staff/mutations", () => {
 
     it("現在の確定シフトがなく過去・未来のシフトだけなら予約しない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t, { windows: ["past", "future"] });
+      const { shopId, staffId } = await setupCurrentShiftNotification(t, { windows: ["past", "future"] });
 
       const result = await t
         .withIdentity({ subject: "current_shift_manager" })
-        .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
+        .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId });
 
       expect(result).toEqual({ scheduled: false, reason: "noCurrentShift" });
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
@@ -932,35 +1011,35 @@ describe("staff/mutations", () => {
 
     it("他店舗のスタッフには通知を予約できない（IDOR）", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t, { otherShop: true });
+      const { shopId, staffId } = await setupCurrentShiftNotification(t, { otherShop: true });
 
       await expect(
         t
           .withIdentity({ subject: "current_shift_manager" })
-          .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId }),
+          .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId }),
       ).rejects.toThrowError("Not found");
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
     });
 
     it("削除済みスタッフには通知を予約できない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t, { staffDeleted: true });
+      const { shopId, staffId } = await setupCurrentShiftNotification(t, { staffDeleted: true });
 
       await expect(
         t
           .withIdentity({ subject: "current_shift_manager" })
-          .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId }),
+          .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId }),
       ).rejects.toThrowError("Not found");
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
     });
 
     it("シフト対象外スタッフには通知を予約しない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t, { excludedFromShift: true });
+      const { shopId, staffId } = await setupCurrentShiftNotification(t, { excludedFromShift: true });
 
       const result = await t
         .withIdentity({ subject: "current_shift_manager" })
-        .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
+        .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId });
 
       expect(result).toEqual({ scheduled: false, reason: "noCurrentShift" });
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
@@ -968,23 +1047,26 @@ describe("staff/mutations", () => {
 
     it("メール・LINE連携のないスタッフには通知を予約できない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t, { email: "" });
+      const { shopId, staffId } = await setupCurrentShiftNotification(t, { email: "" });
 
       await expect(
         t
           .withIdentity({ subject: "current_shift_manager" })
-          .mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId }),
+          .mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId }),
       ).rejects.toThrowError("メールアドレスまたはLINE連携が必要です");
       expect(await getScheduledCurrentShiftNotifications(t)).toHaveLength(0);
     });
 
     it("短時間の再送はrate limitで拒否し通知予約を重複させない", async () => {
       const t = convexTest(schema, modules);
-      const { staffId } = await setupCurrentShiftNotification(t);
+      const { shopId, staffId } = await setupCurrentShiftNotification(t);
       const asManager = t.withIdentity({ subject: "current_shift_manager" });
 
-      const first = await asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
-      const second = await asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, { staffId });
+      const first = await asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, { shopId, staffId });
+      const second = await asManager.mutation(api.staff.mutations.sendCurrentShiftNotification, {
+        shopId,
+        staffId,
+      });
 
       expect(first).toEqual({ scheduled: true });
       expect(second).toEqual({ scheduled: false, reason: "rateLimited" });

--- a/convex/staff/mutations.ts
+++ b/convex/staff/mutations.ts
@@ -6,7 +6,7 @@ import { managerMutation } from "../_lib/functions";
 import { rateLimit } from "../_lib/rateLimits";
 import { getStaffLineAccount } from "../line/service";
 import { addStaffsSchema, editStaffSchema } from "./schemas";
-import { findActiveStaffByEmail, normalizeEmail } from "./service";
+import { findActiveStaffByEmail, getActiveStaffInShop, normalizeEmail } from "./service";
 
 type StaffNotificationKind = "openRecruitments" | "currentShift";
 type ManagerStaffMutationCtx = MutationCtx & {
@@ -15,8 +15,8 @@ type ManagerStaffMutationCtx = MutationCtx & {
 };
 
 async function getSendableStaff(ctx: ManagerStaffMutationCtx, staffId: Id<"staffs">) {
-  const staff = await ctx.db.get(staffId);
-  if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted) {
+  const staff = await getActiveStaffInShop(ctx, ctx.shop._id, staffId);
+  if (!staff) {
     throw new ConvexError("Not found");
   }
 
@@ -117,8 +117,8 @@ export const editStaff = managerMutation({
       throw new ConvexError(parsed.error.issues[0]?.message ?? "入力内容を確認してください");
     }
     const input = parsed.data;
-    const staff = await ctx.db.get(args.staffId);
-    if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted) {
+    const staff = await getActiveStaffInShop(ctx, ctx.shop._id, args.staffId);
+    if (!staff) {
       throw new ConvexError("Not found");
     }
 
@@ -220,8 +220,8 @@ export const setShiftExclusion = managerMutation({
     excluded: v.boolean(),
   },
   handler: async (ctx, args) => {
-    const staff = await ctx.db.get(args.staffId);
-    if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted) {
+    const staff = await getActiveStaffInShop(ctx, ctx.shop._id, args.staffId);
+    if (!staff) {
       throw new ConvexError("Not found");
     }
     // 削除と異なり、管理者（店舗共通アドレス本人）もシフト対象外にできる（主ユースケース）。
@@ -256,8 +256,8 @@ export const deleteStaff = managerMutation({
     staffId: v.id("staffs"),
   },
   handler: async (ctx, args) => {
-    const staff = await ctx.db.get(args.staffId);
-    if (!staff || staff.shopId !== ctx.shop._id || staff.isDeleted) {
+    const staff = await getActiveStaffInShop(ctx, ctx.shop._id, args.staffId);
+    if (!staff) {
       throw new ConvexError("Not found");
     }
 

--- a/convex/staff/service.ts
+++ b/convex/staff/service.ts
@@ -1,5 +1,7 @@
 import type { Id } from "../_generated/dataModel";
-import type { MutationCtx } from "../_generated/server";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+
+type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
 
 export function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
@@ -11,6 +13,11 @@ export function normalizeEmail(email: string) {
  */
 export function isShiftTargetStaff(staff: { isDeleted: boolean; excludedFromShift?: boolean }) {
   return !staff.isDeleted && !staff.excludedFromShift;
+}
+
+export async function getActiveStaffInShop(ctx: DbCtx, shopId: Id<"shops">, staffId: Id<"staffs">) {
+  const staff = await ctx.db.get(staffId);
+  return staff && staff.shopId === shopId && !staff.isDeleted ? staff : null;
 }
 
 export async function findActiveStaffByEmail(

--- a/convex/staffRegistration/actions.test.ts
+++ b/convex/staffRegistration/actions.test.ts
@@ -7,7 +7,7 @@ import { modules, schema } from "../_test/setup.test-helper";
 describe("staffRegistration/actions", () => {
   it("店舗担当者digestのoutboxにuserIdを残す", async () => {
     const t = convexTest(schema, modules);
-    const { userId } = await t.run(async (ctx) => {
+    const { shopId, userId } = await t.run(async (ctx) => {
       return await seedManagerShop(ctx, {
         subject: "user_mgr",
         email: "owner-digest@example.com",
@@ -15,7 +15,9 @@ describe("staffRegistration/actions", () => {
       });
     });
     const asManager = t.withIdentity({ subject: "user_mgr" });
-    const registrationLink = await asManager.mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+    const registrationLink = await asManager.mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {
+      shopId,
+    });
     await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: registrationLink.token,
       name: "申請スタッフ",

--- a/convex/staffRegistration/mutations.test.ts
+++ b/convex/staffRegistration/mutations.test.ts
@@ -11,16 +11,17 @@ describe("staffRegistration/mutations", () => {
 
   it("店舗固定の登録リンクを作成し、再取得では同じリンクを返す", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, { subject: "manager_link", email: "manager-link@example.com" });
+    const shopId = await t.run(async (ctx) => {
+      const seeded = await seedManagerShop(ctx, { subject: "manager_link", email: "manager-link@example.com" });
+      return seeded.shopId;
     });
 
     const first = await t
       .withIdentity({ subject: "manager_link" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
     const second = await t
       .withIdentity({ subject: "manager_link" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
 
     expect(first.token).toBe(second.token);
     expect(first.registrationUrl).toContain(`/staff/register?token=${first.token}`);
@@ -28,12 +29,13 @@ describe("staffRegistration/mutations", () => {
 
   it("スタッフが登録リンクから参加申請できる", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, { subject: "manager_submit", email: "manager-submit@example.com" });
+    const shopId = await t.run(async (ctx) => {
+      const seeded = await seedManagerShop(ctx, { subject: "manager_submit", email: "manager-submit@example.com" });
+      return seeded.shopId;
     });
     const link = await t
       .withIdentity({ subject: "manager_submit" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
 
     await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
@@ -44,18 +46,22 @@ describe("staffRegistration/mutations", () => {
 
     const requests = await t
       .withIdentity({ subject: "manager_submit" })
-      .query(api.staffRegistration.queries.getPendingRequests, {});
+      .query(api.staffRegistration.queries.getPendingRequests, { shopId });
     expect(requests).toMatchObject([{ name: "申請スタッフ", email: "request@example.com" }]);
   });
 
   it("参加申請の入力内容をサーバー側でも検証する", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, { subject: "manager_validation", email: "manager-validation@example.com" });
+    const shopId = await t.run(async (ctx) => {
+      const seeded = await seedManagerShop(ctx, {
+        subject: "manager_validation",
+        email: "manager-validation@example.com",
+      });
+      return seeded.shopId;
     });
     const link = await t
       .withIdentity({ subject: "manager_validation" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
 
     await expect(
       t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
@@ -109,12 +115,16 @@ describe("staffRegistration/mutations", () => {
 
   it("同じメールアドレスの承認待ち申請は重複登録できない", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, { subject: "manager_duplicate", email: "manager-duplicate@example.com" });
+    const shopId = await t.run(async (ctx) => {
+      const seeded = await seedManagerShop(ctx, {
+        subject: "manager_duplicate",
+        email: "manager-duplicate@example.com",
+      });
+      return seeded.shopId;
     });
     const link = await t
       .withIdentity({ subject: "manager_duplicate" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
 
     await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
@@ -134,7 +144,7 @@ describe("staffRegistration/mutations", () => {
 
   it("既存スタッフと同じメールアドレスでは参加申請できない", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
+    const shopId = await t.run(async (ctx) => {
       const { shopId } = await seedManagerShop(ctx, {
         subject: "manager_existing_staff",
         email: "manager-existing-staff@example.com",
@@ -145,10 +155,11 @@ describe("staffRegistration/mutations", () => {
         email: "Existing@Example.com",
         isDeleted: false,
       });
+      return shopId;
     });
     const link = await t
       .withIdentity({ subject: "manager_existing_staff" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
 
     const existingResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
@@ -160,19 +171,23 @@ describe("staffRegistration/mutations", () => {
 
     const requests = await t
       .withIdentity({ subject: "manager_existing_staff" })
-      .query(api.staffRegistration.queries.getPendingRequests, {});
+      .query(api.staffRegistration.queries.getPendingRequests, { shopId });
     expect(requests).toEqual([]);
   });
 
   it("他店舗のシフト担当者は承認待ち申請を閲覧・承認・却下できない", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await seedManagerShop(ctx, { subject: "manager_manager", email: "manager-manager@example.com" });
-      await seedManagerShop(ctx, { subject: "manager_other", email: "manager-other@example.com" });
+    const { managerShopId, otherShopId } = await t.run(async (ctx) => {
+      const manager = await seedManagerShop(ctx, {
+        subject: "manager_manager",
+        email: "manager-manager@example.com",
+      });
+      const other = await seedManagerShop(ctx, { subject: "manager_other", email: "manager-other@example.com" });
+      return { managerShopId: manager.shopId, otherShopId: other.shopId };
     });
     const link = await t
       .withIdentity({ subject: "manager_manager" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId: managerShopId });
     const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "承認待ちスタッフ",
@@ -184,23 +199,25 @@ describe("staffRegistration/mutations", () => {
 
     const otherShopRequests = await t
       .withIdentity({ subject: "manager_other" })
-      .query(api.staffRegistration.queries.getPendingRequests, {});
+      .query(api.staffRegistration.queries.getPendingRequests, { shopId: otherShopId });
     expect(otherShopRequests).toEqual([]);
     await expect(
       t.withIdentity({ subject: "manager_other" }).mutation(api.staffRegistration.mutations.approveRequest, {
         requestId,
+        shopId: otherShopId,
       }),
     ).rejects.toThrow("Not found");
     await expect(
       t.withIdentity({ subject: "manager_other" }).mutation(api.staffRegistration.mutations.rejectRequest, {
         requestId,
+        shopId: otherShopId,
       }),
     ).rejects.toThrow("Not found");
   });
 
-  it("先頭の所属店舗が削除済みの場合、次の有効店舗の承認待ち申請を返す", async () => {
+  it("削除済み店舗とは別の有効な所属店舗を指定すると、その店舗の承認待ち申請を返す", async () => {
     const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
+    const activeShopId = await t.run(async (ctx) => {
       const userId = await seedUser(ctx, "manager_deleted_first", "manager-deleted-first@example.com");
       const deletedShopId = await seedShop(ctx, "削除済み店舗");
       await ctx.db.patch(deletedShopId, { isDeleted: true });
@@ -221,11 +238,12 @@ describe("staffRegistration/mutations", () => {
         consentedAt: Date.now(),
         createdAt: Date.now(),
       });
+      return activeShopId;
     });
 
     const requests = await t
       .withIdentity({ subject: "manager_deleted_first" })
-      .query(api.staffRegistration.queries.getPendingRequests, {});
+      .query(api.staffRegistration.queries.getPendingRequests, { shopId: activeShopId });
 
     expect(requests).toMatchObject([{ name: "承認待ちスタッフ", email: "pending-active@example.com" }]);
   });
@@ -248,7 +266,7 @@ describe("staffRegistration/mutations", () => {
     });
     const link = await t
       .withIdentity({ subject: "manager_approve" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
     const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "承認スタッフ",
@@ -260,7 +278,7 @@ describe("staffRegistration/mutations", () => {
 
     const { staffId } = await t
       .withIdentity({ subject: "manager_approve" })
-      .mutation(api.staffRegistration.mutations.approveRequest, { requestId });
+      .mutation(api.staffRegistration.mutations.approveRequest, { requestId, shopId });
 
     const state = await t.run(async (ctx) => {
       const staff = await ctx.db.get(staffId);
@@ -306,7 +324,7 @@ describe("staffRegistration/mutations", () => {
     });
     const link = await t
       .withIdentity({ subject: "manager_reject" })
-      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, {});
+      .mutation(api.staffRegistration.mutations.ensureShopRegistrationLink, { shopId });
     const submitResult = await t.mutation(api.staffRegistration.mutations.submitRegistrationRequest, {
       token: link.token,
       name: "却下スタッフ",
@@ -318,6 +336,7 @@ describe("staffRegistration/mutations", () => {
 
     await t.withIdentity({ subject: "manager_reject" }).mutation(api.staffRegistration.mutations.rejectRequest, {
       requestId,
+      shopId,
     });
 
     const state = await t.run(async (ctx) => {

--- a/convex/staffRegistration/queries.test.ts
+++ b/convex/staffRegistration/queries.test.ts
@@ -94,7 +94,9 @@ describe("staffRegistration/queries", () => {
         return { ownShopId: own.shopId, otherShopId: other.shopId };
       });
 
-      await expect(t.query(api.staffRegistration.queries.getActiveRegistrationLink, {})).resolves.toBeNull();
+      await expect(
+        t.query(api.staffRegistration.queries.getActiveRegistrationLink, { shopId: ownShopId }),
+      ).resolves.toBeNull();
       await expect(
         t
           .withIdentity({ subject: "registration_manager" })
@@ -112,7 +114,7 @@ describe("staffRegistration/queries", () => {
 
     it("承認待ち申請は自店舗のpendingだけを最小DTOで返す", async () => {
       const t = convexTest(schema, modules);
-      await t.run(async (ctx) => {
+      const ownShopId = await t.run(async (ctx) => {
         const own = await seedManagerShop(ctx, {
           subject: "pending_request_manager",
           email: "pending-request-manager@example.com",
@@ -151,11 +153,12 @@ describe("staffRegistration/queries", () => {
           emailNormalized: "other@example.com",
           status: "pending",
         });
+        return own.shopId;
       });
 
       const result = await t
         .withIdentity({ subject: "pending_request_manager" })
-        .query(api.staffRegistration.queries.getPendingRequests, {});
+        .query(api.staffRegistration.queries.getPendingRequests, { shopId: ownShopId });
 
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({

--- a/doc/features/manager-shop-membership.md
+++ b/doc/features/manager-shop-membership.md
@@ -6,9 +6,12 @@
 
 - `convex/schema.ts` — `users` / `shops` / `shopMembers` と所属検索index
 - `convex/_lib/functions.ts` — manager向けAPIの認証と現在店舗解決
-- `convex/dashboard/queries.ts` — dashboard表示用の現在店舗解決
+- `convex/dashboard/queries.ts` — dashboard表示用の店舗スコープquery
 - `convex/setup/mutations.ts` — 初回店舗登録とmanager所属作成
 - `src/components/features/AuthenticatedApp/AuthGuard.tsx` — フロントの選択中店舗を所属一覧と整合
+- `src/hooks/useShopQuery.ts` — 選択中店舗をmanager queryへ注入
+- `src/hooks/useShopPaginatedQuery.ts` — 選択中店舗をmanager paginated queryへ注入
+- `src/hooks/useShopMutation.ts` — 選択中店舗をmanager mutationへ注入
 - `src/components/features/AuthenticatedApp/AuthenticatedHeader/` — 店舗削除確認UI（入口は一時停止中）
 - `convex/staffRegistration/notificationQueries.ts` — 店舗のmanager usersを通知対象として取得
 
@@ -16,7 +19,7 @@
 
 | 画面 | 役割 |
 |---|---|
-| ダッシュボード | 現在はログインmanagerの最初の有効なactive所属店舗を表示する |
+| ダッシュボード | フロントで選択中のactive所属店舗を表示する |
 | 右上ユーザーメニュー | 店舗削除入口は誤操作リスクを再検討するため一時停止中 |
 
 ## API一覧
@@ -31,17 +34,25 @@
 
 ## 現在店舗の解決（manager API）
 
-`managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）は optional 引数 `shopId` を受け取る。
+現行フロントは、`managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）へ `shopId` を必ず渡す。
 
-- `shopId` 指定あり: `shopMembers.by_userId_and_shopId_and_isDeleted` でactive所属を確認し、その店舗を `ctx.shop` にする。未所属なら query は `null`、mutation は `Not found`（IDOR・列挙対策）。
-- `shopId` 未指定: 先頭のactive所属店舗にフォールバック（後方互換）。
+- `shopMembers.by_userId_and_shopId_and_isDeleted` でactive所属を確認し、指定店舗を `ctx.shop` にする。
+- 店舗が削除済み、membershipが削除済み、または未所属の場合、queryは各APIの空結果を返し、mutationは `Not found` とする。
+- クライアントの `shopId` は操作対象の指定にだけ使い、認可根拠には使わない。
+- Convexをフロントより先にデプロイする間も旧フロントを壊さないよう、サーバー引数はこのリリースではoptionalとする。
+  省略時だけ先頭のactive所属店舗へフォールバックし、現行フロントの配布後に別リリースで互換経路を削除する。
 
-フロント側は `selectedShopAtom`（localStorage永続化）に選択中店舗を保持し、`useShopMutation`（`src/hooks/useShopMutation.ts`）が manager 系 mutation へ `shopId` を自動注入する。`AuthGuard` が `getMyShops` で atom を初期化/整合する。
+フロント側は `selectedShopAtom`（localStorage永続化）に選択中店舗を保持する。
+`useShopQuery`、`useShopPaginatedQuery`、`useShopMutation` がmanager APIへ `shopId` を自動注入する。
+店舗が未選択の場合、query系hookは購読を `skip` し、mutation hookはバックエンドを呼ばずに失敗する。
+`AuthGuard` は `getMyShops` でatomを初期化・整合し、選択中店舗の確定前は配下画面を表示しない。
 `getMyShops` が0件になった場合は `selectedShopAtom` を `null` にし、削除した店舗が保存値に残っている場合は先頭の有効店舗へ切り替える。
 
 ## 補足
 
-- **店舗切替UI（プルダウン等）は未実装**。`selectedShopAtom` は先頭店舗で初期化されるため、現状の挙動は実質これまでと同じ（送信経路だけ整備済み）。
-- ダッシュボードの読み取り（`getDashboardShop` 等）は `authenticatedQuery` + `getManagerShop`（先頭の有効店舗）で、まだ `shopId` を受け取らない。完全な複数店舗読み取りは切替UI導入時に対応する。
+- **店舗切替UI（プルダウン等）は未実装**。
+  `selectedShopAtom` は `getMyShops` の先頭店舗で初期化され、現行フロントのmanager API呼び出しは必ず選択中の `shopId` を含む。
+- ダッシュボードの店舗スコープ読み取りは `managerQuery` を使う。
+- `getMyShops`、`getCurrentUser`、全体向けお知らせなどのbootstrap・userスコープqueryは `authenticatedQuery` のままとする。
 - 2店舗目作成、店舗招待は未実装。
 - managerの法務同意はuser単位で判定する。`legalConsentStates.shopId` は同意した店舗文脈の履歴として扱う。

--- a/doc/plans/2026-07-03_AIシフト下書き機能.md
+++ b/doc/plans/2026-07-03_AIシフト下書き機能.md
@@ -180,7 +180,7 @@ aiShiftDraft: { kind: "token bucket", rate: 10, period: HOUR_MS, capacity: 3 },
    - → **どのパターンの過去実績も実時間に落ちるため、パターン不一致でも除外不要**
 2. **曜日×30分スロット集計**: 各区間を30分刻みスロットに展開し、曜日×スロットの在籍人数を加算
 3. **期間按分**: 過去N期間で「その曜日が営業日として何日あったか」で割り、**1営業日あたりの平均同時在籍人数**へ。定休日（`shops.regularClosedDays`）・`shopClosedDates`は母数から除外。期間の長さ・営業日数の違いを吸収
-4. **現営業時間帯へクランプ**: 現募集の`getBoardTimeRange(現pattern)`（`convex/shiftBoard/validation.ts:54`）の外側スロットは捨てる。**現在の方が営業時間が広い区間は最近傍スロット値で補間**（0埋めだと端の時間帯が誰も居ない下書きになるため）
+4. **現営業時間帯へクランプ**: 現募集の`getSubmissionPatternTimeRange(現pattern)`（`convex/_lib/submissionPattern.ts`）の外側スロットは捨てる。**現在の方が営業時間が広い区間は最近傍スロット値で補間**（0埋めだと端の時間帯が誰も居ない下書きになるため）
 5. **現パターンへ再投影**:
    - 現time / dateOnly: 人数が同水準の連続スロットを帯にまとめ `[[start, end, count], ...]`
    - 現shiftType: 各optionの`[st, et)`に重なるスロット目標の**時間加重平均（四捨五入）**をoption単位の目標人数に按分
@@ -368,9 +368,9 @@ const generateAction = useAction(api.aiShiftDraft.actions.generateShiftDraft);
 - `convex/schema.ts` — recruitments / shiftSubmissions / shiftSubmissionSlots / shiftSubmissionDates / shiftAssignments / staffs
 - `convex/shiftBoard/queries.ts` — getShiftBoardData（提出済み判定 L66）
 - `convex/shiftBoard/mutations.ts` — saveShiftAssignments（保存契約）
-- `convex/shiftBoard/validation.ts` — validateShiftAssignments / getBoardTimeRange（検証の最終ゲート）
+- `convex/shiftBoard/validation.ts` — validateShiftAssignments（検証の最終ゲート）
 - `convex/dashboard/queries.ts` — getDashboardPastRecruitments（過去確定期間クエリの前例）
-- `convex/_lib/submissionPattern.ts` — ShiftSubmissionPattern / ShiftTypeOption
+- `convex/_lib/submissionPattern.ts` — ShiftSubmissionPattern / ShiftTypeOption / getSubmissionPatternTimeRange
 - `convex/_lib/rateLimits.ts` / `convex/_lib/functions.ts` / `convex/_lib/config.ts` / `convex/_lib/time.ts` / `convex/_lib/validation.ts`
 - `convex/line/actions.ts` + `src/components/features/Line/useRedeemLineToken.ts` — 公開action+useActionの前例
 - `convex/notification/actions.ts` — "use node" 外部API呼び出しの前例

--- a/doc/plans/2026-07-03_AIシフト下書き機能_実装仕様書.md
+++ b/doc/plans/2026-07-03_AIシフト下書き機能_実装仕様書.md
@@ -219,7 +219,7 @@ export type DraftInput = {
   mode: DraftMode;
   period: { start: string; end: string; closedDates: string[] };
   pattern: ShiftSubmissionPattern;
-  /** getBoardTimeRange(pattern) の結果。dateOnly時間補完・検証の枠 */
+  /** getSubmissionPatternTimeRange(pattern) の結果。dateOnly時間補完・検証の枠 */
   boardRange: { startTime: string; endTime: string };
   /**
    * シフト対象スタッフ。index はプロンプト内の参照ID。
@@ -394,7 +394,7 @@ aiShiftDraft: {
 | `period.closed` | `string[]` | `recruitment.shopClosedDates`。割当禁止日 |
 | `pattern.kind` | `"time" \| "shiftType" \| "dateOnly"` | 現募集の提出パターン |
 | `pattern.options[].id/name/st/et` | shiftTypeのみ | 現募集の区分。**AIに渡すのは現募集の区分のみ**（過去の廃止区分は渡さない） |
-| `pattern.board` | dateOnlyのみ | `getBoardTimeRange(pattern)` の `[startTime, endTime]`。時間補完の許容枠 |
+| `pattern.board` | dateOnlyのみ | `getSubmissionPatternTimeRange(pattern)` の `[startTime, endTime]`。時間補完の許容枠 |
 | `staff[].i` | 整数 | スタッフ参照index（0起点連番） |
 | `staff[].n` | 文字列 | 表示名。AIが文脈を掴むために渡すが、出力には使わせない |
 | `requests` | パターン依存 | **提出者の希望のみ**。キーは `staff[].i` の文字列化 |
@@ -435,7 +435,7 @@ export type PastPeriod = {
 export type BuildTrendTargetInput = {
   pastPeriods: PastPeriod[];        // 直近確定3期間まで（新しい順でなくてよい）
   currentPattern: ShiftSubmissionPattern;
-  currentBoardRange: { startTime: string; endTime: string }; // getBoardTimeRange(currentPattern)
+  currentBoardRange: { startTime: string; endTime: string }; // getSubmissionPatternTimeRange(currentPattern)
 };
 
 export function buildTrendTarget(input: BuildTrendTargetInput): TrendTarget | null;
@@ -1074,11 +1074,11 @@ export function toDraftShiftData(args: {
 ### Convex
 
 - `convex/schema.ts` — recruitments / shiftSubmissions / shiftSubmissionSlots / shiftSubmissionDates / shiftAssignments / staffs / positions
-- `convex/shiftBoard/queries.ts` — getShiftBoardData（提出済み判定 L61-66、getBoardTimeRange L13-23）
+- `convex/shiftBoard/queries.ts` — getShiftBoardData（提出済み判定）
 - `convex/shiftBoard/mutations.ts` — saveShiftAssignments（保存契約 L13-96。デフォルトポジション補完 L69, L88）
-- `convex/shiftBoard/validation.ts` — validateShiftAssignments（L77-160）/ getBoardTimeRange（L54-64）/ isSupportedShiftTime
+- `convex/shiftBoard/validation.ts` — validateShiftAssignments / isSupportedShiftTime
 - `convex/dashboard/queries.ts` — getDashboardPastRecruitments（過去確定期間クエリの前例 L236-250）
-- `convex/_lib/submissionPattern.ts` — ShiftSubmissionPattern / ShiftTypeOption（L5-16）
+- `convex/_lib/submissionPattern.ts` — ShiftSubmissionPattern / ShiftTypeOption / getSubmissionPatternTimeRange
 - `convex/_lib/rateLimits.ts` — token bucket定義の前例9件
 - `convex/_lib/functions.ts` — managerMutation / resolveShopForUser（L43-55）
 - `convex/_lib/time.ts` — timeToMinutes / isSupportedShiftTime / MAX_SHIFT_TIME_MINUTES

--- a/doc/plans/2026-07-03_複数店舗・複数マネージャー設計.md
+++ b/doc/plans/2026-07-03_複数店舗・複数マネージャー設計.md
@@ -21,15 +21,19 @@
 ### 実装済み（土台）
 
 - `shopMembers`（user↔shop 多対多）: スキーマ上は複数店舗・複数マネージャー対応済み
-- `managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）: optional `shopId` を受け取り所属検証（IDOR対策）。未指定は先頭店舗フォールバック
-- `selectedShopAtom`（`src/stores/shop/index.ts`）+ `useShopMutation`（`src/hooks/useShopMutation.ts`）: **書き込み経路の複数店舗対応は済み**
+- `managerQuery` / `managerMutation`（`convex/_lib/functions.ts`）: `shopId` を受け取り所属を検証する（IDOR対策）。
+  現行フロントエンドは必ず `shopId` を明示する。
+- `managerQuery` / `managerMutation` の引数は、段階リリース中だけ `shopId` をoptionalとして受け入れる。
+  省略時の先頭のactive所属店舗へのフォールバックは、旧クライアント互換経路に限定する。
+  後続リリースで `shopId` をrequired化し、互換経路を削除する。
+- `selectedShopAtom`（`src/stores/shop/index.ts`）+ `useShopQuery` / `useShopPaginatedQuery` / `useShopMutation`（`src/hooks/`）: **読み取りと書き込み経路の複数店舗対応は済み**。
 - `convex/billing/service.ts`: `requirePaidFeature` / `getShopEntitlements`（planKey直接判定は禁止）
 - 通知fan-out: `convex/_lib/shopManagerRecipients.ts` の `loadShopManagerRecipients` が店舗のactive manager全員を対象にしており **修正不要**
 
 ### 未実装（本設計の対象）
 
 - 2店舗目の作成（`convex/setup/mutations.ts` が「既に店舗が登録されています」でブロック）
-- 店舗切替UI、ダッシュボード読み取りの `shopId` 対応（`convex/dashboard/queries.ts` が先頭店舗固定）
+- 店舗切替UI（ダッシュボード読み取りの `shopId` 対応は実装済み）
 - manager招待フロー全般（`managerInviteTokens` テーブルなし）
 - manager解除、スタッフ一覧の管理者バッジ（現状は「ログイン本人か」で判定しており複数manager非対応）
 
@@ -50,9 +54,12 @@
 
 - ローカルの `getManagerShop()`（先頭店舗フォールバック）を削除し、以下を `authenticatedQuery` → `managerQuery` に変更して `ctx.shop` を使う:
   - `getDashboardShop` / `getDashboardRecruitments` / `hasDashboardPastRecruitments` / `getDashboardPastRecruitments` / `getDashboardCurrentRecruitments` / `getDashboardStaffs`
-- `managerQuery` は `shopId` 未指定なら先頭店舗フォールバックのため後方互換。shop未作成時は `ctx.shop = null` → `getDashboardShop` は `null`（SetupModal表示の既存挙動維持）、他は EMPTY_PAGE / `[]` / `false` を返す
-- `getMyShops` / `getCurrentUser` / `getActiveDashboardAnnouncement` は `authenticatedQuery` のまま
-- 補足（検証済み）: 先頭店舗フォールバックの読み取りは dashboard/queries.ts のみ。他のmanager向けquery（`staffRegistration.getPendingRequests`、`getActiveRegistrationLink`、`line.getLinkStatusByShop`、`getQuotaStatus`、`notificationOutbox.listOpenFailures`、`hasOpenFailures`、`shiftBoard.getShiftBoardData`、`legal.getManagerConsentStatus`）は既に `managerQuery` で shopId 対応済み（フロントが渡していないだけ）
+- 現行フロントエンドは `manager API` へ必ず選択中の `shopId` を渡す。
+  server側は段階リリース中だけ `shopId` をoptionalとして受け入れ、省略時のみ旧クライアント向けに先頭のactive所属店舗へフォールバックする。
+- 店舗未作成時は `getMyShops` の結果を使って `manager query` をskipし、SetupModalの既存挙動を維持する。
+- `getMyShops` / `getCurrentUser` / `getActiveDashboardAnnouncement` は `authenticatedQuery` のままとする。
+- その他の店舗スコープquery（`staffRegistration.getPendingRequests`、`getActiveRegistrationLink`、`line.getLinkStatusByShop`、`getQuotaStatus`、`notificationOutbox.listOpenFailures`、`hasOpenFailures`、`shiftBoard.getShiftBoardData`）も `managerQuery` と店舗選択hookを使う。
+  `legal.getManagerConsentStatus` はuserスコープのため `authenticatedQuery` のままとする。
 
 ### A-2. `useShopQuery` / `useShopPaginatedQuery` フック新設
 
@@ -64,15 +71,16 @@ export function useShopQuery<Q extends FunctionReference<"query">>(
   args: Omit<FunctionArgs<Q>, "shopId"> | "skip",
 ) {
   const selectedShop = useAtomValue(selectedShopAtom);
-  const merged =
-    args === "skip" ? "skip"
-    : selectedShop?.shopId ? { ...args, shopId: selectedShop.shopId as Id<"shops"> } : args;
-  return useQuery(queryRef, merged as FunctionArgs<Q> | "skip");
+  const queryArgs =
+    args === "skip" || !selectedShop?.shopId
+      ? "skip"
+      : { ...args, shopId: selectedShop.shopId };
+  return useQuery(queryRef, queryArgs as FunctionArgs<Q> | "skip");
 }
 ```
 
-- 置換対象: `src/pages/dashboard/index.tsx` の8クエリ（getDashboardShop, getManagerConsentStatus, getDashboardRecruitments, hasDashboardPastRecruitments, getDashboardPastRecruitments, getDashboardStaffs, getPendingRequests, listOpenFailures）
-- `src/pages/shift-board/index.tsx` は既にshopIdを手渡ししているためリファクタは任意
+- 置換対象: ダッシュボードの店舗スコープquery（getDashboardShop, getDashboardRecruitments, hasDashboardPastRecruitments, getDashboardPastRecruitments, getDashboardStaffs, getPendingRequests, listOpenFailures）
+- `src/pages/shift-board/index.tsx` も `useShopQuery` に統一する
 
 ### A-3. 店舗切替UI（ShopSwitcher）
 
@@ -81,7 +89,7 @@ export function useShopQuery<Q extends FunctionReference<"query">>(
 - UI: `UserMenu` と同型の Chakra `Menu`（トリガー = 現店舗名、選択中はチェックマーク。Phase Bで「新しい店舗を追加」項目を末尾に追加）
 - 配置: `src/components/templates/Header/index.tsx` の user variant、`<UserMenu />` の左隣（SideMenu/BottomMenuは存在せず、Headerが唯一のグローバルナビ）
 - 切替時の挙動: atom更新 + `/dashboard` へ navigate（シフトボード表示中に他店舗へ切り替えた際の誤操作対策）。`src/pages/dashboard/index.tsx` で `<DashboardContent key={selectedShop?.shopId}>` としてページ内state（表示件数等）をリセット
-- `AuthGuard`（`src/components/features/auths/AuthGuard.tsx`）は変更不要（保存値が所属一覧に無ければ先頭店舗へ整合するeffectが既存）
+- `AuthGuard`（`src/components/features/AuthenticatedApp/AuthGuard.tsx`）は保存値をactive所属一覧と整合し、選択中店舗が確定するまで配下画面を表示しない。
 
 ---
 
@@ -340,13 +348,13 @@ managerInviteTokens: defineTable({
 - `convex/_lib/functions.ts` — `managerQuery` / `managerMutation` / `resolveShopForUser`
 - `convex/billing/service.ts` — `requirePaidFeature` / `getShopEntitlements`
 - `convex/setup/mutations.ts` — `setupShopAndManager`（1店舗ガード、店舗作成一式）
-- `convex/dashboard/queries.ts` — `getMyShops` / 先頭店舗フォールバック
+- `convex/dashboard/queries.ts` — `getMyShops` / 店舗スコープのDashboard query
 - `convex/_lib/shopManagerRecipients.ts` — manager通知fan-out（対応済み）
 - `convex/_lib/notificationDeliveryQueries.ts` — dry-run抑止（要修正）
 - `convex/line/actions.ts` — `sendInviteEmail`（メール送信パターン）
 - `src/stores/shop/index.ts` — `selectedShopAtom`
 - `src/hooks/useShopMutation.ts` — shopId注入パターン
-- `src/components/features/auths/AuthGuard.tsx` — selectedShop初期化/整合
+- `src/components/features/AuthenticatedApp/AuthGuard.tsx` — selectedShop初期化/整合
 - `src/components/templates/Header/index.tsx` — 切替UI配置先
 - `doc/features/manager-billing-roles.md` — 招待・権限モデルの元設計
 - `doc/features/manager-shop-membership.md` — 所属モデルの現状

--- a/src/components/features/AuthenticatedApp/AuthGuard.test.tsx
+++ b/src/components/features/AuthenticatedApp/AuthGuard.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type SelectedShop = {
+  shopId: string;
+  shopName: string;
+} | null;
+
+const mocks = vi.hoisted(() => ({
+  currentUserQuery: Symbol("getCurrentUser"),
+  myShopsQuery: Symbol("getMyShops"),
+  selectedShopAtom: Symbol("selectedShopAtom"),
+  userAtom: Symbol("userAtom"),
+  useAuth: vi.fn(),
+  useQuery: vi.fn(),
+  useRouterState: vi.fn(),
+  useAtom: vi.fn(),
+  setSelectedShop: vi.fn(),
+  setUser: vi.fn(),
+  managerChildRender: vi.fn(),
+  currentUser: { name: "管理者", email: "manager@example.com" },
+  myShops: [{ shopId: "active-shop", shopName: "所属店舗" }],
+  selectedShop: null as SelectedShop,
+  user: { authId: "manager-user", name: "管理者", email: "manager@example.com" },
+}));
+
+vi.mock("@clerk/clerk-react", () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Navigate: () => null,
+  useRouterState: mocks.useRouterState,
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: mocks.useQuery,
+}));
+
+vi.mock("jotai", () => ({
+  useAtom: mocks.useAtom,
+}));
+
+vi.mock("@/convex/_generated/api", () => ({
+  api: {
+    dashboard: {
+      queries: {
+        getCurrentUser: mocks.currentUserQuery,
+        getMyShops: mocks.myShopsQuery,
+      },
+    },
+  },
+}));
+
+vi.mock("@/src/components/templates/FullPageSpinner", () => ({
+  FullPageSpinner: () => <div data-testid="full-page-spinner" />,
+}));
+
+vi.mock("@/src/stores/shop", () => ({
+  selectedShopAtom: mocks.selectedShopAtom,
+}));
+
+vi.mock("@/src/stores/user", () => ({
+  userAtom: mocks.userAtom,
+}));
+
+import { AuthGuard } from "./AuthGuard";
+
+const ManagerChild = () => {
+  mocks.managerChildRender();
+  return <div data-testid="manager-child" />;
+};
+
+beforeEach(() => {
+  mocks.useAuth.mockReset();
+  mocks.useQuery.mockReset();
+  mocks.useRouterState.mockReset();
+  mocks.useAtom.mockReset();
+  mocks.setSelectedShop.mockReset();
+  mocks.setUser.mockReset();
+  mocks.managerChildRender.mockReset();
+
+  mocks.selectedShop = { shopId: "stale-shop", shopName: "過去の所属店舗" };
+  mocks.user = { authId: "manager-user", name: "管理者", email: "manager@example.com" };
+
+  mocks.useAuth.mockReturnValue({
+    isLoaded: true,
+    isSignedIn: true,
+    userId: "manager-user",
+  });
+  mocks.useRouterState.mockReturnValue({ pathname: "/dashboard", searchStr: "" });
+  mocks.useQuery.mockImplementation((queryReference: unknown) => {
+    if (queryReference === mocks.currentUserQuery) return mocks.currentUser;
+    if (queryReference === mocks.myShopsQuery) return mocks.myShops;
+    throw new Error("Unexpected query reference");
+  });
+  mocks.useAtom.mockImplementation((targetAtom: unknown) => {
+    if (targetAtom === mocks.userAtom) return [mocks.user, mocks.setUser];
+    if (targetAtom === mocks.selectedShopAtom) return [mocks.selectedShop, mocks.setSelectedShop];
+    throw new Error("Unexpected atom");
+  });
+});
+
+describe("AuthGuard", () => {
+  it("保存済みの不所属店舗を整合するまではmanager子画面を描画しない", async () => {
+    const { rerender } = render(
+      <AuthGuard>
+        <ManagerChild />
+      </AuthGuard>,
+    );
+
+    expect(mocks.managerChildRender).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("manager-child")).toBeNull();
+    expect(screen.queryByTestId("full-page-spinner")).not.toBeNull();
+    await waitFor(() => {
+      expect(mocks.setSelectedShop).toHaveBeenCalledWith({ shopId: "active-shop", shopName: "所属店舗" });
+    });
+
+    mocks.selectedShop = { shopId: "active-shop", shopName: "所属店舗" };
+    rerender(
+      <AuthGuard>
+        <ManagerChild />
+      </AuthGuard>,
+    );
+
+    expect(mocks.managerChildRender).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("manager-child")).not.toBeNull();
+    expect(screen.queryByTestId("full-page-spinner")).toBeNull();
+  });
+});

--- a/src/components/features/AuthenticatedApp/AuthGuard.tsx
+++ b/src/components/features/AuthenticatedApp/AuthGuard.tsx
@@ -53,6 +53,12 @@ export const AuthGuard = ({ children }: Props) => {
     }
   }, [myShops, selectedShop, setSelectedShop]);
 
+  const isShopContextReady =
+    myShops !== undefined &&
+    (myShops.length === 0
+      ? selectedShop === null
+      : selectedShop !== null && myShops.some((shop) => shop.shopId === selectedShop.shopId));
+
   // ログアウト・セッション失効時は userAtom が残っていても必ずログインへ戻す。
   // （queryは未認証時にthrowせず空を返すため、エラー経由のリダイレクトは発生しない）
   if (isLoaded && !isSignedIn) {
@@ -61,7 +67,7 @@ export const AuthGuard = ({ children }: Props) => {
     );
   }
 
-  if (user.authId) {
+  if (user.authId && isShopContextReady) {
     return children;
   }
 
@@ -69,7 +75,7 @@ export const AuthGuard = ({ children }: Props) => {
     return <FullPageSpinner showHeader />;
   }
 
-  if (currentUser === undefined) {
+  if (currentUser === undefined || !isShopContextReady) {
     return <FullPageSpinner showHeader />;
   }
 

--- a/src/components/features/Dashboard/NotificationFailureRecovery/index.tsx
+++ b/src/components/features/Dashboard/NotificationFailureRecovery/index.tsx
@@ -1,4 +1,3 @@
-import { usePaginatedQuery } from "convex/react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -6,6 +5,7 @@ import { showErrorToast, showSuccessToast } from "@/src/components/shared/feedba
 import { useDialog } from "@/src/components/ui/Dialog";
 import { toaster } from "@/src/components/ui/toaster";
 import { useShopMutation } from "@/src/hooks/useShopMutation";
+import { useShopPaginatedQuery } from "@/src/hooks/useShopPaginatedQuery";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import type { DashboardNotificationFailure } from "../NotificationFailureDialog";
 import { NotificationFailureRecoveryView } from "./NotificationFailureRecoveryView";
@@ -26,7 +26,7 @@ const NOTIFICATION_FAILURE_PAGE_SIZE = 50;
 
 export function NotificationFailureRecovery({ failures: failureOverrides, children }: Props) {
   const dialog = useDialog();
-  const failureQuery = usePaginatedQuery(
+  const failureQuery = useShopPaginatedQuery(
     api.notificationOutbox.queries.listOpenFailures,
     failureOverrides ? "skip" : {},
     { initialNumItems: NOTIFICATION_FAILURE_PAGE_SIZE },

--- a/src/components/features/Dashboard/RecruitmentManagement/index.tsx
+++ b/src/components/features/Dashboard/RecruitmentManagement/index.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "@tanstack/react-router";
-import { usePaginatedQuery, useQuery } from "convex/react";
 import { type ReactNode, useState } from "react";
 import { api } from "@/convex/_generated/api";
 import type { RegularClosedDay, ShiftSubmissionPattern } from "@/convex/shop/schemas";
@@ -8,6 +7,8 @@ import { showErrorToast, showSuccessToast } from "@/src/components/shared/feedba
 import { useDialog } from "@/src/components/ui/Dialog";
 import { toaster } from "@/src/components/ui/toaster";
 import { useShopMutation } from "@/src/hooks/useShopMutation";
+import { useShopPaginatedQuery } from "@/src/hooks/useShopPaginatedQuery";
+import { useShopQuery } from "@/src/hooks/useShopQuery";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import { buildDashboardRecruitmentGroups, sortRecruitmentsByCreatedAt } from "../script";
 import type { DashboardRecruitmentGroup, PaginationStatus, Recruitment } from "../types";
@@ -62,11 +63,11 @@ export function RecruitmentManagement({ regularClosedDays, submissionPattern, da
   const deleteDialog = useDialog();
   const [deleteTarget, setDeleteTarget] = useState<Recruitment | null>(null);
   const [isPastRecruitmentsVisible, setIsPastRecruitmentsVisible] = useState(data?.isPastRecruitmentsVisible ?? false);
-  const recruitments = usePaginatedQuery(api.dashboard.queries.getDashboardRecruitments, data ? "skip" : {}, {
+  const recruitments = useShopPaginatedQuery(api.dashboard.queries.getDashboardRecruitments, data ? "skip" : {}, {
     initialNumItems: ACTIVE_RECRUITMENT_QUERY_PAGE_SIZE,
   });
-  const hasPastRecruitments = useQuery(api.dashboard.queries.hasDashboardPastRecruitments, data ? "skip" : {});
-  const pastRecruitments = usePaginatedQuery(
+  const hasPastRecruitments = useShopQuery(api.dashboard.queries.hasDashboardPastRecruitments, data ? "skip" : {});
+  const pastRecruitments = useShopPaginatedQuery(
     api.dashboard.queries.getDashboardPastRecruitments,
     data || !isPastRecruitmentsVisible ? "skip" : {},
     { initialNumItems: PAST_RECRUITMENT_PAGE_SIZE },

--- a/src/components/features/Dashboard/StaffManagement/index.tsx
+++ b/src/components/features/Dashboard/StaffManagement/index.tsx
@@ -1,6 +1,6 @@
-import { usePaginatedQuery } from "convex/react";
 import { type ReactNode, useState } from "react";
 import { api } from "@/convex/_generated/api";
+import { useShopPaginatedQuery } from "@/src/hooks/useShopPaginatedQuery";
 import type { PaginationStatus, Recruitment, Staff } from "../types";
 import { StaffManagementView } from "./StaffManagementView";
 import { useStaffInvitation } from "./useStaffInvitation";
@@ -34,7 +34,7 @@ type Props = {
 
 export function StaffManagement({ data, openRecruitments, currentRecruitments, children }: Props) {
   const [visibleStaffCount, setVisibleStaffCount] = useState(STAFF_INITIAL_VISIBLE_COUNT);
-  const staffQuery = usePaginatedQuery(api.dashboard.queries.getDashboardStaffs, data ? "skip" : {}, {
+  const staffQuery = useShopPaginatedQuery(api.dashboard.queries.getDashboardStaffs, data ? "skip" : {}, {
     initialNumItems: STAFF_QUERY_PAGE_SIZE,
   });
   const staffs = data?.staffs ?? staffQuery.results.slice(0, visibleStaffCount);

--- a/src/components/features/Dashboard/StaffRegistrationRequestManagement/index.tsx
+++ b/src/components/features/Dashboard/StaffRegistrationRequestManagement/index.tsx
@@ -1,9 +1,9 @@
-import { useQuery } from "convex/react";
 import { type ReactNode, useEffect, useState } from "react";
 import { api } from "@/convex/_generated/api";
 import { showErrorToast, showSuccessToast } from "@/src/components/shared/feedback";
 import { useDialog } from "@/src/components/ui/Dialog";
 import { useShopMutation } from "@/src/hooks/useShopMutation";
+import { useShopQuery } from "@/src/hooks/useShopQuery";
 import { useSingleFlight } from "@/src/hooks/useSingleFlight";
 import type { StaffRegistrationRequest } from "../types";
 import { StaffRegistrationRequestManagementView } from "./StaffRegistrationRequestManagementView";
@@ -23,7 +23,10 @@ type Props = {
 export function StaffRegistrationRequestManagement({ requests: requestOverrides, children }: Props) {
   const dialog = useDialog();
   const [rejectTarget, setRejectTarget] = useState<StaffRegistrationRequest | null>(null);
-  const queriedRequests = useQuery(api.staffRegistration.queries.getPendingRequests, requestOverrides ? "skip" : {});
+  const queriedRequests = useShopQuery(
+    api.staffRegistration.queries.getPendingRequests,
+    requestOverrides ? "skip" : {},
+  );
   const requests = requestOverrides ?? queriedRequests ?? [];
   const approveRequest = useShopMutation(api.staffRegistration.mutations.approveRequest);
   const rejectRequest = useShopMutation(api.staffRegistration.mutations.rejectRequest);

--- a/src/components/features/FeatureRequestDialog/index.tsx
+++ b/src/components/features/FeatureRequestDialog/index.tsx
@@ -19,7 +19,7 @@ type FormData = z.infer<typeof formSchema>;
 
 const submitFeatureRequestRef = makeFunctionReference<
   "mutation",
-  { comment: string; requestId: string; shopId?: Id<"shops"> },
+  { comment: string; requestId: string; shopId: Id<"shops"> },
   { status: "accepted" }
 >("featureRequest/mutations:submit");
 

--- a/src/hooks/useShopMutation.test.ts
+++ b/src/hooks/useShopMutation.test.ts
@@ -4,7 +4,7 @@ import { renderHook } from "@testing-library/react";
 import type { FunctionReference } from "convex/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type TestMutation = FunctionReference<"mutation", "public", { label: string; shopId?: string }, { saved: boolean }>;
+type TestMutation = FunctionReference<"mutation", "public", { label: string; shopId: string }, { saved: boolean }>;
 
 const mocks = vi.hoisted(() => ({
   mutate: vi.fn(),
@@ -43,13 +43,12 @@ describe("useShopMutation", () => {
     expect(input).toEqual({ label: "募集A" });
   });
 
-  it("店舗が未選択ならshopIdを追加しない", async () => {
-    mocks.mutate.mockResolvedValueOnce({ saved: true });
+  it("店舗が未選択ならmutationを呼ばずに失敗する", async () => {
     const { result } = renderHook(() => useShopMutation(mutationRef));
 
-    await result.current({ label: "募集A" });
+    await expect(result.current({ label: "募集A" })).rejects.toThrow("店舗が選択されていません");
 
-    expect(mocks.mutate).toHaveBeenCalledWith({ label: "募集A" });
+    expect(mocks.mutate).not.toHaveBeenCalled();
   });
 
   it("店舗選択が変わった後は最新の店舗IDを使う", async () => {

--- a/src/hooks/useShopMutation.ts
+++ b/src/hooks/useShopMutation.ts
@@ -1,26 +1,28 @@
 import { useMutation } from "convex/react";
-import type { FunctionArgs, FunctionReference, FunctionReturnType } from "convex/server";
+import type { FunctionArgs, FunctionReference, FunctionReturnType, OptionalRestArgs } from "convex/server";
 import { useAtomValue } from "jotai";
 import { useCallback } from "react";
 import { selectedShopAtom } from "@/src/stores/shop";
 
+type ShopMutationReference = FunctionReference<"mutation", "public", { shopId?: string }>;
+
 /**
  * マネージャー系 mutation 用のラッパー。
  * 選択中店舗（selectedShopAtom）の shopId を自動で引数に注入する。
- *
- * バックエンドの managerMutation は shopId を optional で受け取り、
- * 未指定なら先頭の所属店舗にフォールバックする。複数店舗マネージャーが
- * 操作対象店舗を明示できるようにするための入口。
+ * バックエンドの optional は段階リリース互換用であり、このhookでは省略しない。
  */
-export function useShopMutation<M extends FunctionReference<"mutation">>(mutationRef: M) {
+export function useShopMutation<M extends ShopMutationReference>(mutationRef: M) {
   const mutate = useMutation(mutationRef);
   const selectedShop = useAtomValue(selectedShopAtom);
   const shopId = selectedShop?.shopId;
 
   return useCallback(
     (args: Omit<FunctionArgs<M>, "shopId">): Promise<FunctionReturnType<M>> => {
-      const merged = shopId ? { ...args, shopId } : args;
-      return mutate(merged as FunctionArgs<M>);
+      if (!shopId) {
+        return Promise.reject(new Error("店舗が選択されていません"));
+      }
+      const mutationArgs = { ...args, shopId } as FunctionArgs<M>;
+      return mutate(...([mutationArgs] as unknown as OptionalRestArgs<M>));
     },
     [mutate, shopId],
   );

--- a/src/hooks/useShopPaginatedQuery.test.ts
+++ b/src/hooks/useShopPaginatedQuery.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { FunctionReference, PaginationResult } from "convex/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestQuery = FunctionReference<
+  "query",
+  "public",
+  { label: string; shopId: string; paginationOpts: { numItems: number; cursor: string | null } },
+  PaginationResult<{ name: string }>
+>;
+
+const mocks = vi.hoisted(() => ({
+  usePaginatedQuery: vi.fn(() => ({ results: [], status: "LoadingFirstPage", loadMore: vi.fn() })),
+  selectedShop: null as { shopId: string; shopName: string } | null,
+}));
+
+vi.mock("convex/react", () => ({
+  usePaginatedQuery: mocks.usePaginatedQuery,
+}));
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => mocks.selectedShop,
+}));
+
+import { useShopPaginatedQuery } from "./useShopPaginatedQuery";
+
+const queryRef = {} as TestQuery;
+const options = { initialNumItems: 10 };
+
+beforeEach(() => {
+  mocks.usePaginatedQuery.mockClear();
+  mocks.selectedShop = null;
+});
+
+describe("useShopPaginatedQuery", () => {
+  it("選択中の店舗IDをpaginated query引数へ注入する", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+
+    renderHook(() => useShopPaginatedQuery(queryRef, { label: "募集A" }, options));
+
+    expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(queryRef, { label: "募集A", shopId: "shop-1" }, options);
+  });
+
+  it("店舗が未選択ならpaginated queryをskipする", () => {
+    renderHook(() => useShopPaginatedQuery(queryRef, { label: "募集A" }, options));
+
+    expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(queryRef, "skip", options);
+  });
+
+  it("呼び出し側のskipを維持する", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+
+    renderHook(() => useShopPaginatedQuery(queryRef, "skip", options));
+
+    expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(queryRef, "skip", options);
+  });
+
+  it("店舗選択が変わった後は最新の店舗IDを使う", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+    const { rerender } = renderHook(() => useShopPaginatedQuery(queryRef, { label: "募集A" }, options));
+
+    mocks.selectedShop = { shopId: "shop-2", shopName: "新宿店" };
+    rerender();
+
+    expect(mocks.usePaginatedQuery).toHaveBeenNthCalledWith(1, queryRef, { label: "募集A", shopId: "shop-1" }, options);
+    expect(mocks.usePaginatedQuery).toHaveBeenNthCalledWith(2, queryRef, { label: "募集A", shopId: "shop-2" }, options);
+  });
+});

--- a/src/hooks/useShopPaginatedQuery.ts
+++ b/src/hooks/useShopPaginatedQuery.ts
@@ -1,0 +1,27 @@
+import {
+  type PaginatedQueryArgs,
+  type PaginatedQueryReference,
+  type UsePaginatedQueryReturnType,
+  usePaginatedQuery,
+} from "convex/react";
+import { useAtomValue } from "jotai";
+import { selectedShopAtom } from "@/src/stores/shop";
+
+type ShopPaginatedQueryReference = PaginatedQueryReference & {
+  _args: PaginatedQueryReference["_args"] & { shopId?: string };
+};
+
+/** 選択中店舗を shopId として注入するマネージャー系 paginated query 用ラッパー。 */
+export function useShopPaginatedQuery<Q extends ShopPaginatedQueryReference>(
+  queryRef: Q,
+  args: Omit<PaginatedQueryArgs<Q>, "shopId"> | "skip",
+  options: { initialNumItems: number },
+): UsePaginatedQueryReturnType<Q> {
+  const selectedShop = useAtomValue(selectedShopAtom);
+  const queryArgs =
+    args === "skip" || !selectedShop?.shopId
+      ? "skip"
+      : ({ ...args, shopId: selectedShop.shopId } as unknown as PaginatedQueryArgs<Q>);
+
+  return usePaginatedQuery(queryRef, queryArgs, options);
+}

--- a/src/hooks/useShopQuery.test.ts
+++ b/src/hooks/useShopQuery.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { FunctionReference } from "convex/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestQuery = FunctionReference<"query", "public", { label: string; shopId: string }, { name: string }>;
+
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  selectedShop: null as { shopId: string; shopName: string } | null,
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: mocks.useQuery,
+}));
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => mocks.selectedShop,
+}));
+
+import { useShopQuery } from "./useShopQuery";
+
+const queryRef = {} as TestQuery;
+
+beforeEach(() => {
+  mocks.useQuery.mockReset();
+  mocks.selectedShop = null;
+});
+
+describe("useShopQuery", () => {
+  it("選択中の店舗IDをquery引数へ注入する", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+
+    renderHook(() => useShopQuery(queryRef, { label: "募集A" }));
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(queryRef, { label: "募集A", shopId: "shop-1" });
+  });
+
+  it("店舗が未選択ならqueryをskipする", () => {
+    renderHook(() => useShopQuery(queryRef, { label: "募集A" }));
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(queryRef, "skip");
+  });
+
+  it("呼び出し側のskipを維持する", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+
+    renderHook(() => useShopQuery(queryRef, "skip"));
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(queryRef, "skip");
+  });
+
+  it("店舗選択が変わった後は最新の店舗IDを使う", () => {
+    mocks.selectedShop = { shopId: "shop-1", shopName: "渋谷店" };
+    const { rerender } = renderHook(() => useShopQuery(queryRef, { label: "募集A" }));
+
+    mocks.selectedShop = { shopId: "shop-2", shopName: "新宿店" };
+    rerender();
+
+    expect(mocks.useQuery).toHaveBeenNthCalledWith(1, queryRef, { label: "募集A", shopId: "shop-1" });
+    expect(mocks.useQuery).toHaveBeenNthCalledWith(2, queryRef, { label: "募集A", shopId: "shop-2" });
+  });
+});

--- a/src/hooks/useShopQuery.ts
+++ b/src/hooks/useShopQuery.ts
@@ -1,0 +1,18 @@
+import { type OptionalRestArgsOrSkip, useQuery } from "convex/react";
+import type { FunctionArgs, FunctionReference, FunctionReturnType } from "convex/server";
+import { useAtomValue } from "jotai";
+import { selectedShopAtom } from "@/src/stores/shop";
+
+type ShopQueryReference = FunctionReference<"query", "public", { shopId?: string }>;
+
+/** 選択中店舗を shopId として注入するマネージャー系 query 用ラッパー。 */
+export function useShopQuery<Q extends ShopQueryReference>(
+  queryRef: Q,
+  args: Omit<FunctionArgs<Q>, "shopId"> | "skip",
+): FunctionReturnType<Q> | undefined {
+  const selectedShop = useAtomValue(selectedShopAtom);
+  const queryArgs =
+    args === "skip" || !selectedShop?.shopId ? "skip" : ({ ...args, shopId: selectedShop.shopId } as FunctionArgs<Q>);
+
+  return useQuery(queryRef, ...([queryArgs] as unknown as OptionalRestArgsOrSkip<Q>));
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -6,9 +6,12 @@ import { Dashboard, DashboardSkeleton } from "@/src/components/features/Dashboar
 import { Animation } from "@/src/components/templates/Animation";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { RootContentWrapper } from "@/src/components/templates/RootContentWrapper";
+import { useShopQuery } from "@/src/hooks/useShopQuery";
 
 export function DashboardPage() {
-  const shop = useQuery(api.dashboard.queries.getDashboardShop);
+  const myShops = useQuery(api.dashboard.queries.getMyShops, {});
+  const selectedShop = useShopQuery(api.dashboard.queries.getDashboardShop, {});
+  const shop = myShops === undefined ? undefined : myShops.length === 0 ? null : selectedShop;
   const currentUser = useQuery(api.dashboard.queries.getCurrentUser, {});
   const managerLegalConsentStatus = useQuery(
     api.legal.queries.getManagerConsentStatus,

--- a/src/pages/shift-board/index.tsx
+++ b/src/pages/shift-board/index.tsx
@@ -1,22 +1,18 @@
-import { useQuery } from "convex/react";
-import { useAtomValue } from "jotai";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { ShiftBoardPage } from "@/src/components/features/ShiftBoard";
 import { Animation } from "@/src/components/templates/Animation";
 import { HEADER_HEIGHT } from "@/src/components/templates/Header";
 import { ShiftoriLoading } from "@/src/components/ui/ShiftoriLoading";
-import { selectedShopAtom } from "@/src/stores/shop";
+import { useShopQuery } from "@/src/hooks/useShopQuery";
 
 type Props = {
   recruitmentId: string;
 };
 
 export function ShiftBoardRoutePage({ recruitmentId }: Props) {
-  const selectedShop = useAtomValue(selectedShopAtom);
-  const data = useQuery(api.shiftBoard.queries.getShiftBoardData, {
+  const data = useShopQuery(api.shiftBoard.queries.getShiftBoardData, {
     recruitmentId: recruitmentId as Id<"recruitments">,
-    ...(selectedShop?.shopId ? { shopId: selectedShop.shopId as Id<"shops"> } : {}),
   });
 
   if (data === undefined) {


### PR DESCRIPTION
## Summary

Convexに散在していた店舗解決、スタッフセッション検証、activeレコード取得、提出パターンの時間範囲計算を共通化します。
管理画面は選択店舗を明示しつつ、Convex先行デプロイ中の旧クライアント互換を維持します。

## Changes

- **店舗コンテキスト**：選択中の`shopId`をmanager APIへ注入し、所属確認済みの店舗だけを操作対象にします。

<details>
<summary>確認項目</summary>

- 同一managerが2店舗に所属するとき、各店舗の`shopId`でDashboard queryを呼ぶと、指定した店舗の情報へ切り替わることを確認した。
- 保存済みの店舗が所属一覧にないとき、`AuthGuard`を描画すると、所属店舗へ整合するまでmanager画面を表示しないことを確認した。
- 旧クライアントが`shopId`を省略するとき、manager queryとmutationを呼ぶと、先頭のactive所属店舗を対象に処理できることを確認した。
- 共通化後の主要導線があるとき、E2E全体を1 workerで実行すると64件が成功し、画面読込の待機不足で失敗した1件も単独再実行で成功することを確認した。

</details>

- **提出パターンの時間範囲**：シフト提出、シフト作成、確定シフト閲覧、割当検証で同じ時間範囲計算を使います。

<details>
<summary>確認項目</summary>

- 時間指定、並び順の異なる勤務区分、日付のみ、勤務区分なしの提出パターンがあるとき、時間範囲を計算すると、それぞれ設定値、最小開始時刻と最大終了時刻、既定範囲になることを確認した。

</details>

- **セッションとactiveレコード取得**：staff sessionの解決と、店舗内の有効なstaffおよびrecruitment取得を共通処理へ集約します。

<details>
<summary>確認項目</summary>

- 期限切れ、用途違い、削除済み、シフト対象外のstaff sessionがあるとき、queryまたはmutationを呼ぶと、既存のnull返却とエラー種別を維持することを確認した。
- 他店舗または削除済みのstaffとrecruitmentがあるとき、manager APIまたはstaff APIから参照すると、対象データを取得できないことを確認した。
- 共通化後の回帰テストがあるとき、Logic、UI、Convexの全テストを実行すると、246ファイル1,536件が成功することを確認した。

</details>

- **設計契約**：現行フロントの`shopId`明示、段階リリース中のserver互換、共通時間範囲helperの配置を関連文書へ反映します。

<details>
<summary>確認項目</summary>

- 共通化後のコードがあるとき、店舗所属とAIシフト下書きの関連文書を照合すると、現在のAPI契約とhelper名に一致することを確認した。

</details>