### PR TITLE
fix: prerender出力をフラットな.htmlにしてCloudflare Pagesの308リダイレクトを解消

### DIFF
--- a/doc/features/public-pages.md
+++ b/doc/features/public-pages.md
@@ -27,6 +27,12 @@ LPの既存コンテンツを流用し、検索結果に法務ページ以外の
 - `/articles/categories/:categorySlug` — `BreadcrumbList`
 - ルート側で og:type / og:image を出すと、prerender が index.html の既定タグと重複排除して後勝ちで焼き込む（`scripts/prerender.ts` の `ROUTE_MANAGED_META_*`）
 
+## URL正規化（末尾スラッシュ）
+
+- prerender は `dist/features.html` のようにフラットな `.html` で出力する（`routeToOutputPath`）。ディレクトリ index（`dist/features/index.html`）にすると Cloudflare Pages が正規URLを `/features/` と判定し、`/features` を308リダイレクトする
+- sitemap.xml と canonical（`buildLinks`）はどちらも末尾スラッシュ**なし**。ここが出力形式とズレると、送信URL ⇄ 正規URL が循環して Google Search Console でリダイレクトエラーになる
+- `dist/404.html` は置かないこと。置くと未知パスがSPAフォールバック（ルートの `index.html` を200で返す）ではなく404になり、`/dashboard` などアプリ内ルートの直リロードが壊れる
+
 ## 画面一覧
 
 | パス | 内容 |

