### PR TITLE
Add staff count limit enforcement for shop staff registration

### DIFF
--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -39,6 +39,8 @@ export const PERSON_NAME_MAX_LENGTH = 80;
 export const SHIFT_TYPE_NAME_MAX_LENGTH = 30;
 export const EMAIL_MAX_LENGTH = 254;
 export const STAFF_ADD_ENTRIES_MAX = 50;
+// 1店舗に登録できるスタッフ数の上限。現状はフロント（スタッフ追加・登録申請の承認）でのみ判定する
+export const SHOP_STAFF_COUNT_MAX = 40;
 export const RECRUITMENT_PERIOD_DAYS_MAX = 62;
 export const FEATURE_REQUEST_COMMENT_MAX_LENGTH = 200;
 export const FEATURE_REQUEST_REQUEST_ID_MAX_LENGTH = 64;

--- a/convex/dashboard/queries.test.ts
+++ b/convex/dashboard/queries.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { api } from "../_generated/api";
 import { seedManagerShop, seedShop, seedShopMembership, seedUser, testAuthTokenIdentifier } from "../_test/seed";
 import { modules, schema } from "../_test/setup.test-helper";
+import { SHOP_STAFF_COUNT_MAX } from "../constants";
 
 const PAGINATION_FIRST_PAGE = { paginationOpts: { numItems: 10, cursor: null } };
 
@@ -791,6 +792,54 @@ describe("dashboard/queries", () => {
         "isManager",
         "name",
       ]);
+    });
+  });
+
+  describe("getDashboardStaffCount", () => {
+    it("未認証の場合、0を返す", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t.query(api.dashboard.queries.getDashboardStaffCount, {});
+      expect(result).toBe(0);
+    });
+
+    it("店舗未登録の場合、0を返す", async () => {
+      const t = convexTest(schema, modules);
+      const result = await t
+        .withIdentity({ subject: "user_staff_count_no_shop" })
+        .query(api.dashboard.queries.getDashboardStaffCount, {});
+      expect(result).toBe(0);
+    });
+
+    it("論理削除済みスタッフを除外して登録済みスタッフ数を返す", async () => {
+      const t = convexTest(schema, modules);
+      await t.run(async (ctx) => {
+        const { shopId } = await seedManagerShop(ctx, {
+          subject: "user_staff_count",
+          email: "staff-count@example.com",
+          shopName: "スタッフ数店舗",
+        });
+
+        for (let index = 0; index < SHOP_STAFF_COUNT_MAX + 1; index += 1) {
+          await ctx.db.insert("staffs", {
+            shopId,
+            name: `スタッフ${index + 1}`,
+            email: `staff-${index + 1}@example.com`,
+            isDeleted: false,
+          });
+        }
+        await ctx.db.insert("staffs", {
+          shopId,
+          name: "削除済みスタッフ",
+          email: "deleted-staff-count@example.com",
+          isDeleted: true,
+        });
+      });
+
+      const result = await t
+        .withIdentity({ subject: "user_staff_count" })
+        .query(api.dashboard.queries.getDashboardStaffCount, {});
+
+      expect(result).toBe(SHOP_STAFF_COUNT_MAX + 1);
     });
   });
 

--- a/convex/dashboard/queries.ts
+++ b/convex/dashboard/queries.ts
@@ -7,6 +7,7 @@ import {
   DASHBOARD_CURRENT_RECRUITMENT_SCAN_LIMIT,
   DASHBOARD_RECRUITMENT_CANDIDATE_GROUP_LIMIT,
   DASHBOARD_RESPONSE_COUNT_LIMIT,
+  SHIFT_BOARD_STAFF_LIMIT,
 } from "../constants";
 import { getStaffLineAccount } from "../line/service";
 
@@ -305,6 +306,24 @@ export const getDashboardStaffs = authenticatedQuery({
       ...paginatedResult,
       page,
     };
+  },
+});
+
+/**
+ * 登録済み（論理削除されていない）スタッフ数。
+ * スタッフ追加・登録申請の承認で SHOP_STAFF_COUNT_MAX を超えないかを画面側で判定するために使う。
+ */
+export const getDashboardStaffCount = authenticatedQuery({
+  args: {},
+  handler: async (ctx) => {
+    const shop = await getManagerShop(ctx);
+    if (!shop) return 0;
+
+    const staffs = await ctx.db
+      .query("staffs")
+      .withIndex("by_shopId_isDeleted", (q) => q.eq("shopId", shop._id).eq("isDeleted", false))
+      .take(SHIFT_BOARD_STAFF_LIMIT);
+    return staffs.length;
   },
 });
 

