### PR TITLE
fix: prerender成果物のインデックス検証を強化

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -8,37 +8,37 @@
   </url>
   <url>
     <loc>https://shiftori.app/demo/shiftboard</loc>
-    <lastmod>2026-04-25</lastmod>
+    <lastmod>2026-07-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://shiftori.app/demo/flow</loc>
-    <lastmod>2026-05-13</lastmod>
+    <lastmod>2026-06-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://shiftori.app/features</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://shiftori.app/faq</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-07-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://shiftori.app/contact</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://shiftori.app/howto</loc>
-    <lastmod>2026-07-11</lastmod>
+    <lastmod>2026-07-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -22,10 +22,13 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium, type Page } from "playwright";
+import { assertNoLoopbackUrls, normalizePrerenderedHtml } from "./prerenderHtml";
 
 const DIST_DIR = "dist";
 const DIST_ABS = resolve(DIST_DIR);
 const ARTICLE_CONTENT_DIR = join("src", "components", "features", "ArticleSite", "content");
+const SITE_URL = "https://shiftori.app";
+const NOINDEX_ROUTES = new Set(["/privacy", "/terms"]);
 const STATIC_ROUTES = [
   "/",
   "/features",
@@ -148,6 +151,10 @@ function recordPageEvent(events: string[], event: string): void {
   }
 }
 
+function getHtmlAttribute(tag: string, attribute: string): string | undefined {
+  return tag.match(new RegExp(`\\b${attribute}=(['"])(.*?)\\1`, "i"))?.[2];
+}
+
 async function buildPageDiagnostics(route: string, page: Page, events: string[]): Promise<string> {
   let snapshot = "unavailable";
 
@@ -250,6 +257,8 @@ async function collectPrerenderRoutes(): Promise<string[]> {
  * 不完全な HTML を CF Pages にデプロイするのを防ぐ。
  */
 function assertRenderedHtml(route: string, html: string): void {
+  assertNoLoopbackUrls(route, html);
+
   if (html.length < MIN_HTML_BYTES) {
     throw new Error(`[prerender] ${route} produced suspiciously small HTML (${html.length} bytes < ${MIN_HTML_BYTES})`);
   }
@@ -295,6 +304,17 @@ function assertRenderedHtml(route: string, html: string): void {
   if (duplicatedOptionalMeta) {
     const [name, count] = duplicatedOptionalMeta;
     throw new Error(`[prerender] ${route} produced ${count} ${name} meta tags — expected at most one`);
+  }
+  const canonicalTag = html.match(/<link\b[^>]*\brel=["']canonical["'][^>]*>/i)?.[0];
+  const canonicalHref = canonicalTag ? getHtmlAttribute(canonicalTag, "href") : undefined;
+  const expectedCanonical = new URL(route, SITE_URL).href;
+  if (canonicalHref !== expectedCanonical) {
+    throw new Error(`[prerender] ${route} canonical is ${canonicalHref ?? "missing"} — expected ${expectedCanonical}`);
+  }
+  const robotsTags = html.match(/<meta\b[^>]*\bname=["']robots["'][^>]*>/gi) ?? [];
+  const robotsContent = robotsTags.map((tag) => getHtmlAttribute(tag, "content") ?? "").join(",");
+  if (!NOINDEX_ROUTES.has(route) && /(?:^|[\s,])noindex(?:[\s,]|$)/i.test(robotsContent)) {
+    throw new Error(`[prerender] ${route} must be indexable but contains robots noindex`);
   }
   // GTM が prerender 中に起動すると、注入されたタグ (Clarity / GA4 等) が焼き込まれて
   // 実行時に二重初期化される (initGTM は isPrerendering() で起動を抑止している)。
@@ -499,7 +519,7 @@ async function main(): Promise<void> {
         }
       });
 
-      const html = await page.content();
+      const html = normalizePrerenderedHtml(await page.content(), baseUrl);
       await page.close();
 
       assertRenderedHtml(route, html);

--- a/scripts/prerenderHtml.ts
+++ b/scripts/prerenderHtml.ts
@@ -1,0 +1,18 @@
+const LOOPBACK_URL_PATTERN = /https?:\/\/(?:localhost|127(?:\.\d{1,3}){3}|\[::1\])(?::\d+)?(?:\/[^\s"'<>]*)?/i;
+
+/**
+ * prerender 用の一時 origin を、デプロイ先でも解決できる同一 origin の URL に戻す。
+ * page.content() は React が動的に追加した preload の href を絶対 URL で返すため、
+ * そのまま配信すると閲覧端末の loopback へのアクセスになってしまう。
+ */
+export function normalizePrerenderedHtml(html: string, renderingBaseUrl: string): string {
+  const renderingOrigin = new URL(renderingBaseUrl).origin;
+  return html.replaceAll(renderingOrigin, "");
+}
+
+export function assertNoLoopbackUrls(route: string, html: string): void {
+  const match = html.match(LOOPBACK_URL_PATTERN);
+  if (!match) return;
+
+  throw new Error(`[prerender] ${route} contains a loopback URL (${match[0]})`);
+}


### PR DESCRIPTION
## Summary

Cloudflare Pages向けのフラットHTML出力はmainに反映済みですが、成果物のcanonicalやrobotsが壊れてもデプロイできる状態でした。
Search Consoleの再クロール前に、公開ページのインデックス条件をprerender時に検証し、sitemapの更新日を実際の公開内容に合わせます。

## Changes

- **公開ページのインデックス条件を検証**：公開ページにはURL自身のcanonicalを必須とし、法務ページ以外への`noindex`混入をprerender失敗として検出します。

<details>
<summary>確認項目</summary>

- sitemapに24 URLがあり、法務2ページを含む26ルートがprerender対象のとき、成果物を生成すると、公開24ページがself canonicalかつ`noindex`なしで、法務2ページが意図した`noindex`付きで生成されることを確認した。

</details>

- **一時HTTP originを成果物から除去**：prerender中に絶対URLへ変換されたloopback URLを相対URLへ戻し、残存した場合はデプロイ前に検出します。

<details>
<summary>確認項目</summary>

- ローカルの一時HTTPサーバーで26ルートをprerenderすると、全成果物が生成され、HTMLにlocalhost、IPv4 loopback、IPv6 loopbackが残らないことを確認した。

</details>

- **sitemapの更新日を補正**：デモ、機能紹介、FAQ、問い合わせ、HowToの6ページについて、`lastmod`を現在の公開内容の最終更新日に合わせます。

<details>
<summary>確認項目</summary>

- main上の固定公開ページとsitemapを比較したとき、公開内容の更新履歴を確認すると、6ページの`lastmod`がそれぞれの最終更新日と一致することを確認した。

</details>
