### PR TITLE
chore: Biomeの設定バージョンをRenovate更新に連動

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,23 @@
   "branchConcurrentLimit": 10,
   "prHourlyLimit": 10,
   "commitHourlyLimit": 10,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^biome\\.json$/"],
+      "matchStrings": [
+        "\"\\$schema\"\\s*:\\s*\"https://biomejs\\.dev/schemas/(?<currentValue>[^/]+)/schema\\.json\""
+      ],
+      "depNameTemplate": "@biomejs/biome",
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
+    {
+      "groupName": "Biome",
+      "matchPackageNames": ["@biomejs/biome"]
+    },
     {
       "addLabels": ["react"],
       "groupName": "React packages",

--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^biome\\.json$/"],
-      "matchStrings": [
-        "\"\\$schema\"\\s*:\\s*\"https://biomejs\\.dev/schemas/(?<currentValue>[^/]+)/schema\\.json\""
-      ],
+      "matchStrings": ["\"\\$schema\"\\s*:\\s*\"https://biomejs\\.dev/schemas/(?<currentValue>[^/]+)/schema\\.json\""],
       "depNameTemplate": "@biomejs/biome",
       "datasourceTemplate": "npm",
       "versioningTemplate": "semver"


### PR DESCRIPTION
## Summary

Biome本体の更新後も設定ファイルのスキーマURLが古いバージョンに残るため、Renovateが両方を同じPull Requestで更新するようにします。

## Changes

- **Biome設定のバージョン連動**：Renovateが `biome.json` のスキーマURLをnpmパッケージと同じ依存関係として検出し、Biome本体と同じグループで更新します。

<details>
<summary>確認項目</summary>

- Biome本体とスキーマURLがともに `2.5.5` のとき、追加したCustom Managerを適用すると、スキーマURLがnpm datasourceの `@biomejs/biome@2.5.5` として検出されることを確認した。
- 今回追加したCustom Managerとpackage ruleだけを含む設定のとき、Renovate公式バリデーターを実行すると、設定が正常と判定されることを確認した。
- `renovate.json` 全体の公式バリデーター実行は、既存の `commitHourlyLimit` を無効な設定として検出するため未成功。今回の変更範囲には含めていない。

</details>