--- a/doc/features/billing-plans.md
+++ b/doc/features/billing-plans.md
@@ -20,6 +20,8 @@
 
 スタッフ上限は料金設計のメタデータとして定義しているが、課金機能公開前のためまだ強制しない。既存店舗はスタッフ数に関係なくそのまま利用できる。
 
+なお、プランとは別に全店舗共通のスタッフ数上限 `SHOP_STAFF_COUNT_MAX`（40人）をフロントで判定している（`doc/features/staff-registration.md` 参照）。プラン別上限を強制するときは、この定数との関係を整理する。
+
 ## 判定方針
 
 有料機能をConvex側で実装するときは、画面やmutation内で `planKey` を直接判定しない。必ず `convex/billing/service.ts` の `requirePaidFeature(ctx, shopId)` または `getShopEntitlements(ctx, shopId)` を使う。

--- a/doc/features/staff-registration.md
+++ b/doc/features/staff-registration.md
@@ -13,6 +13,9 @@
 - `src/components/features/StaffRegistration/` — 登録フォーム、メールtypo警告、確認表示
 - `src/components/features/Dashboard/StaffRegistrationLinkPanel/` — シフト担当者向けQR/URL表示
 - `src/components/features/Dashboard/StaffRegistrationRequests/` — スタッフ参加申請カード、モーダル、承認/却下リスト
+- `src/components/features/Dashboard/AddStaffForm/` — 手入力追加フォーム（スタッフ数上限の判定を含む）
+- `src/components/features/Dashboard/staffAdditionCopy.ts` — 追加時の案内文と上限到達トーストの文言
+- `convex/constants.ts` — `SHOP_STAFF_COUNT_MAX`（1店舗のスタッフ数上限）
 
 ## 画面一覧
 
@@ -32,6 +35,7 @@
 | `api.staffRegistration.mutations.approveRequest` | mutation | 申請を承認し、正式スタッフ作成・同意コピー・通知予約を行う |
 | `api.staffRegistration.mutations.rejectRequest` | mutation | 申請を却下する |
 | `api.staffRegistration.mutations.ensureShopRegistrationLink` | mutation | 店舗固定の登録リンクを作成/取得 |
+| `api.dashboard.queries.getDashboardStaffCount` | query | 登録済みスタッフ数を取得（スタッフ数上限の判定に使う） |
 | `api.dashboard.mutations.dismissOnboarding` | mutation | ダッシュボードチュートリアル終了をDB保存 |
 | `internal.staffRegistration.actions.sendOwnerDailyDigest` | internalAction | 毎日17:00 JSTに承認待ち申請がある店舗のmanager usersへ通知 |
 | `internal.staffRegistration.notificationQueries.listPendingRequestShopIdsPage` | internalQuery | 3日以内に作成された承認待ち申請がある店舗IDをページング取得 |
@@ -47,3 +51,11 @@
 - 承認待ち申請が残っている店舗には、毎日17:00 JSTに店舗のmanager usersへ短い確認通知を送る。manager userに紐づくstaffがLINE連携済みならLINE、未連携・友達解除・Quota超過時はusers.emailへメールで送る。
 - 通知コスト抑制のため、通知は最新の承認待ち申請から3日間（72時間、`STAFF_REGISTRATION_DIGEST_WINDOW_MS`）だけ送る。日次cronなので最大3回で打ち切られ、4日目以降は承認されていなくても送らない。
 - 承認待ち通知には申請者名・メールアドレス・件数は載せず、ダッシュボードリンクだけを案内する。
+
+## スタッフ数の上限
+
+- 1店舗に登録できるスタッフ数の上限は `SHOP_STAFF_COUNT_MAX`（40人、`convex/constants.ts`）。
+- 判定するのは「手入力追加」と「参加申請の承認」の2箇所。上限に達している場合はトーストを出して処理を中断する（追加フォームでは行追加も送信も止まる）。
+- スタッフ本人の参加申請（`/staff/register`）は上限に関係なく受け付ける。上限で止まるのはシフト担当者の承認側。
+- 現状はフロントのみの判定で、mutation側では強制しない。
+- 課金プランの `maxStaffCount`（`convex/billing/service.ts`）とは別物。プラン別上限は現在も未強制。