--- a/scripts/prerender.test.ts
+++ b/scripts/prerender.test.ts
@@ -1,0 +1,37 @@
+import { join, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import { routeToOutputPath } from "./prerender";
+
+describe("routeToOutputPath", () => {
+  it("writes the root route to dist/index.html", () => {
+    expect(routeToOutputPath("/")).toBe(join("dist", "index.html"));
+  });
+
+  // ディレクトリ index (dist/features/index.html) にすると Cloudflare Pages が
+  // /features → /features/ へ 308 リダイレクトし、sitemap.xml / canonical が指す
+  // 末尾スラッシュなしのURLと食い違う。フラットな .html で出力すること。
+  it("writes non-root routes as flat .html files, not directory indexes", () => {
+    expect(routeToOutputPath("/features")).toBe(join("dist", "features.html"));
+    expect(routeToOutputPath("/articles")).toBe(join("dist", "articles.html"));
+  });
+
+  it("keeps nested routes nested", () => {
+    expect(routeToOutputPath("/demo/shiftboard")).toBe(join("dist", "demo", "shiftboard.html"));
+    expect(routeToOutputPath("/articles/excel-shift-management-limits")).toBe(
+      join("dist", "articles", "excel-shift-management-limits.html"),
+    );
+    expect(routeToOutputPath("/articles/categories/tool-review")).toBe(
+      join("dist", "articles", "categories", "tool-review.html"),
+    );
+  });
+
+  // /articles (一覧) と /articles/:slug (詳細) は dist/articles.html と
+  // dist/articles/*.html に分かれるため、互いを上書きしない。
+  it("does not collide between a list route and its child routes", () => {
+    const listPath = routeToOutputPath("/articles");
+    const childPath = routeToOutputPath("/articles/fair-shift-scheduling");
+
+    expect(listPath).not.toBe(childPath);
+    expect(childPath.startsWith(`${join("dist", "articles")}${sep}`)).toBe(true);
+  });
+});

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -20,6 +20,7 @@
 import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { dirname, extname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
 
 const DIST_DIR = "dist";
@@ -124,8 +125,20 @@ function createShellHandler(shell: Buffer) {
   };
 }
 
-function routeToOutputPath(route: string): string {
-  return route === "/" ? join(DIST_DIR, "index.html") : join(DIST_DIR, route.replace(/^\//, ""), "index.html");
+/**
+ * ルートを dist/ の出力先パスへ変換する。
+ *
+ * ディレクトリ index (`dist/features/index.html`) ではなくフラットな
+ * `dist/features.html` に書き出す。Cloudflare Pages は前者を「正規URLは
+ * `/features/`」と解釈して `/features` を 308 リダイレクトするが、
+ * sitemap.xml と canonical (src/helpers/seo) はどちらも末尾スラッシュなしの
+ * `/features` を指すため、送信URL ⇄ 正規URL が循環し Google Search Console で
+ * リダイレクトエラーになる。
+ * フラット形式なら `/features` が 200、`/features/` が `/features` へ 308 となり、
+ * 送信URLと正規URLが一致する。
+ */
+export function routeToOutputPath(route: string): string {
+  return route === "/" ? join(DIST_DIR, "index.html") : join(DIST_DIR, `${route.replace(/^\//, "")}.html`);
 }
 
 function recordPageEvent(events: string[], event: string): void {
@@ -507,7 +520,9 @@ async function main(): Promise<void> {
   console.log("[prerender] Done");
 }
 
-main().catch((err: unknown) => {
-  console.error("[prerender] Failed:", err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err: unknown) => {
+    console.error("[prerender] Failed:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## 概要

Google Search Console で、sitemap.xml の24URLのうち **トップページ以外の23URLが1枚もインデックスされていない** 問題の修正です。

| GSCのステータス | 件数 | 内訳 |
|---|---|---|
| インデックス済み | 1 | `/` のみ |
| リダイレクト エラー | 8 | `/features`, `/articles`, カテゴリ4件, 記事2件 |
| 検出 - インデックス未登録 | 15 | 記事10件 + `/faq` `/contact` `/howto` `/demo/shiftboard` `/demo/flow` |

8 + 15 = 23 = `/` を除く全URL。

## 原因

`scripts/prerender.ts` の `routeToOutputPath` がディレクトリ index 形式で出力していました。

```ts
"/features" → dist/features/index.html
```

Cloudflare Pages は `foo/index.html` を「正規URLは `/foo/`（末尾スラッシュあり）」と解釈し、`/foo` を308リダイレクトします。一方 sitemap.xml と canonical（`src/helpers/seo/index.ts` の `buildLinks`）はどちらも末尾スラッシュ**なし**を指しています。

結果、Googlebot から見ると次の循環になります。

```
sitemap の /features → 308 → /features/ → canonical が /features を指す → 308 → …
```

送信URLと正規URLが互いを指し合うため、Google はページの正規URLを確定できずリダイレクトエラーとして打ち切ります。「検出 - インデックス未登録」の15件は、クロールした8件が全て空振りしたことでクロール優先度が下がり、まだ一度もクロールされていないURL群です（前回のクロール: 該当なし）。

トップページだけ無傷なのは、`dist/index.html` がルート直下でそのまま `/` の正規URLになり、リダイレクトが発生しないためです。

prerender の導入は `a3ca48e`（2026-06-18）で、それ以前は該当ファイルが存在せず未知パスがSPAフォールバックで200を返していたためリダイレクトは発生していませんでした。GSCのグラフの立ち上がり時期とも一致します。

## 変更内容

### `scripts/prerender.ts`

```diff
-return route === "/" ? join(DIST_DIR, "index.html") : join(DIST_DIR, route.replace(/^\//, ""), "index.html");
+return route === "/" ? join(DIST_DIR, "index.html") : join(DIST_DIR, `${route.replace(/^\//, "")}.html`);
```

`foo.html` 形式なら Cloudflare Pages の正規URLが `/foo`（スラッシュなし）側になり、sitemap.xml・canonical と一致します。

併せて `routeToOutputPath` を export し、テストから import しても `main()` が起動しないよう `process.argv[1] === fileURLToPath(import.meta.url)` のガードを追加しました（`deleteConvexPreviews.ts` / `check-convex-timezone.ts` と同じパターン）。

### `scripts/prerender.test.ts`（新規）

出力がフラットな `.html` であること、`/articles`（一覧）と `/articles/:slug`（詳細）が `dist/articles.html` と `dist/articles/*.html` に分かれて衝突しないことを検証します。

### `doc/features/public-pages.md`

「URL正規化（末尾スラッシュ）」節を追加。出力形式と sitemap/canonical を揃える必要があること、`dist/404.html` を置いてはいけない理由を記録しました。

## 動作確認

実際の Cloudflare Pages ランタイム（`wrangler pages dev`）に修正前後のディレクトリ構成を渡して比較しました。

**修正前**

```
/                                  200
/features                          308 -> /features/
/articles                          308 -> /articles/
/articles/categories/tool-review   308 -> /articles/categories/tool-review/
```

**修正後**

```
/features                                  200   ← sitemap・canonical と一致
/features/                                 308 -> /features
/articles                                  200
/articles/excel-shift-management-limits    200
/articles/categories/tool-review           200
/dashboard                                 200   ← SPAフォールバック維持
/shifts/2026-07                            200
/login                                     200
```

アプリ内ルートの直リロードが引き続きルートの `index.html`（200）にフォールバックすることも確認済みです。`404.html` を追加するとここが404になりアプリが壊れるため、意図的に追加していません。

### 品質チェック

| コマンド | 結果 |
|---|---|
| `pnpm lint` | PASS（warning 0） |
| `pnpm type-check` | PASS |
| `pnpm test:logic` | PASS（53ファイル / 422テスト） |
| `pnpm test` | ロジック系は全PASS（1077テスト）。`ui` プロジェクトのみ、実行環境に Playwright の chrome-headless-shell が無く起動失敗。変更起因の失敗は0件 |

## マージ後にやること

1. 本番反映後、`curl -sSIL https://shiftori.app/features` が **200**（308を経由しない）ことを確認
2. GSC の「リダイレクト エラー」レポートで「修正を検証」を実行
3. sitemap.xml を再送信し、「検出 - インデックス未登録」15件のクロールを促す

反映には数日〜数週間かかります。

なお、このリポジトリの通常フローは develop 経由ですが、依頼により main 向けPRとしています。本番デプロイには `release:patch` ラベルが必要です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BULSPMowi8GV6UKsChhiwG)_