--- a/src/components/features/Dashboard/AddStaffForm/index.stories.tsx
+++ b/src/components/features/Dashboard/AddStaffForm/index.stories.tsx
@@ -2,8 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 import { LuUserPlus } from "react-icons/lu";
 import { expect, userEvent, within } from "storybook/test";
+import { SHOP_STAFF_COUNT_MAX } from "@/convex/constants";
 import { Button } from "@/src/components/ui/Button";
 import { Dialog } from "@/src/components/ui/Dialog";
+import { Toaster } from "@/src/components/ui/toaster";
 import { StaffRegistrationLinkPanel } from "../StaffRegistrationLinkPanel";
 import { AddStaffForm } from "./index.tsx";
 
@@ -94,6 +96,50 @@ export const BackToQrFromManual: Story = {
     await userEvent.click(await page.findByRole("button", { name: "戻る" }));
     await expect(await page.findByRole("button", { name: "スタッフ情報を手入力する" })).toBeInTheDocument();
     expect(page.queryByRole("button", { name: "スタッフを追加する" })).not.toBeInTheDocument();
+  },
+};
+
+function StaffCountLimitFixture() {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  return (
+    <Dialog
+      title="スタッフを招待"
+      isOpen={true}
+      onOpenChange={() => {}}
+      formId="add-staff-form"
+      submitLabel="スタッフを追加する"
+      onClose={() => {}}
+      closeLabel="戻る"
+    >
+      <Toaster />
+      {isSubmitted && <p>onSubmitが呼ばれました</p>}
+      <AddStaffForm onSubmit={() => setIsSubmitted(true)} currentStaffCount={SHOP_STAFF_COUNT_MAX} />
+    </Dialog>
+  );
+}
+
+export const StaffCountLimitReached: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => <StaffCountLimitFixture />,
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(await page.findByRole("button", { name: /スタッフをもう1人追加/ }));
+    await expect(await page.findByText(`スタッフは${SHOP_STAFF_COUNT_MAX}人まで登録できます`)).toBeInTheDocument();
+
+    await userEvent.type(await page.findAllByPlaceholderText("例：田中 花子").then((inputs) => inputs[0]), "田中 花子");
+    await userEvent.type(
+      await page.findAllByPlaceholderText("例：hanako@example.com").then((inputs) => inputs[0]),
+      "hanako@example.com",
+    );
+    await userEvent.click(await page.findByRole("button", { name: "スタッフを追加する" }));
+
+    // 行追加時と送信時でそれぞれトーストが出る
+    await expect(await page.findAllByText(`スタッフは${SHOP_STAFF_COUNT_MAX}人まで登録できます`)).toHaveLength(2);
+    expect(page.queryByText("onSubmitが呼ばれました")).not.toBeInTheDocument();
   },
 };
 

--- a/src/components/features/Dashboard/AddStaffForm/index.stories.tsx
+++ b/src/components/features/Dashboard/AddStaffForm/index.stories.tsx
@@ -5,7 +5,7 @@ import { expect, userEvent, within } from "storybook/test";
 import { SHOP_STAFF_COUNT_MAX } from "@/convex/constants";
 import { Button } from "@/src/components/ui/Button";
 import { Dialog } from "@/src/components/ui/Dialog";
-import { Toaster } from "@/src/components/ui/toaster";
+import { Toaster, toaster } from "@/src/components/ui/toaster";
 import { StaffRegistrationLinkPanel } from "../StaffRegistrationLinkPanel";
 import { AddStaffForm } from "./index.tsx";
 
@@ -139,6 +139,48 @@ export const StaffCountLimitReached: Story = {
 
     // 行追加時と送信時でそれぞれトーストが出る
     await expect(await page.findAllByText(`スタッフは${SHOP_STAFF_COUNT_MAX}人まで登録できます`)).toHaveLength(2);
+    expect(page.queryByText("onSubmitが呼ばれました")).not.toBeInTheDocument();
+  },
+};
+
+function StaffCountOneSlotRemainingFixture() {
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  return (
+    <Dialog
+      title="スタッフを招待"
+      isOpen={true}
+      onOpenChange={() => {}}
+      formId="add-staff-form"
+      submitLabel="スタッフを追加する"
+      onClose={() => {}}
+      closeLabel="戻る"
+    >
+      <Toaster />
+      {isSubmitted && <p>onSubmitが呼ばれました</p>}
+      <AddStaffForm onSubmit={() => setIsSubmitted(true)} currentStaffCount={SHOP_STAFF_COUNT_MAX - 1} />
+    </Dialog>
+  );
+}
+
+export const StaffCountLimitPreventsBatchOverflow: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => <StaffCountOneSlotRemainingFixture />,
+  play: async ({ canvasElement }) => {
+    toaster.dismiss();
+    const page = within(canvasElement.ownerDocument.body);
+
+    const nameInputs = await page.findAllByPlaceholderText("例：田中 花子");
+    const emailInputs = await page.findAllByPlaceholderText("例：hanako@example.com");
+    await userEvent.type(nameInputs[0], "田中 花子");
+    await userEvent.type(emailInputs[0], "hanako@example.com");
+    await userEvent.type(nameInputs[1], "佐藤 花子");
+    await userEvent.type(emailInputs[1], "hanako2@example.com");
+    await userEvent.click(await page.findByRole("button", { name: "スタッフを追加する" }));
+
+    await expect(await page.findByText(`スタッフは${SHOP_STAFF_COUNT_MAX}人まで登録できます`)).toBeInTheDocument();
     expect(page.queryByText("onSubmitが呼ばれました")).not.toBeInTheDocument();
   },
 };

--- a/src/components/features/Dashboard/AddStaffForm/index.tsx
+++ b/src/components/features/Dashboard/AddStaffForm/index.tsx
@@ -2,15 +2,23 @@ import { Box, Field, Flex, Input, Stack, Text } from "@chakra-ui/react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useFieldArray, useForm } from "react-hook-form";
 import { LuPlus, LuX } from "react-icons/lu";
-import { EMAIL_MAX_LENGTH, PERSON_NAME_MAX_LENGTH, STAFF_ADD_ENTRIES_MAX } from "@/convex/constants";
+import {
+  EMAIL_MAX_LENGTH,
+  PERSON_NAME_MAX_LENGTH,
+  SHOP_STAFF_COUNT_MAX,
+  STAFF_ADD_ENTRIES_MAX,
+} from "@/convex/constants";
 import { Button, IconButton } from "@/src/components/ui/Button";
-import { STAFF_ADDITION_EMAIL_NOTICE } from "../staffAdditionCopy";
+import { toaster } from "@/src/components/ui/toaster";
+import { STAFF_ADDITION_EMAIL_NOTICE, STAFF_COUNT_LIMIT_TOAST } from "../staffAdditionCopy";
 import { type AddStaffFormData, addStaffSchema } from "./index";
 
 const EMPTY_ENTRY = { name: "", email: "" } as const;
 
 type Props = {
   onSubmit: (data: AddStaffFormData) => void | Promise<void>;
+  /** 登録済みスタッフ数。これと入力行数の合計が上限を超える場合は追加・送信をさせない */
+  currentStaffCount?: number;
 };
 
 function RemoveButton({ onClick }: { onClick: () => void }) {
@@ -21,7 +29,7 @@ function RemoveButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-export const AddStaffForm = ({ onSubmit }: Props) => {
+export const AddStaffForm = ({ onSubmit, currentStaffCount = 0 }: Props) => {
   const {
     register,
     control,
@@ -35,9 +43,33 @@ export const AddStaffForm = ({ onSubmit }: Props) => {
   const { fields, append, remove } = useFieldArray({ control, name: "entries" });
   const entriesErrorMessage = errors.entries?.root?.message ?? errors.entries?.message;
   const canAppend = fields.length < STAFF_ADD_ENTRIES_MAX;
+  // あと何人追加できるか。上限を超えている店舗は 0 になり、追加も送信もできない
+  const remainingSlots = Math.max(0, SHOP_STAFF_COUNT_MAX - currentStaffCount);
+
+  const notifyStaffCountLimit = () => {
+    toaster.create({ ...STAFF_COUNT_LIMIT_TOAST, type: "warning" });
+  };
+
+  const handleAppend = () => {
+    if (!canAppend) return;
+    if (fields.length >= remainingSlots) {
+      notifyStaffCountLimit();
+      return;
+    }
+    append(EMPTY_ENTRY);
+  };
+
+  const handleValidSubmit = (data: AddStaffFormData) => {
+    const filledCount = data.entries.filter((entry) => entry.name !== "").length;
+    if (filledCount > remainingSlots) {
+      notifyStaffCountLimit();
+      return;
+    }
+    return onSubmit(data);
+  };
 
   return (
-    <form id="add-staff-form" noValidate onSubmit={handleSubmit(onSubmit)}>
+    <form id="add-staff-form" noValidate onSubmit={handleSubmit(handleValidSubmit)}>
       <Stack gap={4}>
         <Text fontSize="sm" color="fg.muted" lineHeight="tall">
           {STAFF_ADDITION_EMAIL_NOTICE}
@@ -107,9 +139,7 @@ export const AddStaffForm = ({ onSubmit }: Props) => {
           colorPalette="teal"
           alignSelf="flex-start"
           disabled={!canAppend}
-          onClick={() => {
-            if (canAppend) append(EMPTY_ENTRY);
-          }}
+          onClick={handleAppend}
         >
           <LuPlus />
           スタッフをもう1人追加

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Heading, HStack, Stack, Text } from "@chakra-ui/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LuSparkles, LuUserPlus } from "react-icons/lu";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -153,6 +153,40 @@ export const DashboardContent = ({
   const [dismissedOnboardingStages, setDismissedOnboardingStages] = useState<DashboardOnboardingStage[]>([]);
   const [autoDismissedOnboarding, setAutoDismissedOnboarding] = useState(false);
   const [reviewedRecruitmentIds, setReviewedRecruitmentIds] = useState(readReviewedRecruitmentIds);
+  // Convexの購読更新前に追加・承認を続けても、同じ画面内で枠を二重に使わないための予約数。
+  const [reservedStaffCount, setReservedStaffCount] = useState(0);
+  const staffCountRef = useRef(staffCount);
+  const reservedStaffCountRef = useRef(0);
+
+  useEffect(() => {
+    const queryCountDelta = staffCount - staffCountRef.current;
+    if (queryCountDelta > 0) {
+      const nextReservedStaffCount = Math.max(0, reservedStaffCountRef.current - queryCountDelta);
+      reservedStaffCountRef.current = nextReservedStaffCount;
+      setReservedStaffCount(nextReservedStaffCount);
+    }
+    staffCountRef.current = staffCount;
+  }, [staffCount]);
+
+  const effectiveStaffCount = staffCount + reservedStaffCount;
+  const reserveStaffSlots = (count: number) => {
+    const nextReservedStaffCount = reservedStaffCountRef.current + count;
+    const observedStaffCount = Math.max(staffCountRef.current, staffCount);
+    if (observedStaffCount + nextReservedStaffCount > SHOP_STAFF_COUNT_MAX) {
+      toaster.create({ ...STAFF_COUNT_LIMIT_TOAST, type: "warning" });
+      return false;
+    }
+    reservedStaffCountRef.current = nextReservedStaffCount;
+    setReservedStaffCount(nextReservedStaffCount);
+    return true;
+  };
+
+  const releaseStaffSlots = (count: number) => {
+    const nextReservedStaffCount = Math.max(0, reservedStaffCountRef.current - count);
+    reservedStaffCountRef.current = nextReservedStaffCount;
+    setReservedStaffCount(nextReservedStaffCount);
+  };
+
   const knownRecruitments = sortRecruitmentsByCreatedAt(
     Array.from(
       new Map([...recruitments, ...currentRecruitments].map((recruitment) => [recruitment._id, recruitment])).values(),
@@ -395,6 +429,9 @@ export const DashboardContent = ({
 
   const { run: handleAddStaffs, isRunning: isAddingStaffs } = useSingleFlight(
     async (data: { entries: Array<{ name: string; email: string }> }) => {
+      const addedStaffCount = data.entries.filter((entry) => entry.name !== "").length;
+      if (!reserveStaffSlots(addedStaffCount)) return;
+
       try {
         await addStaffs({ entries: data.entries });
         staffModal.close();
@@ -403,6 +440,7 @@ export const DashboardContent = ({
           description: "同意依頼とLINE連携案内をメールで送りました。募集中シフトがある場合は提出リンクも届きます。",
         });
       } catch (error) {
+        releaseStaffSlots(addedStaffCount);
         showErrorToast(error);
       }
     },
@@ -432,10 +470,8 @@ export const DashboardContent = ({
 
   const { run: handleApproveStaffRequest, isRunning: isApprovingStaffRequest } = useSingleFlight(
     async (request: StaffRegistrationRequest) => {
-      if (staffCount >= SHOP_STAFF_COUNT_MAX) {
-        toaster.create({ ...STAFF_COUNT_LIMIT_TOAST, type: "warning" });
-        return;
-      }
+      if (!reserveStaffSlots(1)) return;
+
       try {
         await approveStaffRequest({ requestId: request._id });
         showSuccessToast({
@@ -443,6 +479,7 @@ export const DashboardContent = ({
           description: "LINE連携案内をメールで送りました。募集中シフトがある場合は提出リンクも届きます。",
         });
       } catch (error) {
+        releaseStaffSlots(1);
         showErrorToast(error);
       }
     },
@@ -752,7 +789,7 @@ export const DashboardContent = ({
             }
           />
         ) : (
-          <AddStaffForm onSubmit={handleAddStaffs} currentStaffCount={staffCount} />
+          <AddStaffForm onSubmit={handleAddStaffs} currentStaffCount={effectiveStaffCount} />
         )}
       </Dialog>
 

--- a/src/components/features/Dashboard/DashboardContent/index.tsx
+++ b/src/components/features/Dashboard/DashboardContent/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { LuSparkles, LuUserPlus } from "react-icons/lu";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
+import { SHOP_STAFF_COUNT_MAX } from "@/convex/constants";
 import { ContentWrapper } from "@/src/components/templates/ContentWrapper";
 import { Button } from "@/src/components/ui/Button";
 import { Dialog, useDialog } from "@/src/components/ui/Dialog";
@@ -31,6 +32,7 @@ import { StaffRegistrationLinkPanel } from "../StaffRegistrationLinkPanel";
 import { StaffRegistrationRequestDialog } from "../StaffRegistrationRequests";
 import { StaffRoster, StaffRosterSkeleton } from "../StaffRoster";
 import { StaffDetailDialog } from "../StaffRoster/StaffDetailDialog";
+import { STAFF_COUNT_LIMIT_TOAST } from "../staffAdditionCopy";
 import {
   buildDashboardRecruitmentGroups,
   type DashboardAnnouncement as DashboardAnnouncementData,
@@ -88,6 +90,8 @@ type Props = {
   staffStatus: PaginationStatus;
   canLoadMoreStaffs: boolean;
   loadMoreStaffs: () => void;
+  /** 登録済みスタッフ数（一覧のページングとは別に全件をカウントした値） */
+  staffCount?: number;
   pendingStaffRequests?: StaffRegistrationRequest[];
   notificationFailures?: DashboardNotificationFailure[];
   isDashboardOnboardingDismissed?: boolean;
@@ -112,6 +116,7 @@ export const DashboardContent = ({
   staffStatus,
   canLoadMoreStaffs,
   loadMoreStaffs,
+  staffCount = 0,
   pendingStaffRequests = [],
   notificationFailures = [],
   isDashboardOnboardingDismissed = false,
@@ -427,6 +432,10 @@ export const DashboardContent = ({
 
   const { run: handleApproveStaffRequest, isRunning: isApprovingStaffRequest } = useSingleFlight(
     async (request: StaffRegistrationRequest) => {
+      if (staffCount >= SHOP_STAFF_COUNT_MAX) {
+        toaster.create({ ...STAFF_COUNT_LIMIT_TOAST, type: "warning" });
+        return;
+      }
       try {
         await approveStaffRequest({ requestId: request._id });
         showSuccessToast({
@@ -743,7 +752,7 @@ export const DashboardContent = ({
             }
           />
         ) : (
-          <AddStaffForm onSubmit={handleAddStaffs} />
+          <AddStaffForm onSubmit={handleAddStaffs} currentStaffCount={staffCount} />
         )}
       </Dialog>
 

--- a/src/components/features/Dashboard/staffAdditionCopy.ts
+++ b/src/components/features/Dashboard/staffAdditionCopy.ts
@@ -1,2 +1,10 @@
+import { SHOP_STAFF_COUNT_MAX } from "@/convex/constants";
+
 export const STAFF_ADDITION_EMAIL_NOTICE =
   "追加後、同意依頼とLINE連携案内をメールで送ります。募集中シフトがある場合は提出リンクも送ります。";
+
+/** スタッフ数が上限に達したときの通知文言（追加・承認で共通） */
+export const STAFF_COUNT_LIMIT_TOAST = {
+  title: `スタッフは${SHOP_STAFF_COUNT_MAX}人まで登録できます`,
+  description: "登録済みのスタッフを削除すると、新しいスタッフを追加できます。",
+} as const;

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -91,6 +91,7 @@ export function DashboardPage() {
         managerLegalConsentStatus === undefined ||
         pendingStaffRequests === undefined ||
         hasPastRecruitments === undefined ||
+        staffCount === undefined ||
         recruitments.status === "LoadingFirstPage" ||
         staffs.status === "LoadingFirstPage"));
 
@@ -123,7 +124,7 @@ export function DashboardPage() {
           staffStatus={staffs.status}
           canLoadMoreStaffs={canLoadMoreStaffs}
           loadMoreStaffs={handleLoadMoreStaffs}
-          staffCount={staffCount ?? 0}
+          staffCount={staffCount}
           pendingStaffRequests={pendingStaffRequests ?? []}
           notificationFailures={notificationFailures.results}
           announcement={announcement ?? null}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -43,6 +43,7 @@ export function DashboardPage() {
   const staffs = usePaginatedQuery(api.dashboard.queries.getDashboardStaffs, skipPagination ? "skip" : {}, {
     initialNumItems: STAFF_QUERY_PAGE_SIZE,
   });
+  const staffCount = useQuery(api.dashboard.queries.getDashboardStaffCount, skipPagination ? "skip" : {});
   const pendingStaffRequests = useQuery(
     api.staffRegistration.queries.getPendingRequests,
     shop === undefined || shop === null ? "skip" : {},
@@ -122,6 +123,7 @@ export function DashboardPage() {
           staffStatus={staffs.status}
           canLoadMoreStaffs={canLoadMoreStaffs}
           loadMoreStaffs={handleLoadMoreStaffs}
+          staffCount={staffCount ?? 0}
           pendingStaffRequests={pendingStaffRequests ?? []}
           notificationFailures={notificationFailures.results}
           announcement={announcement ?? null}


### PR DESCRIPTION
## Summary
Implements a staff count limit (40 per shop) for staff registration, enforced at the UI level when adding staff manually or approving registration requests. The limit prevents exceeding `SHOP_STAFF_COUNT_MAX` by blocking form submissions and showing a warning toast notification.

## Key Changes

- **Staff count limit constant**: Added `SHOP_STAFF_COUNT_MAX = 40` to `convex/constants.ts` as a shared constant for the maximum staff per shop
- **Backend query**: Added `getDashboardStaffCount` query to retrieve the count of non-deleted staff for a shop
- **Form validation**: Enhanced `AddStaffForm` to:
  - Accept `currentStaffCount` prop to track registered staff
  - Calculate remaining available slots
  - Prevent adding new entry rows when limit would be exceeded
  - Validate on form submission to block if filled entries exceed remaining slots
  - Show warning toast when limit is reached
- **Approval validation**: Added staff count check in `DashboardContent.handleApproveStaffRequest` to prevent approving requests when at capacity
- **UI integration**: 
  - Updated `DashboardContent` to fetch and pass `staffCount` to `AddStaffForm`
  - Added `Toaster` component to story fixtures for testing
- **Documentation**: 
  - Added staff count limit section to `doc/features/staff-registration.md`
  - Updated `doc/features/billing-plans.md` to clarify relationship between plan limits and shop-wide limit
  - Added new components/files to feature documentation

## Implementation Details

- Limit enforcement is frontend-only (not enforced in mutations)
- Staff self-registration (`/staff/register`) is not affected by the limit; only manual addition and approval are restricted
- Toast notification is shown both when attempting to add a row and when submitting the form with too many entries
- The limit is independent of billing plan limits (`maxStaffCount`)

https://claude.ai/code/session_01UunBuorJ2oWEZHaD7dCYYP